### PR TITLE
Fixed a multithreading bug where index can be called multiple times.

### DIFF
--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
@@ -179,10 +179,13 @@ public class Index : IIndex
 
     public int BulkBatchSize { get; set; } = 1000;
 
-    public virtual Task DeleteAsync()
+    public virtual async Task DeleteAsync()
     {
-        _isEnsured = false;
-        return DeleteIndexAsync(Name);
+        using (await _lock.LockAsync().AnyContext())
+        {
+            await DeleteIndexAsync(Name).AnyContext();
+            _isEnsured = false;
+        }
     }
 
     protected virtual async Task CreateIndexAsync(string name, Func<CreateIndexDescriptor, CreateIndexDescriptor> descriptor = null)

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Foundatio.AsyncEx;
 using Foundatio.Parsers.ElasticQueries;
 using Foundatio.Parsers.ElasticQueries.Extensions;
 using Foundatio.Parsers.LuceneQueries.Visitors;
@@ -26,8 +28,9 @@ public class Index : IIndex
     private readonly Lazy<ElasticQueryParser> _queryParser;
     private readonly Lazy<ElasticMappingResolver> _mappingResolver;
     private readonly Lazy<QueryFieldResolver> _fieldResolver;
+    private readonly ConcurrentDictionary<string, ICustomFieldType> _customFieldTypes = new();
+    private readonly AsyncLock _lock = new();
     protected readonly ILogger _logger;
-    private readonly IDictionary<string, ICustomFieldType> _customFieldTypes = new Dictionary<string, ICustomFieldType>();
 
     public Index(IElasticConfiguration configuration, string name = null)
     {
@@ -149,14 +152,14 @@ public class Index : IIndex
         if (_isEnsured)
             return;
 
-        bool existsResult = await IndexExistsAsync(Name).AnyContext();
-        if (existsResult)
+        using (await _lock.LockAsync().AnyContext())
         {
-            _isEnsured = true;
-            return;
-        }
+            if (_isEnsured)
+                return;
 
-        await ConfigureAsync().AnyContext();
+            await ConfigureAsync().AnyContext();
+            _isEnsured = true;
+        }
     }
 
     public virtual Task MaintainAsync(bool includeOptionalTasks = true)
@@ -178,6 +181,7 @@ public class Index : IIndex
 
     public virtual Task DeleteAsync()
     {
+        _isEnsured = false;
         return DeleteIndexAsync(Name);
     }
 

--- a/src/Foundatio.Repositories/Extensions/TaskExtensions.cs
+++ b/src/Foundatio.Repositories/Extensions/TaskExtensions.cs
@@ -1,6 +1,8 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Foundatio.AsyncEx;
 
 namespace Foundatio.Repositories.Extensions;
 
@@ -14,6 +16,12 @@ internal static class TaskHelper
 
     [DebuggerStepThrough]
     public static ConfiguredTaskAwaitable AnyContext(this Task task)
+    {
+        return task.ConfigureAwait(continueOnCapturedContext: false);
+    }
+
+    [DebuggerStepThrough]
+    public static ConfiguredTaskAwaitable<TResult> AnyContext<TResult>(this AwaitableDisposable<TResult> task) where TResult : IDisposable
     {
         return task.ConfigureAwait(continueOnCapturedContext: false);
     }


### PR DESCRIPTION
I don't love adding a lock here but I think it might make some sense. It also simplifies as ConfigureAsync already calls IndexExists.