### PR TITLE
Passes TimeProvider to date setting extensions

### DIFF
--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -1154,9 +1154,9 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     private async Task OnDocumentsAddingAsync(IReadOnlyCollection<T> documents, ICommandOptions options)
     {
         if (HasDates)
-            documents.OfType<IHaveDates>().SetDates();
+            documents.OfType<IHaveDates>().SetDates(ElasticIndex.Configuration.TimeProvider);
         else if (HasCreatedDate)
-            documents.OfType<IHaveCreatedDate>().SetCreatedDates();
+            documents.OfType<IHaveCreatedDate>().SetCreatedDates(ElasticIndex.Configuration.TimeProvider);
 
         if (DocumentsAdding != null && DocumentsAdding.HasHandlers)
             await DocumentsAdding.InvokeAsync(this, new DocumentsEventArgs<T>(documents, this, options)).AnyContext();
@@ -1186,7 +1186,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             return;
 
         if (HasDates)
-            documents.Cast<IHaveDates>().SetDates();
+            documents.Cast<IHaveDates>().SetDates(ElasticIndex.Configuration.TimeProvider);
 
         documents.EnsureIds(ElasticIndex.CreateDocumentId, ElasticIndex.Configuration.TimeProvider);
 


### PR DESCRIPTION
## Pull request overview

This PR ensures that mocked `TimeProvider` instances are correctly respected when setting dates on entities during repository operations. It fixes a bug where `SetDates` and `SetCreatedDates` extension methods would default to `TimeProvider.System` instead of using the configured time provider.

- Passes `ElasticIndex.Configuration.TimeProvider` to `SetDates` and `SetCreatedDates` extension methods
- Adds comprehensive tests to verify mocked time providers work correctly, including future-dated scenarios
- Renames existing test to better reflect its purpose and makes assertions more precise

### Reviewed changes

Copilot reviewed 2 out of 2 changed files in this pull request and generated 2 comments.

| File | Description |
| ---- | ----------- |
| src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs | Adds TimeProvider parameter to SetDates and SetCreatedDates calls in OnDocumentsAddingAsync and OnDocumentsSavingAsync methods, ensuring consistency with other time-provider-aware operations like EnsureIds |
| tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs | Enhances existing test with more precise assertions and adds two new tests to verify correct behavior with future-dated mocked time providers, demonstrating the fix prevents the system from overwriting mocked future dates |



