### PR TITLE
Unable to set Custom Date for Index Id before Adding event handler

### DIFF
--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -947,11 +947,11 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         else if (HasCreatedDate)
             documents.OfType<IHaveCreatedDate>().SetCreatedDates();
 
-        documents.EnsureIds(ElasticIndex.CreateDocumentId);
-
         if (DocumentsAdding != null && DocumentsAdding.HasHandlers)
             await DocumentsAdding.InvokeAsync(this, new DocumentsEventArgs<T>(documents, this, options)).AnyContext();
-
+        
+        documents.EnsureIds(ElasticIndex.CreateDocumentId);
+        
         await OnDocumentsChangingAsync(ChangeType.Added, documents, options).AnyContext();
     }
 

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/MonthlyRepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/MonthlyRepositoryTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading.Tasks;
+using Foundatio.Repositories.Elasticsearch.Tests.Repositories;
+using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
+using Foundatio.Repositories.Models;
+using Foundatio.Utility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Foundatio.Repositories.Elasticsearch.Tests;
+
+public sealed class MonthlyRepositoryTests : ElasticRepositoryTestBase {
+    private readonly IFileAccessHistoryRepository _fileAccessHistoryRepository;
+
+    public MonthlyRepositoryTests(ITestOutputHelper output) : base(output) {
+        _fileAccessHistoryRepository = new FileAccessHistoryRepository(_configuration);
+    }
+
+    public override async Task InitializeAsync() {
+        await base.InitializeAsync();
+        await RemoveDataAsync();
+    }
+
+    [Fact]
+    public async Task AddAsyncWithCustomDateIndex() {
+        var utcNow = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var history = await _fileAccessHistoryRepository.AddAsync(new FileAccessHistory { Path = "path1", AccessedDateUtc = utcNow }, o => o.ImmediateConsistency());
+        Assert.NotNull(history?.Id);
+
+        var result = await _fileAccessHistoryRepository.FindOneAsync(f => f.Id(history.Id));
+        Assert.Equal("file-access-history-monthly-v1-2023.01", result.Data.GetString("index"));
+    }
+
+    [Fact]
+    public async Task AddAsyncWithCurrentDateViaDocumentsAdding() {
+        using var _ = TestSystemClock.Install();
+        TestSystemClock.SetFrozenTime(new DateTime(2023, 02, 1, 0, 0, 0, DateTimeKind.Local));
+
+        try {
+            // NOTE: This has to be async handler as there is no way to remove a sync handler.
+            _fileAccessHistoryRepository.DocumentsAdding.AddHandler(OnDocumentsAdding);
+            
+            var history = await _fileAccessHistoryRepository.AddAsync(new FileAccessHistory { Path = "path2" }, o => o.ImmediateConsistency());
+            Assert.NotNull(history?.Id);
+            
+            var result = await _fileAccessHistoryRepository.FindOneAsync(f => f.Id(history.Id));
+            Assert.Equal("file-access-history-monthly-v1-2023.02", result.Data.GetString("index"));
+        } finally {
+            _fileAccessHistoryRepository.DocumentsAdding.RemoveHandler(OnDocumentsAdding);
+        }
+    }
+
+    private Task OnDocumentsAdding(object sender, DocumentsEventArgs<FileAccessHistory> arg) {
+        foreach (var document in arg.Documents) {
+            if (document.AccessedDateUtc == DateTime.MinValue || document.AccessedDateUtc > SystemClock.UtcNow)
+                document.AccessedDateUtc = SystemClock.UtcNow;
+        }
+        
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/MonthlyFileAccessHistoryIndex.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/MonthlyFileAccessHistoryIndex.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Foundatio.Repositories.Elasticsearch.Configuration;
+using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
+using Nest;
+
+namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Configuration.Indexes;
+
+public sealed class MonthlyFileAccessHistoryIndex : MonthlyIndex<FileAccessHistory> {
+    public MonthlyFileAccessHistoryIndex(IElasticConfiguration configuration) : base(configuration, "file-access-history-monthly", 1, d => ((FileAccessHistory)d).AccessedDateUtc) {
+    }
+
+    public override CreateIndexDescriptor ConfigureIndex(CreateIndexDescriptor idx) {
+        return base.ConfigureIndex(idx.Settings(s => s.NumberOfReplicas(0).NumberOfShards(1)));
+    }
+}

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/MyAppElasticConfiguration.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/MyAppElasticConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -27,6 +27,7 @@ public class MyAppElasticConfiguration : ElasticConfiguration {
         AddIndex(DailyLogEvents = new DailyLogEventIndex(this));
         AddIndex(MonthlyLogEvents = new MonthlyLogEventIndex(this));
         AddIndex(ParentChild = new ParentChildIndex(this));
+        AddIndex(MonthlyFileAccessHistory = new MonthlyFileAccessHistoryIndex(this));
         AddCustomFieldIndex(replicas: 0);
     }
 
@@ -86,4 +87,5 @@ public class MyAppElasticConfiguration : ElasticConfiguration {
     public DailyLogEventIndex DailyLogEvents { get; }
     public MonthlyLogEventIndex MonthlyLogEvents { get; }
     public ParentChildIndex ParentChild { get; }
+    public MonthlyFileAccessHistoryIndex MonthlyFileAccessHistory { get; }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/FileAccessHistoryRepository.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/FileAccessHistoryRepository.cs
@@ -1,0 +1,11 @@
+﻿using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Configuration;
+using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
+
+namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories; 
+
+public interface IFileAccessHistoryRepository : ISearchableRepository<FileAccessHistory> {}
+
+public class FileAccessHistoryRepository : ElasticRepositoryBase<FileAccessHistory>, IFileAccessHistoryRepository {
+    public FileAccessHistoryRepository(MyAppElasticConfiguration elasticConfiguration) : base(elasticConfiguration.MonthlyFileAccessHistory) {
+    }
+}

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/FileAccessHistory.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/FileAccessHistory.cs
@@ -1,0 +1,10 @@
+using System;
+using Foundatio.Repositories.Models;
+
+namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
+
+public record FileAccessHistory : IIdentity {
+    public string Id { get; set; }
+    public DateTime AccessedDateUtc { get; set; }
+    public string Path { get; set; }
+}


### PR DESCRIPTION
Added a test that shows off that monthly/daily indexes are failing due to unable to set custom date via event handler. Custom dates are set before the handler this preventing us from having custom logic before the document id is created.

```
    private async Task OnDocumentsAddingAsync(IReadOnlyCollection<T> documents, ICommandOptions options) {
        if (HasDates)
            documents.OfType<IHaveDates>().SetDates();
        else if (HasCreatedDate)
            documents.OfType<IHaveCreatedDate>().SetCreatedDates();

        documents.EnsureIds(ElasticIndex.CreateDocumentId);

        if (DocumentsAdding != null && DocumentsAdding.HasHandlers)
            await DocumentsAdding.InvokeAsync(this, new DocumentsEventArgs<T>(documents, this, options)).AnyContext();

        await OnDocumentsChangingAsync(ChangeType.Added, documents, options).AnyContext();
    }
```