### PR TITLE
Cache improvements

### DIFF
--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -68,8 +68,6 @@ namespace Foundatio.Repositories.Elasticsearch {
                 return;
 
             options = ConfigureOptions(options.As<T>());
-            if (IsCacheEnabled && options.HasCacheKey())
-                throw new ArgumentException("Cache key can't be set when calling AddAsync");
 
             await OnDocumentsAddingAsync(docs, options).AnyContext();
 
@@ -81,7 +79,7 @@ namespace Foundatio.Repositories.Elasticsearch {
 
             await OnDocumentsAddedAsync(docs, options).AnyContext();
             if (IsCacheEnabled && options.ShouldUseCache())
-                await AddDocumentsToCacheAsync(docs, options).AnyContext();
+                await AddDocumentsToCacheAsync(docs, options, false).AnyContext();
         }
 
         public Task<T> SaveAsync(T document, CommandOptionsDescriptor<T> options) {
@@ -113,8 +111,6 @@ namespace Foundatio.Repositories.Elasticsearch {
                 throw new ArgumentException("Id must be set when calling Save.");
 
             options = ConfigureOptions(options.As<T>());
-            if (IsCacheEnabled && options.HasCacheKey())
-                throw new ArgumentException("Cache key can't be set when calling SaveAsync");
 
             var originalDocuments = await GetOriginalDocumentsAsync(ids, options).AnyContext();
             await OnDocumentsSavingAsync(docs, originalDocuments, options).AnyContext();
@@ -127,7 +123,7 @@ namespace Foundatio.Repositories.Elasticsearch {
 
             await OnDocumentsSavedAsync(docs, originalDocuments, options).AnyContext();
             if (IsCacheEnabled && options.ShouldUseCache())
-                await AddDocumentsToCacheAsync(docs, options).AnyContext();
+                await AddDocumentsToCacheAsync(docs, options, false).AnyContext();
         }
 
         public Task PatchAsync(Id id, IPatchOperation operation, CommandOptionsDescriptor<T> options) {

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
@@ -46,6 +46,24 @@ namespace Foundatio.Repositories.Elasticsearch.Tests {
         }
 
         [Fact]
+        public async Task CanCacheSaveByKeyAsync() {
+            var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(age: 20), o => o.ImmediateConsistency().Cache("test"));
+            Assert.Equal(2, _cache.Count);
+
+            var employeeResult1 = await _employeeRepository.FindOneAsync(new RepositoryQuery().Age(20), new CommandOptions().Cache("test"));
+            Assert.NotNull(employeeResult1);
+            Assert.Equal(2, _cache.Count);
+            Assert.Equal(1, _cache.Hits);
+            Assert.Equal(0, _cache.Misses);
+
+            var employeeResult2 = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache("test"));
+            Assert.NotNull(employeeResult2);
+            Assert.Equal(2, _cache.Count);
+            Assert.Equal(2, _cache.Hits);
+            Assert.Equal(0, _cache.Misses);
+        }
+
+        [Fact]
         public async Task CanCacheFindOneAsync() {
             var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(age: 20), o => o.ImmediateConsistency());
 

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/EmployeeRepository.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/EmployeeRepository.cs
@@ -114,8 +114,8 @@ namespace Foundatio.Repositories.Elasticsearch.Tests {
             return PatchAllAsync(query, new ScriptPatch(script), o => o.ImmediateConsistency(true));
         }
 
-        protected override async Task AddDocumentsToCacheAsync(ICollection<FindHit<Employee>> findHits, ICommandOptions options) {
-            await base.AddDocumentsToCacheAsync(findHits, options);
+        protected override async Task AddDocumentsToCacheAsync(ICollection<FindHit<Employee>> findHits, ICommandOptions options, bool isDirtyRead) {
+            await base.AddDocumentsToCacheAsync(findHits, options, isDirtyRead);
 
             var cacheEntries = new Dictionary<string, FindHit<Employee>>();
             foreach (var hit in findHits.Where(d => !String.IsNullOrEmpty(d.Document.EmailAddress)))


### PR DESCRIPTION
Call AddDocumentsToCacheAsync in more situations. Allow immediately caching added or saved docs. Add docs to cache by Id if they are not coming from dirty reads.