### PR TITLE
Ensure ConfigureOptions is called in a consistent manner.

### DIFF
--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -59,11 +59,11 @@ namespace Foundatio.Repositories.Elasticsearch {
             if (query == null)
                 query = new RepositoryQuery();
 
+            options = ConfigureOptions(options);
             bool useSnapshotPaging = options.ShouldUseSnapshotPaging();
             // don't use caching with snapshot paging.
             bool allowCaching = IsCacheEnabled && useSnapshotPaging == false;
 
-            options = ConfigureOptions(options);
             await OnBeforeQueryAsync(query, options, typeof(TResult)).AnyContext();
 
             async Task<FindResults<TResult>> GetNextPageFunc(FindResults<TResult> r) {
@@ -195,11 +195,11 @@ namespace Foundatio.Repositories.Elasticsearch {
             if (query == null)
                 throw new ArgumentNullException(nameof(query));
 
+            options = ConfigureOptions(options);
             var result = IsCacheEnabled ? await GetCachedQueryResultAsync<FindHit<T>>(options).AnyContext() : null;
             if (result != null)
                 return result;
 
-            options = ConfigureOptions(options);
             await OnBeforeQueryAsync(query, options, typeof(T)).AnyContext();
 
             var searchDescriptor = (await CreateSearchDescriptorAsync(query, options).AnyContext()).Size(1);
@@ -237,6 +237,8 @@ namespace Foundatio.Repositories.Elasticsearch {
         public virtual async Task<T> GetByIdAsync(Id id, ICommandOptions options = null) {
             if (String.IsNullOrEmpty(id.Value))
                 return null;
+
+            options = ConfigureOptions(options);
 
             CacheValue<T> hit = null;
             if (IsCacheEnabled && options.ShouldReadCache())
@@ -280,6 +282,8 @@ namespace Foundatio.Repositories.Elasticsearch {
 
             if (!HasIdentity)
                 throw new NotSupportedException("Model type must implement IIdentity.");
+
+            options = ConfigureOptions(options);
 
             var hits = new List<T>();
             if (IsCacheEnabled && options.ShouldReadCache()) {
@@ -390,11 +394,11 @@ namespace Foundatio.Repositories.Elasticsearch {
             if (query == null)
                 throw new ArgumentNullException(nameof(query));
 
+            options = ConfigureOptions(options);
             var result = await GetCachedQueryResultAsync<CountResult>(options, "count").AnyContext();
             if (result != null)
                 return result;
 
-            options = ConfigureOptions(options);
             await OnBeforeQueryAsync(query, options, typeof(T)).AnyContext();
 
             var searchDescriptor = await CreateSearchDescriptorAsync(query, options).AnyContext();
@@ -419,6 +423,8 @@ namespace Foundatio.Repositories.Elasticsearch {
         }
 
         public virtual async Task<long> CountAsync(ICommandOptions options = null) {
+            options = ConfigureOptions(options);
+
             var response = await _client.CountAsync<T>(c => c.Query(q => q.MatchAll()).Index(String.Join(",", GetIndexesByQuery(null))).Type(ElasticType.Name)).AnyContext();
             if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
                 _logger.LogTrace(response.GetRequest());

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -54,6 +54,7 @@ namespace Foundatio.Repositories.Elasticsearch {
             if (docs.Count == 0)
                 return;
 
+            options = ConfigureOptions(options);
             await OnDocumentsAddingAsync(docs, options).AnyContext();
 
             if (_validator != null)
@@ -120,6 +121,8 @@ namespace Foundatio.Repositories.Elasticsearch {
 
             if (operation == null)
                 throw new ArgumentNullException(nameof(operation));
+
+            options = ConfigureOptions(options);
 
             var pipelinedIndexType = ElasticType as IHavePipelinedIndexType;
             string pipeline = pipelinedIndexType?.Pipeline;
@@ -219,6 +222,7 @@ namespace Foundatio.Repositories.Elasticsearch {
             if (ids.Count == 0)
                 return;
 
+            options = ConfigureOptions(options);
             if (ids.Count == 1) {
                 await PatchAsync(ids[0], operation, options).AnyContext();
                 return;
@@ -451,9 +455,7 @@ namespace Foundatio.Repositories.Elasticsearch {
             if (ids == null)
                 throw new ArgumentNullException(nameof(ids));
 
-            if (options == null)
-                options = new CommandOptions();
-
+            options = ConfigureOptions(options);
             if (IsCacheEnabled)
                 options = options.ReadCache();
 
@@ -486,6 +488,7 @@ namespace Foundatio.Repositories.Elasticsearch {
                     await TimeSeriesType.EnsureIndexAsync(documentGroup.First()).AnyContext();
             }
 
+            options = ConfigureOptions(options);
             await OnDocumentsRemovingAsync(docs, options).AnyContext();
 
             if (docs.Count == 1) {


### PR DESCRIPTION
The following method implementation weren't calling `ConfigureOptions(options)`: `CountAsync`, `AddAsync`, `PatchAsync`, `GetbyIdAsync`, `GetByIdsAsync`, and `RemoveAsync`.

Some of these implementations call other implementations that rely on options.

Also, sometimes the options were configured after they were read (look at `ShouldUseSnapShotPaging` on line 63 of `ElasticReadOnlyRepositoryBase`). If configure allows you to set values globally than this has to be called first.