### PR TITLE
fix: Add default Id sort for deterministic pagination

### DIFF
--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/DefaultSortQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/DefaultSortQueryBuilder.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Foundatio.Parsers.ElasticQueries.Extensions;
+using Foundatio.Repositories.Models;
+using Nest;
+
+namespace Foundatio.Repositories.Elasticsearch.Queries.Builders;
+
+public class DefaultSortQueryBuilder : IElasticQueryBuilder
+{
+    private const string Id = nameof(IIdentity.Id);
+
+    public Task BuildAsync<T>(QueryBuilderContext<T> ctx) where T : class, new()
+    {
+        if (ctx.Search is not ISearchRequest searchRequest)
+            return Task.CompletedTask;
+
+        var resolver = ctx.GetMappingResolver();
+        string idField = resolver.GetResolvedField(Id) ?? "_id";
+
+        searchRequest.Sort ??= new List<ISort>();
+        var sortFields = searchRequest.Sort;
+
+        // ensure id field is always present as a sort (default or tiebreaker)
+        if (!sortFields.Any(s => idField.Equals(resolver.GetResolvedField(s.SortKey))))
+            sortFields.Add(new FieldSort { Field = idField });
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ElasticQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ElasticQueryBuilder.cs
@@ -159,6 +159,7 @@ public class ElasticQueryBuilder : IElasticQueryBuilder
         Register<ExpressionQueryBuilder>();
         Register<ElasticFilterQueryBuilder>();
         Register<FieldConditionsQueryBuilder>();
+        Register<DefaultSortQueryBuilder>(Int32.MaxValue - 1);
         Register<RuntimeFieldsQueryBuilder>(Int32.MaxValue);
         Register<SearchAfterQueryBuilder>(Int32.MaxValue);
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Foundatio.Parsers.ElasticQueries.Extensions;
 using Foundatio.Repositories.Elasticsearch.Extensions;
-using Foundatio.Repositories.Models;
 using Foundatio.Repositories.Options;
 using Nest;
 
@@ -122,29 +119,17 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
 {
     public class SearchAfterQueryBuilder : IElasticQueryBuilder
     {
-        private const string Id = nameof(IIdentity.Id);
-
         public Task BuildAsync<T>(QueryBuilderContext<T> ctx) where T : class, new()
         {
             if (!ctx.Options.ShouldUseSearchAfterPaging())
                 return Task.CompletedTask;
 
-            var resolver = ctx.GetMappingResolver();
-            string idField = resolver.GetResolvedField(Id) ?? "_id";
-
             if (ctx.Search is not ISearchRequest searchRequest)
                 return Task.CompletedTask;
 
-            searchRequest.Sort ??= new List<ISort>();
-            var sortFields = searchRequest.Sort;
-
-            // ensure id field is always added to the end of the sort fields list
-            if (!sortFields.Any(s => resolver.GetResolvedField(s.SortKey).Equals(idField)))
-                sortFields.Add(new FieldSort { Field = idField });
-
-            // reverse sort orders on all sorts
+            // reverse sort orders on all sorts for search before
             if (ctx.Options.HasSearchBefore())
-                sortFields.ReverseOrder();
+                searchRequest.Sort?.ReverseOrder();
 
             return Task.CompletedTask;
         }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
@@ -967,6 +967,68 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
+    public async Task GetAllAsync_WithNoSortAndPaging_ReturnsAllDocumentsWithoutDuplicates()
+    {
+        // Arrange
+        var identities = IdentityGenerator.GenerateIdentities(100);
+        await _identityRepository.AddAsync(identities, o => o.ImmediateConsistency());
+
+        // Act
+        var results = await _identityRepository.GetAllAsync(o => o.PageLimit(10));
+        var viewedIds = new HashSet<string>();
+        int pagedRecords = 0;
+        do
+        {
+            viewedIds.AddRange(results.Hits.Select(h => h.Id));
+            pagedRecords += results.Documents.Count;
+        } while (await results.NextPageAsync());
+
+        // Assert
+        Assert.Equal(100, pagedRecords);
+        Assert.Equal(100, viewedIds.Count);
+        Assert.True(identities.All(e => viewedIds.Contains(e.Id)));
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithNoSort_ReturnsDocumentsSortedByIdAscending()
+    {
+        // Arrange
+        var identities = IdentityGenerator.GenerateIdentities(100);
+        await _identityRepository.AddAsync(identities, o => o.ImmediateConsistency());
+
+        // Act
+        var results = await _identityRepository.GetAllAsync(o => o.PageLimit(100));
+        var ids = results.Documents.Select(d => d.Id).ToList();
+
+        // Assert
+        Assert.Equal(100, ids.Count);
+        Assert.Equal(ids.OrderBy(id => id).ToList(), ids);
+    }
+
+    [Fact]
+    public async Task FindAsync_WithNoSortAndPaging_ReturnsAllDocumentsWithoutDuplicates()
+    {
+        // Arrange
+        var identities = IdentityGenerator.GenerateIdentities(100);
+        await _identityRepository.AddAsync(identities, o => o.ImmediateConsistency());
+
+        // Act
+        var results = await _identityRepository.FindAsync(q => q, o => o.PageLimit(10));
+        var viewedIds = new HashSet<string>();
+        int pagedRecords = 0;
+        do
+        {
+            viewedIds.AddRange(results.Hits.Select(h => h.Id));
+            pagedRecords += results.Documents.Count;
+        } while (await results.NextPageAsync());
+
+        // Assert
+        Assert.Equal(100, pagedRecords);
+        Assert.Equal(100, viewedIds.Count);
+        Assert.True(identities.All(e => viewedIds.Contains(e.Id)));
+    }
+
+    [Fact]
     public async Task GetAllWithSearchAfterAsync()
     {
         var identity1 = await _identityRepository.AddAsync(IdentityGenerator.Default, o => o.ImmediateConsistency());


### PR DESCRIPTION
## Summary

- Add `DefaultSortQueryBuilder` that ensures the model's `Id` keyword field is always present in the Elasticsearch sort list, either as the default sort (when no other sorts exist) or as a tiebreaker (when user-defined sorts don't include `Id`)
- Simplify `SearchAfterQueryBuilder` by removing its tiebreaker logic, since `DefaultSortQueryBuilder` now handles it universally
- Add tests verifying deterministic pagination with 100 documents across `GetAllAsync` and `FindAsync`

## Root Cause Analysis

When `GetAllAsync()` or `FindAsync()` is called without an explicit sort and the caller paginates using `NextPageAsync()`, Elasticsearch returns results in an undefined order (typically `_doc` order — internal Lucene segment order). If documents are updated concurrently between page fetches, they shift between Lucene segments, causing:

- **Duplicates**: A document appears on multiple pages
- **Missing documents**: A document is skipped entirely

### The Bug

There was **no default sort anywhere in the query pipeline** for non-`SearchAfterPaging` queries. The only automatic sort injection was in `SearchAfterQueryBuilder`, which exits immediately when `ShouldUseSearchAfterPaging()` is false — something callers must explicitly opt into.

### Data Flow Showing the Gap

```
GetAllAsync() → FindAsync(NewQuery(), options) → FindAsAsync
  → ConfigureOptions (sets page limit, NO sort)
  → CreateSearchDescriptorAsync → ElasticQueryBuilder.BuildAsync
    → SortQueryBuilder: skips (no sorts set)
    → SearchAfterQueryBuilder: skips (not search_after mode)
    → Result: NO sort on ES request
  → Elasticsearch returns docs in _doc order
  → NextPageAsync increments page number
  → Re-queries with from/size, STILL no sort
  → Concurrent writes shift docs between segments
  → DUPLICATES / MISSING DOCS
```

### Elasticsearch Documentation Confirming This Behavior

1. **[Sort search results](https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html)**: `_doc` has no real use-case besides being the most efficient sort order — confirms that without an explicit sort, ES uses internal segment ordering that is non-deterministic.

2. **[Paginate search results](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html)**: *"Elasticsearch uses Lucene's internal doc IDs as tie-breakers. These internal doc IDs can be completely different across replicas of the same data."* And for `search_after`: *"If you don't include a tiebreaker field, your paged results could miss or duplicate hits."*

3. **[`_id` field docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html)**: The `_id` field is *"restricted from use in aggregations, sorting, and scripting"* — this is why the fix uses the model's mapped `Id` keyword field (which has `doc_values`), NOT the `_id` metadata field.

## Affected Code Paths

All of these methods were vulnerable when used with `NextPageAsync()` and no explicit sort:

1. **`GetAllAsync()`** — Calls `FindAsync(NewQuery(), options)` with no sort
2. **`FindAsync()` / `FindAsAsync()`** — Core query method, never injected a default sort
3. **`SearchAsync()`** — When called with `sort = null`
4. **Any consumer using `NextPageAsync()`** with offset-based paging without specifying a sort

**Safe paths** (not affected):
- `BatchProcessAsAsync` — Forces `SearchAfterPaging()` which triggered the tiebreaker
- Any call with `.SnapshotPaging()` — Uses scroll API (point-in-time consistent)
- Any call with `.SearchAfterPaging()` — `SearchAfterQueryBuilder` added the tiebreaker

## Design Decision: Why `Id` (not `CreatedUtc` or `_id`)

| Field | Available | Unique | `doc_values` | Decision |
|-------|-----------|--------|--------------|----------|
| `Id` (mapped keyword) | Always (`IIdentity`) | Yes | Yes (default for keyword) | **Chosen** |
| `CreatedUtc` | Only `IHaveCreatedDate` | No (shared timestamps) | Yes | Rejected — not universal, not unique |
| `_id` (metadata) | Always | Yes | No — restricted from sorting | Rejected — performance issue |

Since Foundatio uses `ObjectId`-based IDs (which embed a timestamp in the first 4 bytes), sorting by `Id` ascending naturally produces oldest-to-newest ordering — functionally equivalent to `CreatedUtc` but universally available and unique.

## Implementation

### New: `DefaultSortQueryBuilder`

Registered at priority `Int32.MaxValue - 1` (after all user-sort builders, before `SearchAfterQueryBuilder`). It always ensures `Id` is present in the sort list:

- **No sorts exist** → adds `Id asc` as the default sort
- **Sorts exist but `Id` is missing** → appends `Id asc` as a tiebreaker
- **Sorts exist and `Id` is present** → no-op

### Simplified: `SearchAfterQueryBuilder`

The tiebreaker logic was removed since `DefaultSortQueryBuilder` now handles it universally. `SearchAfterQueryBuilder` now only handles `SearchBefore` sort reversal.

### All Scenarios Verified

| Scenario | Result |
|----------|--------|
| No user sort, no search_after | `[Id asc]` |
| No user sort, with search_after | `[Id asc]` |
| User sort (e.g., Name), no search_after | `[Name asc, Id asc]` — **improvement**: offset paging now has tiebreaker too |
| User sort (e.g., Name), with search_after | `[Name asc, Id asc]` |
| User sort + SearchBefore | `[Name desc, Id desc]` (reversed) |
| User sort already includes Id | No duplicate sort added |

## Test Plan

- [x] `GetAllAsync_WithNoSortAndPaging_ReturnsAllDocumentsWithoutDuplicates` — 100 documents, pages of 10, verifies no duplicates across all pages
- [x] `GetAllAsync_WithNoSort_ReturnsDocumentsSortedByIdAscending` — 100 documents, verifies ascending Id order
- [x] `FindAsync_WithNoSortAndPaging_ReturnsAllDocumentsWithoutDuplicates` — 100 documents, pages of 10, verifies no duplicates across all pages
- [x] All 312 existing tests pass (7 pre-existing skips, 0 failures)
- [x] Build succeeds with 0 errors
