### PR TITLE
fixing issue with json patcher and fields beginning with numeric values

### DIFF
--- a/src/Foundatio.Repositories/Extensions/StringExtensions.cs
+++ b/src/Foundatio.Repositories/Extensions/StringExtensions.cs
@@ -10,13 +10,13 @@ namespace Foundatio.Repositories.Extensions {
             var sb = new StringBuilder();
             var parts = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             for (int i = 0; i < parts.Length; i++) {
-                if (Char.IsNumber(parts[i][0]))
+                if (parts[i].IsNumeric())
                     sb.Append("[").Append(parts[i]).Append("]");
                 else {
                     sb.Append(parts[i]);
                 }
 
-                if (i < parts.Length - 1 && !Char.IsNumber(parts[i + 1][0]))
+                if (i < parts.Length - 1 && !parts[i + 1].IsNumeric())
                     sb.Append(".");
             }
 

--- a/test/Foundatio.Repositories.Tests/JsonPatch/JsonPatchTests.cs
+++ b/test/Foundatio.Repositories.Tests/JsonPatch/JsonPatchTests.cs
@@ -207,6 +207,32 @@ namespace Foundatio.Repositories.Tests.JsonPatch {
         }
 
         [Fact]
+        public void Remove_an_array_element_with_numbered_custom_fields() {
+            var sample = JToken.Parse(@"{
+    'data': {
+        '2017PropertyOne' : '2017 property one value',
+        '2017PropertyTwo' : '2017 property two value',
+        '2017Properties' : ['First value from 2017','Second value from 2017'],
+        '2018PropertyOne' : '2018 property value',
+        '2018PropertyTwo' : '2018 property two value',
+        '2018Properties' : ['First value from 2018','Second value from 2018']
+    }
+}");
+
+            Assert.NotNull(sample.SelectPatchToken("/data/2017Properties/1"));
+
+            var patchDocument = new PatchDocument();
+            string pointer = "/data/2017Properties/0";
+
+            patchDocument.AddOperation(new RemoveOperation { Path = pointer });
+
+            var patcher = new JsonPatcher();
+            patcher.Patch(ref sample, patchDocument);
+
+            Assert.Null(sample.SelectPatchToken("/data/2017Properties/1"));
+        }
+
+        [Fact]
         public void Replace_a_property_value_with_a_new_value() {
             var sample = GetSample2();
 


### PR DESCRIPTION
There was a string extension that was generating the json path that was just checking the first value of the string to determine if it was an index for an array.  This fix checks the entire part of the path to determine if it is a numeric index.