### PR TITLE
added support for decimal column sorting with SearchAfter & SearchBefore

### DIFF
--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
@@ -144,12 +144,22 @@ public class ObjectConverter : JsonConverter<object>
     {
         return reader.TokenType switch
         {
-            JsonTokenType.Number => reader.GetInt64(),
+            JsonTokenType.Number => GetNumber(reader),
             JsonTokenType.String => reader.GetString(),
             JsonTokenType.True => reader.GetBoolean(),
             JsonTokenType.False => reader.GetBoolean(),
             _ => null
         };
+    }
+
+    private object GetNumber(Utf8JsonReader reader)
+    {
+        if (reader.TryGetInt64(out var l))
+            return l;
+        else if (reader.TryGetDecimal(out var d))
+            return d;
+        else
+            throw new InvalidOperationException("Value is not a number");
     }
 
     public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
@@ -1201,8 +1201,10 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Single(employees.Documents);
     }
 
-    [Fact]
-    public async Task CanSearchAfterAndBeforeWithMultipleSorts()
+    [Theory]
+    [InlineData("age")]
+    [InlineData("decimalAge")]
+    public async Task CanSearchAfterAndBeforeWithMultipleSorts(string secondarySort)
     {
         await _employeeRepository.AddAsync(EmployeeGenerator.GenerateEmployees(count: 100), o => o.ImmediateConsistency());
         int pageSize = 10;
@@ -1214,7 +1216,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         do
         {
             page++;
-            var employees = await _employeeRepository.FindAsync(q => q.Sort(e => e.Name).Sort(e => e.CompanyName).SortDescending(e => e.Age), o => o.SearchAfterToken(searchAfterToken).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
+            var employees = await _employeeRepository.FindAsync(q => q.Sort(e => e.Name).Sort(e => e.CompanyName).SortDescending(secondarySort), o => o.SearchAfterToken(searchAfterToken).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
             searchBeforeToken = employees.GetSearchBeforeToken();
             searchAfterToken = employees.GetSearchAfterToken();
             if (page == 1)

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/EmployeeIndex.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/EmployeeIndex.cs
@@ -50,6 +50,7 @@ public sealed class EmployeeIndex : Index<Employee>
                 .Text(f => f.Name(e => e.Name).AddKeywordAndSortFields().CopyTo(c => c.Field("_all")))
                 .Scalar(f => f.Age, f => f.Name(e => e.Age))
                 .FieldAlias(a => a.Name("aliasedage").Path(f => f.Age))
+                .Scalar(f => f.DecimalAge, f => f.Name(e => e.DecimalAge))
                 .Scalar(f => f.NextReview, f => f.Name(e => e.NextReview))
                 .FieldAlias(a => a.Name("next").Path(f => f.NextReview))
                 .GeoPoint(f => f.Name(e => e.Location))

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Employee.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Employee.cs
@@ -31,6 +31,7 @@ public class Employee : IIdentity, IHaveDates, IVersioned, ISupportSoftDeletes
     public string UnmappedEmailAddress => EmailAddress;
     public int Age { get; set; }
     public int UnmappedAge => Age;
+    public double DecimalAge => Age + .5;
     public string Location { get; set; }
     public int YearsEmployed { get; set; }
     public EmploymentType EmploymentType { get; set; } = EmploymentType.FullTime;


### PR DESCRIPTION
The ObjectConverter did not support parsing of decimal tokens, which caused DecodeSortToken to throw when sorting on decimal fields while using SearchBefore or SearchAfter paging. This PR adds support for decimals & an integration test case.