### PR TITLE
Fix #115 Concurrency issue when adding documents.

### DIFF
--- a/samples/Foundatio.SampleApp/Server/Repositories/Configuration/ElasticExtensions.cs
+++ b/samples/Foundatio.SampleApp/Server/Repositories/Configuration/ElasticExtensions.cs
@@ -58,4 +58,3 @@ public static class ElasticExtensions
         return services;
     }
 }
-

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/IndexTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/IndexTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -120,10 +120,8 @@ public sealed class IndexTests : ElasticRepositoryTestBase
 
         await _configuration.DailyLogEvents.ConfigureAsync();
 
-
-        // TODO: Fix this once https://github.com/elastic/elasticsearch-net/issues/3829 is fixed in beta2
-        //var indexes = await _client.GetIndicesPointingToAliasAsync(_configuration.DailyLogEvents.Name);
-        //Assert.Empty(indexes);
+        var indexes = await _client.GetIndicesPointingToAliasAsync(_configuration.DailyLogEvents.Name);
+        Assert.Empty(indexes);
 
         var alias = await _client.Indices.GetAliasAsync(_configuration.DailyLogEvents.Name);
         _logger.LogRequest(alias);
@@ -142,7 +140,7 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         Assert.True(alias.IsValid);
         Assert.Equal(2, alias.Indices.Count);
 
-        var indexes = await _client.GetIndicesPointingToAliasAsync(_configuration.DailyLogEvents.Name);
+        indexes = await _client.GetIndicesPointingToAliasAsync(_configuration.DailyLogEvents.Name);
         Assert.Equal(2, indexes.Count);
 
         await repository.RemoveAllAsync(o => o.ImmediateConsistency());

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/DailyFileAccessHistoryIndex.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/DailyFileAccessHistoryIndex.cs
@@ -1,0 +1,17 @@
+﻿using Foundatio.Repositories.Elasticsearch.Configuration;
+using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
+using Nest;
+
+namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Configuration.Indexes;
+
+public sealed class DailyFileAccessHistoryIndex : DailyIndex<FileAccessHistory>
+{
+    public DailyFileAccessHistoryIndex(IElasticConfiguration configuration) : base(configuration, "file-access-history-daily", 1, d => ((FileAccessHistory)d).AccessedDateUtc)
+    {
+    }
+
+    public override CreateIndexDescriptor ConfigureIndex(CreateIndexDescriptor idx)
+    {
+        return base.ConfigureIndex(idx.Settings(s => s.NumberOfReplicas(0).NumberOfShards(1)));
+    }
+}

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/MyAppElasticConfiguration.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/MyAppElasticConfiguration.cs
@@ -27,6 +27,7 @@ public class MyAppElasticConfiguration : ElasticConfiguration
         AddIndex(DailyLogEvents = new DailyLogEventIndex(this));
         AddIndex(MonthlyLogEvents = new MonthlyLogEventIndex(this));
         AddIndex(ParentChild = new ParentChildIndex(this));
+        AddIndex(DailyFileAccessHistory = new DailyFileAccessHistoryIndex(this));
         AddIndex(MonthlyFileAccessHistory = new MonthlyFileAccessHistoryIndex(this));
         AddCustomFieldIndex(replicas: 0);
     }
@@ -95,5 +96,6 @@ public class MyAppElasticConfiguration : ElasticConfiguration
     public DailyLogEventIndex DailyLogEvents { get; }
     public MonthlyLogEventIndex MonthlyLogEvents { get; }
     public ParentChildIndex ParentChild { get; }
+    public DailyFileAccessHistoryIndex DailyFileAccessHistory { get; }
     public MonthlyFileAccessHistoryIndex MonthlyFileAccessHistory { get; }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/FileAccessHistoryRepository.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/FileAccessHistoryRepository.cs
@@ -1,4 +1,4 @@
-﻿using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Configuration;
+﻿using Foundatio.Repositories.Elasticsearch.Configuration;
 using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 
 namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories;
@@ -7,7 +7,11 @@ public interface IFileAccessHistoryRepository : ISearchableRepository<FileAccess
 
 public class FileAccessHistoryRepository : ElasticRepositoryBase<FileAccessHistory>, IFileAccessHistoryRepository
 {
-    public FileAccessHistoryRepository(MyAppElasticConfiguration elasticConfiguration) : base(elasticConfiguration.MonthlyFileAccessHistory)
+    public FileAccessHistoryRepository(DailyIndex<FileAccessHistory> dailyIndex) : base(dailyIndex)
+    {
+    }
+
+    public FileAccessHistoryRepository(MonthlyIndex<FileAccessHistory> monthlyIndex) : base(monthlyIndex)
     {
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -979,12 +979,12 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         };
 
         await _dailyRepository.AddAsync(logs, o => o.Cache().ImmediateConsistency());
-        Assert.Equal(5, _cache.Count);
+        Assert.Equal(7, _cache.Count);
         Assert.Equal(0, _cache.Hits);
         Assert.Equal(2, _cache.Misses);
 
         Assert.Equal(3, await _dailyRepository.IncrementValueAsync(logs.Select(l => l.Id).ToArray()));
-        Assert.Equal(2, _cache.Count);
+        Assert.Equal(4, _cache.Count);
         Assert.Equal(0, _cache.Hits);
         Assert.Equal(2, _cache.Misses);
 

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -979,12 +979,12 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         };
 
         await _dailyRepository.AddAsync(logs, o => o.Cache().ImmediateConsistency());
-        Assert.Equal(7, _cache.Count);
+        Assert.Equal(5, _cache.Count);
         Assert.Equal(0, _cache.Hits);
         Assert.Equal(2, _cache.Misses);
 
         Assert.Equal(3, await _dailyRepository.IncrementValueAsync(logs.Select(l => l.Id).ToArray()));
-        Assert.Equal(4, _cache.Count);
+        Assert.Equal(2, _cache.Count);
         Assert.Equal(0, _cache.Hits);
         Assert.Equal(2, _cache.Misses);
 


### PR DESCRIPTION
Fixes #115 

```
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.set_Item(TKey key, TValue value)
   at Foundatio.Repositories.Elasticsearch.Configuration.DailyIndex.EnsureDateIndexAsync(DateTime utcDate) in /_/src/Foundatio.Repositories.Elasticsearch/Configuration/DailyIndex.cs:line 150
   at Foundatio.Repositories.Elasticsearch.ElasticRepositoryBase`1.IndexDocumentsAsync(IReadOnlyCollection`1 documents, Boolean isCreateOperation, ICommandOptions options) in /_/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs:line 1252
   at Foundatio.Repositories.Elasticsearch.ElasticRepositoryBase`1.AddAsync(IEnumerable`1 documents, ICommandOptions options) in /_/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs:line 93
   at Foundatio.Repositories.Elasticsearch.ElasticRepositoryBase`1.AddAsync(T document, ICommandOptions options) in /_/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs:line 67
```