### PR TITLE
Merge NRT changes from main into elastic-client-nrt

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -16,8 +16,9 @@
     <Copyright>Copyright © $([System.DateTime]::Now.ToString(yyyy)) Foundatio.  All rights reserved.</Copyright>
     <Authors>FoundatioFx</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <WarningsAsErrors>true</WarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageOutputPath>$(SolutionDir)artifacts</PackageOutputPath>
     <PackageIcon>foundatio-icon.png</PackageIcon>

--- a/build/common.props
+++ b/build/common.props
@@ -15,8 +15,9 @@
     <Copyright>Copyright © $([System.DateTime]::Now.ToString(yyyy)) Foundatio.  All rights reserved.</Copyright>
     <Authors>FoundatioFx</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <WarningsAsErrors>true</WarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageOutputPath>$(SolutionDir)artifacts</PackageOutputPath>
     <PackageIcon>foundatio-icon.png</PackageIcon>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.14
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.2
     environment:
       discovery.type: single-node
       xpack.security.enabled: "false"
@@ -20,7 +20,7 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
-    image: docker.elastic.co/kibana/kibana:8.19.14
+    image: docker.elastic.co/kibana/kibana:9.3.2
     environment:
       xpack.security.enabled: "false"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.14
     environment:
       discovery.type: single-node
       xpack.security.enabled: "false"
@@ -20,7 +20,7 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
-    image: docker.elastic.co/kibana/kibana:9.3.1
+    image: docker.elastic.co/kibana/kibana:8.19.14
     environment:
       xpack.security.enabled: "false"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.11
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.14
     environment:
       discovery.type: single-node
       xpack.security.enabled: "false"
@@ -20,7 +20,7 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
-    image: docker.elastic.co/kibana/kibana:8.19.11
+    image: docker.elastic.co/kibana/kibana:8.19.14
     environment:
       xpack.security.enabled: "false"
     ports:

--- a/docs/guide/querying.md
+++ b/docs/guide/querying.md
@@ -42,6 +42,10 @@ var results = await repository.FindAsync(q => q.FilterExpression("name:John*"));
 var results = await repository.FindAsync(q => q.FilterExpression("_exists_:email"));
 ```
 
+::: tip Prefer Strongly-Typed Queries
+Filter expressions are convenient for dynamic or user-supplied queries, but for application code we recommend using [Strongly-Typed Queries](#strongly-typed-queries) whenever possible. Strongly-typed queries provide compile-time field name checking, full IDE support (Find References, Rename/Refactor, Go to Definition), and runtime field-type validation that catches misuse like `FieldEquals` on text-only fields with a `QueryValidationException`.
+:::
+
 ### Find with Search Expression
 
 Full-text search across analyzed fields:
@@ -49,6 +53,56 @@ Full-text search across analyzed fields:
 ```csharp
 var results = await repository.FindAsync(q => q.SearchExpression("john developer"));
 ```
+
+#### Default Search Fields
+
+`SearchExpression` generates a multi-match query across a set of **default search fields**. Without explicit configuration, Elasticsearch uses its own `index.query.default_field` setting (typically `*`, which matches all top-level fields). You can control exactly which fields are searched by overriding `ConfigureQueryParser` on your `Index<T>` class:
+
+```csharp
+public sealed class EmployeeIndex : Index<Employee>
+{
+    // ... constructor, ConfigureIndex, ConfigureIndexMapping ...
+
+    protected override void ConfigureQueryParser(ElasticQueryParserConfiguration config)
+    {
+        base.ConfigureQueryParser(config);
+        config.SetDefaultFields([
+            nameof(Employee.Name).ToLowerInvariant(),
+            nameof(Employee.EmailAddress).ToLowerInvariant()
+        ]);
+    }
+}
+```
+
+With this configuration, `SearchExpression("john")` generates a multi-match query targeting only `name` and `emailAddress` rather than every field in the index.
+
+#### Alternative: CopyTo with a Catch-All Field
+
+Instead of multi-match, you can copy field values into a single analyzed field at index time using `CopyTo`:
+
+```csharp
+public override TypeMappingDescriptor<Employee> ConfigureIndexMapping(
+    TypeMappingDescriptor<Employee> map)
+{
+    return map
+        .Dynamic(false)
+        .Properties(p => p
+            .SetupDefaults()
+            .Text(f => f.Name("_all"))
+            .Text(f => f.Name(e => e.Name).AddKeywordAndSortFields()
+                .CopyTo(c => c.Field("_all")))
+            .Keyword(f => f.Name(e => e.EmailAddress)
+                .CopyTo(c => c.Field("_all")))
+        );
+}
+```
+
+| Approach | Trade-offs |
+|---|---|
+| `SetDefaultFields` | No extra index storage; generates a multi-match query at search time. Keeps the index lean. |
+| `CopyTo` catch-all | Increases index size (field values stored twice); single-field match at search time, which can be faster for high-throughput queries. |
+
+Both approaches can be combined. For nested field support in default search fields, see [Default Fields with Nested Paths](#default-fields-with-nested-paths) in the Nested Queries section.
 
 ### Find One
 
@@ -539,7 +593,7 @@ var results = await repository.FindAsync(q => q
 
 ### Default Fields with Nested Paths
 
-Nested fields can be included in default search fields via `SetDefaultFields` in your query parser configuration. This allows unqualified search terms to match against nested fields:
+When [default search fields](#default-search-fields) include nested field paths, the framework automatically wraps the corresponding portion of the multi-match query in a `nested` query. No additional configuration is needed beyond including the dotted path in `SetDefaultFields`:
 
 ```csharp
 protected override void ConfigureQueryParser(ElasticQueryParserConfiguration config)
@@ -548,12 +602,12 @@ protected override void ConfigureQueryParser(ElasticQueryParserConfiguration con
     config.SetDefaultFields([
         nameof(Employee.Id).ToLowerInvariant(),
         nameof(Employee.Name).ToLowerInvariant(),
-        "peerReviews.reviewerEmployeeId"
+        "peerReviews.reviewerEmployeeId"  // nested field
     ]);
 }
 ```
 
-With this configuration, a bare search term like `bob_456` will match against `id`, `name`, and `peerReviews.reviewerEmployeeId`:
+With this configuration, a bare search term like `bob_456` will match against `id` and `name` (root-level) as well as `peerReviews.reviewerEmployeeId` (nested). The nested portion is automatically detected via the index mapping:
 
 ```csharp
 // Searches id, name, AND the nested peerReviews.reviewerEmployeeId field
@@ -857,7 +911,7 @@ if (results.Total == 0 && results.IsAsyncQueryRunning())
 {
     // Query is still running, get the ID
     var queryId = results.GetAsyncQueryId();
-    
+
     // Check later
     var laterResults = await repository.FindAsync(
         query,

--- a/docs/guide/querying.md
+++ b/docs/guide/querying.md
@@ -42,6 +42,10 @@ var results = await repository.FindAsync(q => q.FilterExpression("name:John*"));
 var results = await repository.FindAsync(q => q.FilterExpression("_exists_:email"));
 ```
 
+::: tip Prefer Strongly-Typed Queries
+Filter expressions are convenient for dynamic or user-supplied queries, but for application code we recommend using [Strongly-Typed Queries](#strongly-typed-queries) whenever possible. Strongly-typed queries provide compile-time field name checking, full IDE support (Find References, Rename/Refactor, Go to Definition), and runtime field-type validation that catches misuse like `FieldEquals` on text-only fields with a `QueryValidationException`.
+:::
+
 ### Find with Search Expression
 
 Full-text search across analyzed fields:
@@ -49,6 +53,56 @@ Full-text search across analyzed fields:
 ```csharp
 var results = await repository.FindAsync(q => q.SearchExpression("john developer"));
 ```
+
+#### Default Search Fields
+
+`SearchExpression` generates a multi-match query across a set of **default search fields**. Without explicit configuration, Elasticsearch uses its own `index.query.default_field` setting (typically `*`, which matches all top-level fields). You can control exactly which fields are searched by overriding `ConfigureQueryParser` on your `Index<T>` class:
+
+```csharp
+public sealed class EmployeeIndex : Index<Employee>
+{
+    // ... constructor, ConfigureIndex, ConfigureIndexMapping ...
+
+    protected override void ConfigureQueryParser(ElasticQueryParserConfiguration config)
+    {
+        base.ConfigureQueryParser(config);
+        config.SetDefaultFields([
+            nameof(Employee.Name).ToLowerInvariant(),
+            nameof(Employee.EmailAddress).ToLowerInvariant()
+        ]);
+    }
+}
+```
+
+With this configuration, `SearchExpression("john")` generates a multi-match query targeting only `name` and `emailAddress` rather than every field in the index.
+
+#### Alternative: CopyTo with a Catch-All Field
+
+Instead of multi-match, you can copy field values into a single analyzed field at index time using `CopyTo`:
+
+```csharp
+public override TypeMappingDescriptor<Employee> ConfigureIndexMapping(
+    TypeMappingDescriptor<Employee> map)
+{
+    return map
+        .Dynamic(false)
+        .Properties(p => p
+            .SetupDefaults()
+            .Text(f => f.Name("_all"))
+            .Text(f => f.Name(e => e.Name).AddKeywordAndSortFields()
+                .CopyTo(c => c.Field("_all")))
+            .Keyword(f => f.Name(e => e.EmailAddress)
+                .CopyTo(c => c.Field("_all")))
+        );
+}
+```
+
+| Approach | Trade-offs |
+|---|---|
+| `SetDefaultFields` | No extra index storage; generates a multi-match query at search time. Keeps the index lean. |
+| `CopyTo` catch-all | Increases index size (field values stored twice); single-field match at search time, which can be faster for high-throughput queries. |
+
+Both approaches can be combined. For nested field support in default search fields, see [Default Fields with Nested Paths](#default-fields-with-nested-paths) in the Nested Queries section.
 
 ### Find One
 
@@ -538,7 +592,7 @@ var results = await repository.FindAsync(q => q
 
 ### Default Fields with Nested Paths
 
-Nested fields can be included in default search fields via `SetDefaultFields` in your query parser configuration. This allows unqualified search terms to match against nested fields:
+When [default search fields](#default-search-fields) include nested field paths, the framework automatically wraps the corresponding portion of the multi-match query in a `nested` query. No additional configuration is needed beyond including the dotted path in `SetDefaultFields`:
 
 ```csharp
 protected override void ConfigureQueryParser(ElasticQueryParserConfiguration config)
@@ -547,12 +601,12 @@ protected override void ConfigureQueryParser(ElasticQueryParserConfiguration con
     config.SetDefaultFields([
         nameof(Employee.Id).ToLowerInvariant(),
         nameof(Employee.Name).ToLowerInvariant(),
-        "peerReviews.reviewerEmployeeId"
+        "peerReviews.reviewerEmployeeId"  // nested field
     ]);
 }
 ```
 
-With this configuration, a bare search term like `bob_456` will match against `id`, `name`, and `peerReviews.reviewerEmployeeId`:
+With this configuration, a bare search term like `bob_456` will match against `id` and `name` (root-level) as well as `peerReviews.reviewerEmployeeId` (nested). The nested portion is automatically detected via the index mapping:
 
 ```csharp
 // Searches id, name, AND the nested peerReviews.reviewerEmployeeId field
@@ -856,7 +910,7 @@ if (results.Total == 0 && results.IsAsyncQueryRunning())
 {
     // Query is still running, get the ID
     var queryId = results.GetAsyncQueryId();
-    
+
     // Check later
     var laterResults = await repository.FindAsync(
         query,

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -4684,9 +4684,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "devDependencies": {
         "@types/node": "^24.0.0",
-        "mermaid": "^11.13.0",
+        "mermaid": "^11.14.0",
         "vitepress": "^2.0.0-alpha.16",
-        "vitepress-plugin-llms": "^1.11.0",
+        "vitepress-plugin-llms": "^1.12.0",
         "vitepress-plugin-mermaid": "^2.0.17"
       }
     },
@@ -87,46 +87,44 @@
       "license": "MIT"
     },
     "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
-      "integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/gast": "11.1.2",
-        "@chevrotain/types": "11.1.2",
-        "lodash-es": "4.17.23"
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
       }
     },
     "node_modules/@chevrotain/gast": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
-      "integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/types": "11.1.2",
-        "lodash-es": "4.17.23"
+        "@chevrotain/types": "12.0.0"
       }
     },
     "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
-      "integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/types": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
-      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/utils": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
-      "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -655,9 +653,9 @@
       "optional": true
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.1.tgz",
-      "integrity": "sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1937,31 +1935,33 @@
       }
     },
     "node_modules/chevrotain": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
-      "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.1.2",
-        "@chevrotain/gast": "11.1.2",
-        "@chevrotain/regexp-to-ast": "11.1.2",
-        "@chevrotain/types": "11.1.2",
-        "@chevrotain/utils": "11.1.2",
-        "lodash-es": "4.17.23"
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/chevrotain-allstar": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
+      "integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash-es": "^4.17.21"
       },
       "peerDependencies": {
-        "chevrotain": "^11.0.0"
+        "chevrotain": "^12.0.0"
       }
     },
     "node_modules/cliui": {
@@ -3095,14 +3095,15 @@
       }
     },
     "node_modules/langium": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
-      "integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
+      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chevrotain": "~11.1.1",
-        "chevrotain-allstar": "~0.3.1",
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.1",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.11",
         "vscode-uri": "~3.1.0"
@@ -3213,9 +3214,9 @@
       }
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3337,15 +3338,15 @@
       "license": "MIT"
     },
     "node_modules/mermaid": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.13.0.tgz",
-      "integrity": "sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.0.1",
+        "@mermaid-js/parser": "^1.1.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
         "cytoscape": "^3.33.1",
@@ -4805,26 +4806,29 @@
       }
     },
     "node_modules/vitepress-plugin-llms": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/vitepress-plugin-llms/-/vitepress-plugin-llms-1.11.0.tgz",
-      "integrity": "sha512-n6fjWzBNKy40p8cij+d2cHiC2asNW1eQKdmc06gX9VAv7vWppIoVLH/f7Ht1bK0vSpGzzW2QimvNfbfv1oCdJw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/vitepress-plugin-llms/-/vitepress-plugin-llms-1.12.0.tgz",
+      "integrity": "sha512-zuzL7a8UJuGl46le5cAy/QxKMGlpSylcsLjDDn6BYPc1u+eP3nzoQk9ne9XFBqrE7exoJlIYJELVN8HMgYlFKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "gray-matter": "^4.0.3",
         "markdown-it": "^14.1.0",
         "markdown-title": "^1.0.2",
-        "mdast-util-from-markdown": "^2.0.2",
+        "mdast-util-from-markdown": "^2.0.3",
         "millify": "^6.1.0",
-        "minimatch": "^10.1.1",
+        "minimatch": "^10.2.4",
         "path-to-regexp": "^6.3.0",
         "picocolors": "^1.1.1",
         "pretty-bytes": "^7.1.0",
         "remark": "^15.0.1",
         "remark-frontmatter": "^5.0.0",
-        "tokenx": "^1.2.1",
+        "tokenx": "^1.3.0",
         "unist-util-remove": "^4.0.0",
-        "unist-util-visit": "^5.0.0"
+        "unist-util-visit": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/okineadev"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3131,9 +3131,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -3999,9 +3999,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4684,9 +4684,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3131,9 +3131,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3999,9 +3999,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,9 +10,9 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
-    "mermaid": "^11.13.0",
+    "mermaid": "^11.14.0",
     "vitepress": "^2.0.0-alpha.16",
-    "vitepress-plugin-llms": "^1.11.0",
+    "vitepress-plugin-llms": "^1.12.0",
     "vitepress-plugin-mermaid": "^2.0.17"
   },
   "overrides": {

--- a/samples/Foundatio.SampleApp/Server/Foundatio.SampleApp.Server.csproj
+++ b/samples/Foundatio.SampleApp/Server/Foundatio.SampleApp.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Foundatio.Extensions.Hosting" Version="13.0.0-beta3.13" />
+    <PackageReference Include="Foundatio.Extensions.Hosting" Version="13.0.0-beta3.43" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.5" />
   </ItemGroup>
 

--- a/samples/Foundatio.SampleApp/Server/Foundatio.SampleApp.Server.csproj
+++ b/samples/Foundatio.SampleApp/Server/Foundatio.SampleApp.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Foundatio.Extensions.Hosting" Version="13.0.0-beta3.43" />
+    <PackageReference Include="Foundatio.Extensions.Hosting" Version="13.0.0-beta3.45" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.5" />
   </ItemGroup>
 

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/DailyIndex.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/DailyIndex.cs
@@ -616,6 +616,6 @@ public class DailyIndex<T> : DailyIndex, IIndex<T> where T : class
     }
 
     public Inferrer Infer => Configuration.Client.Infer;
-    public string InferField(Expression<Func<T, object>> objectPath) => Infer.Field(objectPath);
-    public string InferPropertyName(Expression<Func<T, object>> objectPath) => Infer.PropertyName(objectPath);
+    public string InferField(Expression<Func<T, object?>> objectPath) => Infer.Field(objectPath);
+    public string InferPropertyName(Expression<Func<T, object?>> objectPath) => Infer.PropertyName(objectPath);
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/DailyIndex.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/DailyIndex.cs
@@ -33,19 +33,18 @@ public class DailyIndex : VersionedIndex
     private TimeSpan? _maxIndexAge;
     protected readonly Func<object, DateTime> _getDocumentDateUtc;
     protected readonly string[] _defaultIndexes;
-    private readonly ConcurrentDictionary<DateTime, string> _ensuredDates = new();
+    private readonly ConcurrentDictionary<DateTime, byte> _ensuredDates = new();
 
-    public DailyIndex(IElasticConfiguration configuration, string name, int version = 1, Func<object, DateTime> getDocumentDateUtc = null)
+    public DailyIndex(IElasticConfiguration configuration, string name, int version = 1, Func<object, DateTime>? getDocumentDateUtc = null)
         : base(configuration, name, version)
     {
         AddAlias(Name);
         _frozenAliases = new Lazy<IReadOnlyCollection<IndexAliasAge>>(() => _aliases.AsReadOnly());
         _aliasCache = new ScopedCacheClient(configuration.Cache, "alias");
-        _getDocumentDateUtc = getDocumentDateUtc;
-        _defaultIndexes = [Name];
+        _defaultIndexes = new[] { Name };
         HasMultipleIndexes = true;
 
-        if (_getDocumentDateUtc != null)
+        if (getDocumentDateUtc is not null)
             _getDocumentDateUtc = document =>
             {
                 var date = getDocumentDateUtc(document);
@@ -149,13 +148,13 @@ public class DailyIndex : VersionedIndex
         string unversionedIndexAlias = GetIndexByDate(utcDate);
         if (await _aliasCache.ExistsAsync(unversionedIndexAlias).AnyContext())
         {
-            _ensuredDates[utcDate] = null;
+            _ensuredDates[utcDate] = 0;
             return;
         }
 
         if (await AliasExistsAsync(unversionedIndexAlias).AnyContext())
         {
-            _ensuredDates[utcDate] = null;
+            _ensuredDates[utcDate] = 0;
             await _aliasCache.SetAsync(unversionedIndexAlias, unversionedIndexAlias, expires).AnyContext();
             return;
         }
@@ -172,7 +171,7 @@ public class DailyIndex : VersionedIndex
                 descriptor.AddAlias(alias.Name, a => { });
         }).AnyContext();
 
-        _ensuredDates[utcDate] = null;
+        _ensuredDates[utcDate] = 0;
         await _aliasCache.SetAsync(unversionedIndexAlias, unversionedIndexAlias, expires).AnyContext();
     }
 
@@ -240,7 +239,7 @@ public class DailyIndex : VersionedIndex
         return DeleteIndexAsync($"{Name}-v*");
     }
 
-    public override async Task ReindexAsync(Func<int, string, Task> progressCallbackAsync = null)
+    public override async Task ReindexAsync(Func<int, string?, Task>? progressCallbackAsync = null)
     {
         int currentVersion = await GetCurrentVersionAsync().AnyContext();
         if (currentVersion < 0 || currentVersion >= Version)
@@ -433,7 +432,7 @@ public class DailyIndex : VersionedIndex
         return ElasticMappingResolver.Create(GetLatestIndexMapping, Configuration.Client.Infer, _logger);
     }
 
-    protected TypeMapping GetLatestIndexMapping()
+    protected TypeMapping? GetLatestIndexMapping()
     {
         string filter = $"{Name}-v{Version}-*";
         var indicesResponse = Configuration.Client.Indices.Get((Indices)(IndexName)filter);
@@ -522,7 +521,7 @@ public class DailyIndex : VersionedIndex
         return base.CreateDocumentId(document);
     }
 
-    public override Task EnsureIndexAsync(object target)
+    public override Task EnsureIndexAsync(object? target)
     {
         if (target == null)
             throw new ArgumentNullException(nameof(target));
@@ -559,18 +558,17 @@ public class DailyIndex : VersionedIndex
     [DebuggerDisplay("Name: {Name} Max Age: {MaxAge}")]
     public class IndexAliasAge
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public TimeSpan MaxAge { get; set; }
     }
 }
 
 public class DailyIndex<T> : DailyIndex, IIndex<T> where T : class
 {
-    private readonly string _typeName = typeof(T).Name.ToLower();
+    private static readonly string _typeName = typeof(T).Name.ToLower();
 
-    public DailyIndex(IElasticConfiguration configuration, string name = null, int version = 1, Func<object, DateTime> getDocumentDateUtc = null) : base(configuration, name, version, getDocumentDateUtc)
+    public DailyIndex(IElasticConfiguration configuration, string? name = null, int version = 1, Func<object, DateTime>? getDocumentDateUtc = null) : base(configuration, name ?? _typeName, version, getDocumentDateUtc)
     {
-        Name = name ?? _typeName;
     }
 
     protected override ElasticMappingResolver CreateMappingResolver()
@@ -606,7 +604,7 @@ public class DailyIndex<T> : DailyIndex, IIndex<T> where T : class
         settings.DefaultMappingFor<T>(d => d.IndexName(Name));
     }
 
-    protected override string GetTimeStampField()
+    protected override string? GetTimeStampField()
     {
         if (typeof(IHaveDates).IsAssignableFrom(typeof(T)))
             return InferField(f => ((IHaveDates)f).UpdatedUtc);

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/DailyIndex.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/DailyIndex.cs
@@ -31,19 +31,18 @@ public class DailyIndex : VersionedIndex
     private TimeSpan? _maxIndexAge;
     protected readonly Func<object, DateTime> _getDocumentDateUtc;
     protected readonly string[] _defaultIndexes;
-    private readonly ConcurrentDictionary<DateTime, string> _ensuredDates = new();
+    private readonly ConcurrentDictionary<DateTime, byte> _ensuredDates = new();
 
-    public DailyIndex(IElasticConfiguration configuration, string name, int version = 1, Func<object, DateTime> getDocumentDateUtc = null)
+    public DailyIndex(IElasticConfiguration configuration, string name, int version = 1, Func<object, DateTime>? getDocumentDateUtc = null)
         : base(configuration, name, version)
     {
         AddAlias(Name);
         _frozenAliases = new Lazy<IReadOnlyCollection<IndexAliasAge>>(() => _aliases.AsReadOnly());
         _aliasCache = new ScopedCacheClient(configuration.Cache, "alias");
-        _getDocumentDateUtc = getDocumentDateUtc;
-        _defaultIndexes = [Name];
+        _defaultIndexes = new[] { Name };
         HasMultipleIndexes = true;
 
-        if (_getDocumentDateUtc != null)
+        if (getDocumentDateUtc is not null)
             _getDocumentDateUtc = document =>
             {
                 var date = getDocumentDateUtc(document);
@@ -147,13 +146,13 @@ public class DailyIndex : VersionedIndex
         string unversionedIndexAlias = GetIndexByDate(utcDate);
         if (await _aliasCache.ExistsAsync(unversionedIndexAlias).AnyContext())
         {
-            _ensuredDates[utcDate] = null;
+            _ensuredDates[utcDate] = 0;
             return;
         }
 
         if (await AliasExistsAsync(unversionedIndexAlias).AnyContext())
         {
-            _ensuredDates[utcDate] = null;
+            _ensuredDates[utcDate] = 0;
             await _aliasCache.SetAsync(unversionedIndexAlias, unversionedIndexAlias, expires).AnyContext();
             return;
         }
@@ -169,7 +168,7 @@ public class DailyIndex : VersionedIndex
             return ConfigureIndex(descriptor).Aliases(a => aliasesDescriptor);
         }).AnyContext();
 
-        _ensuredDates[utcDate] = null;
+        _ensuredDates[utcDate] = 0;
         await _aliasCache.SetAsync(unversionedIndexAlias, unversionedIndexAlias, expires).AnyContext();
     }
 
@@ -223,7 +222,7 @@ public class DailyIndex : VersionedIndex
         return DeleteIndexAsync($"{Name}-v*");
     }
 
-    public override async Task ReindexAsync(Func<int, string, Task> progressCallbackAsync = null)
+    public override async Task ReindexAsync(Func<int, string?, Task>? progressCallbackAsync = null)
     {
         int currentVersion = await GetCurrentVersionAsync().AnyContext();
         if (currentVersion < 0 || currentVersion >= Version)
@@ -405,7 +404,7 @@ public class DailyIndex : VersionedIndex
         return ElasticMappingResolver.Create(GetLatestIndexMapping, Configuration.Client.Infer, _logger);
     }
 
-    protected ITypeMapping GetLatestIndexMapping()
+    protected ITypeMapping? GetLatestIndexMapping()
     {
         string filter = $"{Name}-v{Version}-*";
         var catResponse = Configuration.Client.Cat.Indices(i => i.Pri().Index(Indices.Index((IndexName)filter)));
@@ -487,7 +486,7 @@ public class DailyIndex : VersionedIndex
         return base.CreateDocumentId(document);
     }
 
-    public override Task EnsureIndexAsync(object target)
+    public override Task EnsureIndexAsync(object? target)
     {
         if (target == null)
             throw new ArgumentNullException(nameof(target));
@@ -524,18 +523,17 @@ public class DailyIndex : VersionedIndex
     [DebuggerDisplay("Name: {Name} Max Age: {MaxAge}")]
     public class IndexAliasAge
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public TimeSpan MaxAge { get; set; }
     }
 }
 
 public class DailyIndex<T> : DailyIndex, IIndex<T> where T : class
 {
-    private readonly string _typeName = typeof(T).Name.ToLower();
+    private static readonly string _typeName = typeof(T).Name.ToLower();
 
-    public DailyIndex(IElasticConfiguration configuration, string name = null, int version = 1, Func<object, DateTime> getDocumentDateUtc = null) : base(configuration, name, version, getDocumentDateUtc)
+    public DailyIndex(IElasticConfiguration configuration, string? name = null, int version = 1, Func<object, DateTime>? getDocumentDateUtc = null) : base(configuration, name ?? _typeName, version, getDocumentDateUtc)
     {
-        Name = name ?? _typeName;
     }
 
     protected override ElasticMappingResolver CreateMappingResolver()
@@ -573,7 +571,7 @@ public class DailyIndex<T> : DailyIndex, IIndex<T> where T : class
         settings.DefaultMappingFor<T>(d => d.IndexName(Name));
     }
 
-    protected override string GetTimeStampField()
+    protected override string? GetTimeStampField()
     {
         if (typeof(IHaveDates).IsAssignableFrom(typeof(T)))
             return InferField(f => ((IHaveDates)f).UpdatedUtc);

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/DynamicIndex.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/DynamicIndex.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Repositories.Elasticsearch.Configuration;
 
 public class DynamicIndex<T> : Index<T> where T : class
 {
-    public DynamicIndex(IElasticConfiguration configuration, string name = null) : base(configuration, name) { }
+    public DynamicIndex(IElasticConfiguration configuration, string? name = null) : base(configuration, name) { }
 
     protected override ElasticMappingResolver CreateMappingResolver()
     {

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/ElasticConfiguration.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/ElasticConfiguration.cs
@@ -26,19 +26,19 @@ namespace Foundatio.Repositories.Elasticsearch.Configuration;
 
 public class ElasticConfiguration : IElasticConfiguration
 {
-    protected readonly IQueue<WorkItemData> _workItemQueue;
+    protected readonly IQueue<WorkItemData>? _workItemQueue;
     protected readonly ILogger _logger;
     protected readonly ILockProvider _beginReindexLockProvider;
     protected readonly ILockProvider _lockProvider;
     private readonly List<IIndex> _indexes = new();
     private readonly Lazy<IReadOnlyCollection<IIndex>> _frozenIndexes;
     private readonly Lazy<ElasticsearchClient> _client;
-    private readonly Lazy<ICustomFieldDefinitionRepository> _customFieldDefinitionRepository;
+    private readonly Lazy<ICustomFieldDefinitionRepository?> _customFieldDefinitionRepository;
     protected readonly bool _shouldDisposeCache;
     private readonly bool _shouldDisposeMessageBus;
     private int _disposed;
 
-    public ElasticConfiguration(IQueue<WorkItemData> workItemQueue = null, ICacheClient cacheClient = null, IMessageBus messageBus = null, ITextSerializer serializer = null, TimeProvider timeProvider = null, IResiliencePolicyProvider resiliencePolicyProvider = null, ILoggerFactory loggerFactory = null)
+    public ElasticConfiguration(IQueue<WorkItemData>? workItemQueue = null, ICacheClient? cacheClient = null, IMessageBus? messageBus = null, ITextSerializer? serializer = null, TimeProvider? timeProvider = null, IResiliencePolicyProvider? resiliencePolicyProvider = null, ILoggerFactory? loggerFactory = null)
     {
         _workItemQueue = workItemQueue;
         TimeProvider = timeProvider ?? TimeProvider.System;
@@ -56,13 +56,14 @@ public class ElasticConfiguration : IElasticConfiguration
         ResiliencePolicyProvider = resiliencePolicyProvider ?? cacheClient?.GetResiliencePolicyProvider() ?? new ResiliencePolicyProvider();
         ResiliencePolicy = ResiliencePolicyProvider.GetPolicy<ElasticConfiguration>(_logger, TimeProvider);
         Cache = cacheClient ?? new InMemoryCacheClient(new InMemoryCacheClientOptions { CloneValues = true, ResiliencePolicyProvider = ResiliencePolicyProvider, TimeProvider = TimeProvider, LoggerFactory = LoggerFactory });
-        _lockProvider = new CacheLockProvider(Cache, messageBus, TimeProvider, ResiliencePolicyProvider, LoggerFactory);
-        _beginReindexLockProvider = new ThrottlingLockProvider(Cache, 1, TimeSpan.FromMinutes(15), TimeProvider, ResiliencePolicyProvider, LoggerFactory);
         _shouldDisposeCache = cacheClient is null;
         _shouldDisposeMessageBus = messageBus is null;
-        MessageBus = messageBus ?? new InMemoryMessageBus(new InMemoryMessageBusOptions { ResiliencePolicyProvider = ResiliencePolicyProvider, TimeProvider = TimeProvider, LoggerFactory = LoggerFactory });
+        messageBus ??= new InMemoryMessageBus(new InMemoryMessageBusOptions { ResiliencePolicyProvider = ResiliencePolicyProvider, TimeProvider = TimeProvider, LoggerFactory = LoggerFactory });
+        MessageBus = messageBus;
+        _lockProvider = new CacheLockProvider(Cache, messageBus, TimeProvider, ResiliencePolicyProvider, LoggerFactory);
+        _beginReindexLockProvider = new ThrottlingLockProvider(Cache, 1, TimeSpan.FromMinutes(15), TimeProvider, ResiliencePolicyProvider, LoggerFactory);
         _frozenIndexes = new Lazy<IReadOnlyCollection<IIndex>>(() => _indexes.AsReadOnly());
-        _customFieldDefinitionRepository = new Lazy<ICustomFieldDefinitionRepository>(CreateCustomFieldDefinitionRepository);
+        _customFieldDefinitionRepository = new Lazy<ICustomFieldDefinitionRepository?>(CreateCustomFieldDefinitionRepository);
         _client = new Lazy<ElasticsearchClient>(CreateElasticClient);
     }
 
@@ -88,7 +89,7 @@ public class ElasticConfiguration : IElasticConfiguration
         settings.EnableTcpKeepAlive(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(2));
     }
 
-    protected virtual NodePool CreateConnectionPool()
+    protected virtual NodePool? CreateConnectionPool()
     {
         return null;
     }
@@ -102,10 +103,10 @@ public class ElasticConfiguration : IElasticConfiguration
     public IResiliencePolicy ResiliencePolicy { get; }
     public TimeProvider TimeProvider { get; set; }
     public IReadOnlyCollection<IIndex> Indexes => _frozenIndexes.Value;
-    public ICustomFieldDefinitionRepository CustomFieldDefinitionRepository => _customFieldDefinitionRepository.Value;
+    public ICustomFieldDefinitionRepository? CustomFieldDefinitionRepository => _customFieldDefinitionRepository.Value;
 
-    private CustomFieldDefinitionIndex _customFieldDefinitionIndex = null;
-    private ICustomFieldDefinitionRepository CreateCustomFieldDefinitionRepository()
+    private CustomFieldDefinitionIndex? _customFieldDefinitionIndex = null;
+    private ICustomFieldDefinitionRepository? CreateCustomFieldDefinitionRepository()
     {
         if (_customFieldDefinitionIndex == null)
             return null;
@@ -128,7 +129,7 @@ public class ElasticConfiguration : IElasticConfiguration
         _indexes.Add(index);
     }
 
-    public IIndex GetIndex(string name)
+    public IIndex? GetIndex(string name)
     {
         foreach (var index in Indexes)
             if (index.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
@@ -137,7 +138,7 @@ public class ElasticConfiguration : IElasticConfiguration
         return null;
     }
 
-    public Task ConfigureIndexesAsync(IEnumerable<IIndex> indexes = null, bool beginReindexingOutdated = true)
+    public Task ConfigureIndexesAsync(IEnumerable<IIndex>? indexes = null, bool beginReindexingOutdated = true)
     {
         if (indexes == null)
             indexes = Indexes;
@@ -178,7 +179,7 @@ public class ElasticConfiguration : IElasticConfiguration
         await _beginReindexLockProvider.TryUsingAsync(enqueueReindexLockName, async () => { await _workItemQueue.EnqueueAsync(reindexWorkItem).AnyContext(); }, TimeSpan.Zero, new CancellationToken(true)).AnyContext();
     }
 
-    public Task MaintainIndexesAsync(IEnumerable<IIndex> indexes = null)
+    public Task MaintainIndexesAsync(IEnumerable<IIndex>? indexes = null)
     {
         if (indexes == null)
             indexes = Indexes;
@@ -190,7 +191,7 @@ public class ElasticConfiguration : IElasticConfiguration
         return Task.WhenAll(tasks);
     }
 
-    public Task DeleteIndexesAsync(IEnumerable<IIndex> indexes = null)
+    public Task DeleteIndexesAsync(IEnumerable<IIndex>? indexes = null)
     {
         if (indexes == null)
             indexes = Indexes;
@@ -202,7 +203,7 @@ public class ElasticConfiguration : IElasticConfiguration
         return Task.WhenAll(tasks);
     }
 
-    public async Task ReindexAsync(IEnumerable<IIndex> indexes = null, Func<int, string, Task> progressCallbackAsync = null)
+    public async Task ReindexAsync(IEnumerable<IIndex>? indexes = null, Func<int, string?, Task>? progressCallbackAsync = null)
     {
         if (indexes == null)
             indexes = Indexes;

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/ElasticConfiguration.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/ElasticConfiguration.cs
@@ -23,19 +23,19 @@ namespace Foundatio.Repositories.Elasticsearch.Configuration;
 
 public class ElasticConfiguration : IElasticConfiguration
 {
-    protected readonly IQueue<WorkItemData> _workItemQueue;
+    protected readonly IQueue<WorkItemData>? _workItemQueue;
     protected readonly ILogger _logger;
     protected readonly ILockProvider _beginReindexLockProvider;
     protected readonly ILockProvider _lockProvider;
     private readonly List<IIndex> _indexes = new();
     private readonly Lazy<IReadOnlyCollection<IIndex>> _frozenIndexes;
     private readonly Lazy<IElasticClient> _client;
-    private readonly Lazy<ICustomFieldDefinitionRepository> _customFieldDefinitionRepository;
+    private readonly Lazy<ICustomFieldDefinitionRepository?> _customFieldDefinitionRepository;
     protected readonly bool _shouldDisposeCache;
     private readonly bool _shouldDisposeMessageBus;
     private int _disposed;
 
-    public ElasticConfiguration(IQueue<WorkItemData> workItemQueue = null, ICacheClient cacheClient = null, IMessageBus messageBus = null, TimeProvider timeProvider = null, IResiliencePolicyProvider resiliencePolicyProvider = null, ILoggerFactory loggerFactory = null)
+    public ElasticConfiguration(IQueue<WorkItemData>? workItemQueue = null, ICacheClient? cacheClient = null, IMessageBus? messageBus = null, TimeProvider? timeProvider = null, IResiliencePolicyProvider? resiliencePolicyProvider = null, ILoggerFactory? loggerFactory = null)
     {
         _workItemQueue = workItemQueue;
         TimeProvider = timeProvider ?? TimeProvider.System;
@@ -44,13 +44,14 @@ public class ElasticConfiguration : IElasticConfiguration
         ResiliencePolicyProvider = resiliencePolicyProvider ?? cacheClient?.GetResiliencePolicyProvider() ?? new ResiliencePolicyProvider();
         ResiliencePolicy = ResiliencePolicyProvider.GetPolicy<ElasticConfiguration>(_logger, TimeProvider);
         Cache = cacheClient ?? new InMemoryCacheClient(new InMemoryCacheClientOptions { CloneValues = true, ResiliencePolicyProvider = ResiliencePolicyProvider, TimeProvider = TimeProvider, LoggerFactory = LoggerFactory });
-        _lockProvider = new CacheLockProvider(Cache, messageBus, TimeProvider, ResiliencePolicyProvider, LoggerFactory);
-        _beginReindexLockProvider = new ThrottlingLockProvider(Cache, 1, TimeSpan.FromMinutes(15), TimeProvider, ResiliencePolicyProvider, LoggerFactory);
         _shouldDisposeCache = cacheClient is null;
         _shouldDisposeMessageBus = messageBus is null;
-        MessageBus = messageBus ?? new InMemoryMessageBus(new InMemoryMessageBusOptions { ResiliencePolicyProvider = ResiliencePolicyProvider, TimeProvider = TimeProvider, LoggerFactory = LoggerFactory });
+        messageBus ??= new InMemoryMessageBus(new InMemoryMessageBusOptions { ResiliencePolicyProvider = ResiliencePolicyProvider, TimeProvider = TimeProvider, LoggerFactory = LoggerFactory });
+        MessageBus = messageBus;
+        _lockProvider = new CacheLockProvider(Cache, messageBus, TimeProvider, ResiliencePolicyProvider, LoggerFactory);
+        _beginReindexLockProvider = new ThrottlingLockProvider(Cache, 1, TimeSpan.FromMinutes(15), TimeProvider, ResiliencePolicyProvider, LoggerFactory);
         _frozenIndexes = new Lazy<IReadOnlyCollection<IIndex>>(() => _indexes.AsReadOnly());
-        _customFieldDefinitionRepository = new Lazy<ICustomFieldDefinitionRepository>(CreateCustomFieldDefinitionRepository);
+        _customFieldDefinitionRepository = new Lazy<ICustomFieldDefinitionRepository?>(CreateCustomFieldDefinitionRepository);
         _client = new Lazy<IElasticClient>(CreateElasticClient);
     }
 
@@ -74,7 +75,7 @@ public class ElasticConfiguration : IElasticConfiguration
         settings.EnableTcpKeepAlive(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(2));
     }
 
-    protected virtual IConnectionPool CreateConnectionPool()
+    protected virtual IConnectionPool? CreateConnectionPool()
     {
         return null;
     }
@@ -87,10 +88,10 @@ public class ElasticConfiguration : IElasticConfiguration
     public IResiliencePolicy ResiliencePolicy { get; }
     public TimeProvider TimeProvider { get; set; }
     public IReadOnlyCollection<IIndex> Indexes => _frozenIndexes.Value;
-    public ICustomFieldDefinitionRepository CustomFieldDefinitionRepository => _customFieldDefinitionRepository.Value;
+    public ICustomFieldDefinitionRepository? CustomFieldDefinitionRepository => _customFieldDefinitionRepository.Value;
 
-    private CustomFieldDefinitionIndex _customFieldDefinitionIndex = null;
-    private ICustomFieldDefinitionRepository CreateCustomFieldDefinitionRepository()
+    private CustomFieldDefinitionIndex? _customFieldDefinitionIndex = null;
+    private ICustomFieldDefinitionRepository? CreateCustomFieldDefinitionRepository()
     {
         if (_customFieldDefinitionIndex == null)
             return null;
@@ -113,7 +114,7 @@ public class ElasticConfiguration : IElasticConfiguration
         _indexes.Add(index);
     }
 
-    public IIndex GetIndex(string name)
+    public IIndex? GetIndex(string name)
     {
         foreach (var index in Indexes)
             if (index.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
@@ -122,7 +123,7 @@ public class ElasticConfiguration : IElasticConfiguration
         return null;
     }
 
-    public Task ConfigureIndexesAsync(IEnumerable<IIndex> indexes = null, bool beginReindexingOutdated = true)
+    public Task ConfigureIndexesAsync(IEnumerable<IIndex>? indexes = null, bool beginReindexingOutdated = true)
     {
         if (indexes == null)
             indexes = Indexes;
@@ -163,7 +164,7 @@ public class ElasticConfiguration : IElasticConfiguration
         await _beginReindexLockProvider.TryUsingAsync(enqueueReindexLockName, async () => { await _workItemQueue.EnqueueAsync(reindexWorkItem).AnyContext(); }, TimeSpan.Zero, new CancellationToken(true)).AnyContext();
     }
 
-    public Task MaintainIndexesAsync(IEnumerable<IIndex> indexes = null)
+    public Task MaintainIndexesAsync(IEnumerable<IIndex>? indexes = null)
     {
         if (indexes == null)
             indexes = Indexes;
@@ -175,7 +176,7 @@ public class ElasticConfiguration : IElasticConfiguration
         return Task.WhenAll(tasks);
     }
 
-    public Task DeleteIndexesAsync(IEnumerable<IIndex> indexes = null)
+    public Task DeleteIndexesAsync(IEnumerable<IIndex>? indexes = null)
     {
         if (indexes == null)
             indexes = Indexes;
@@ -187,7 +188,7 @@ public class ElasticConfiguration : IElasticConfiguration
         return Task.WhenAll(tasks);
     }
 
-    public async Task ReindexAsync(IEnumerable<IIndex> indexes = null, Func<int, string, Task> progressCallbackAsync = null)
+    public async Task ReindexAsync(IEnumerable<IIndex>? indexes = null, Func<int, string?, Task>? progressCallbackAsync = null)
     {
         if (indexes == null)
             indexes = Indexes;

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/IElasticConfiguration.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/IElasticConfiguration.cs
@@ -21,13 +21,13 @@ public interface IElasticConfiguration : IDisposable
     IResiliencePolicyProvider ResiliencePolicyProvider { get; }
     TimeProvider TimeProvider { get; set; }
     IReadOnlyCollection<IIndex> Indexes { get; }
-    ICustomFieldDefinitionRepository CustomFieldDefinitionRepository { get; }
+    ICustomFieldDefinitionRepository? CustomFieldDefinitionRepository { get; }
 
-    IIndex GetIndex(string name);
+    IIndex? GetIndex(string name);
     void ConfigureGlobalQueryBuilders(ElasticQueryBuilder builder);
     void ConfigureGlobalQueryParsers(ElasticQueryParserConfiguration config);
-    Task ConfigureIndexesAsync(IEnumerable<IIndex> indexes = null, bool beginReindexingOutdated = true);
-    Task MaintainIndexesAsync(IEnumerable<IIndex> indexes = null);
-    Task DeleteIndexesAsync(IEnumerable<IIndex> indexes = null);
-    Task ReindexAsync(IEnumerable<IIndex> indexes = null, Func<int, string, Task> progressCallbackAsync = null);
+    Task ConfigureIndexesAsync(IEnumerable<IIndex>? indexes = null, bool beginReindexingOutdated = true);
+    Task MaintainIndexesAsync(IEnumerable<IIndex>? indexes = null);
+    Task DeleteIndexesAsync(IEnumerable<IIndex>? indexes = null);
+    Task ReindexAsync(IEnumerable<IIndex>? indexes = null, Func<int, string?, Task>? progressCallbackAsync = null);
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/IElasticConfiguration.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/IElasticConfiguration.cs
@@ -44,10 +44,10 @@ public interface IElasticConfiguration : IDisposable
     IReadOnlyCollection<IIndex> Indexes { get; }
 
     /// <summary>Repository for managing custom field definitions, or <c>null</c> if no custom field index is configured.</summary>
-    ICustomFieldDefinitionRepository CustomFieldDefinitionRepository { get; }
+    ICustomFieldDefinitionRepository? CustomFieldDefinitionRepository { get; }
 
     /// <summary>Returns the index with the specified <paramref name="name"/>, or <c>null</c> if not found.</summary>
-    IIndex GetIndex(string name);
+    IIndex? GetIndex(string name);
 
     /// <summary>Configures global query builders applied to every query across all indexes.</summary>
     void ConfigureGlobalQueryBuilders(ElasticQueryBuilder builder);
@@ -56,14 +56,14 @@ public interface IElasticConfiguration : IDisposable
     void ConfigureGlobalQueryParsers(ElasticQueryParserConfiguration config);
 
     /// <summary>Creates and configures the specified indexes (or all registered indexes) in Elasticsearch.</summary>
-    Task ConfigureIndexesAsync(IEnumerable<IIndex> indexes = null, bool beginReindexingOutdated = true);
+    Task ConfigureIndexesAsync(IEnumerable<IIndex>? indexes = null, bool beginReindexingOutdated = true);
 
     /// <summary>Runs maintenance tasks (e.g., alias management, cleanup) on the specified or all indexes.</summary>
-    Task MaintainIndexesAsync(IEnumerable<IIndex> indexes = null);
+    Task MaintainIndexesAsync(IEnumerable<IIndex>? indexes = null);
 
     /// <summary>Deletes the specified indexes (or all registered indexes) from Elasticsearch.</summary>
-    Task DeleteIndexesAsync(IEnumerable<IIndex> indexes = null);
+    Task DeleteIndexesAsync(IEnumerable<IIndex>? indexes = null);
 
     /// <summary>Reindexes outdated versioned indexes to their latest version.</summary>
-    Task ReindexAsync(IEnumerable<IIndex> indexes = null, Func<int, string, Task> progressCallbackAsync = null);
+    Task ReindexAsync(IEnumerable<IIndex>? indexes = null, Func<int, string?, Task>? progressCallbackAsync = null);
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/IIndex.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/IIndex.cs
@@ -35,6 +35,6 @@ public interface IIndex<T> : IIndex where T : class
 {
     void ConfigureIndexMapping(TypeMappingDescriptor<T> map);
     Inferrer Infer { get; }
-    string InferField(Expression<Func<T, object>> objectPath);
-    string InferPropertyName(Expression<Func<T, object>> objectPath);
+    string InferField(Expression<Func<T, object?>> objectPath);
+    string InferPropertyName(Expression<Func<T, object?>> objectPath);
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/IIndex.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/IIndex.cs
@@ -22,10 +22,10 @@ public interface IIndex : IDisposable
 
     void ConfigureSettings(ElasticsearchClientSettings settings);
     Task ConfigureAsync();
-    Task EnsureIndexAsync(object target);
+    Task EnsureIndexAsync(object? target);
     Task MaintainAsync(bool includeOptionalTasks = true);
     Task DeleteAsync();
-    Task ReindexAsync(Func<int, string, Task> progressCallbackAsync = null);
+    Task ReindexAsync(Func<int, string?, Task>? progressCallbackAsync = null);
     string CreateDocumentId(object document);
     string[] GetIndexesByQuery(IRepositoryQuery query);
     string GetIndex(object target);

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/IIndex.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/IIndex.cs
@@ -21,10 +21,10 @@ public interface IIndex : IDisposable
 
     void ConfigureSettings(ConnectionSettings settings);
     Task ConfigureAsync();
-    Task EnsureIndexAsync(object target);
+    Task EnsureIndexAsync(object? target);
     Task MaintainAsync(bool includeOptionalTasks = true);
     Task DeleteAsync();
-    Task ReindexAsync(Func<int, string, Task> progressCallbackAsync = null);
+    Task ReindexAsync(Func<int, string?, Task>? progressCallbackAsync = null);
     string CreateDocumentId(object document);
     string[] GetIndexesByQuery(IRepositoryQuery query);
     string GetIndex(object target);

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
@@ -32,21 +32,23 @@ public class Index : IIndex
     private readonly Lazy<IElasticQueryBuilder> _queryBuilder;
     private readonly Lazy<ElasticQueryParser> _queryParser;
     private readonly Lazy<ElasticMappingResolver> _mappingResolver;
-    private readonly Lazy<QueryFieldResolver> _fieldResolver;
+    private readonly Lazy<QueryFieldResolver?> _fieldResolver;
     private readonly ConcurrentDictionary<string, ICustomFieldType> _customFieldTypes = new();
     private readonly AsyncLock _lock = new();
     private readonly CancellationTokenSource _disposedCancellationTokenSource = new();
     private int _disposed;
     protected readonly ILogger _logger;
 
-    public Index(IElasticConfiguration configuration, string name = null)
+    public Index(IElasticConfiguration configuration, string name)
     {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
         Name = name;
         Configuration = configuration;
         _queryBuilder = new Lazy<IElasticQueryBuilder>(CreateQueryBuilder);
         _queryParser = new Lazy<ElasticQueryParser>(CreateQueryParser);
         _mappingResolver = new Lazy<ElasticMappingResolver>(CreateMappingResolver);
-        _fieldResolver = new Lazy<QueryFieldResolver>(CreateQueryFieldResolver);
+        _fieldResolver = new Lazy<QueryFieldResolver?>(CreateQueryFieldResolver);
         _logger = configuration.LoggerFactory?.CreateLogger(GetType()) ?? NullLogger.Instance;
     }
 
@@ -107,7 +109,7 @@ public class Index : IIndex
         return parser;
     }
 
-    protected virtual QueryFieldResolver CreateQueryFieldResolver() => null;
+    protected virtual QueryFieldResolver? CreateQueryFieldResolver() => null;
 
     protected virtual void ConfigureQueryParser(ElasticQueryParserConfiguration config) { }
 
@@ -129,7 +131,7 @@ public class Index : IIndex
         };
     }
 
-    private string[] _indexes;
+    private string[]? _indexes;
     public virtual string[] GetIndexesByQuery(IRepositoryQuery query)
     {
         return _indexes ??= new[] { Name };
@@ -154,7 +156,7 @@ public class Index : IIndex
     }
 
     private bool _isEnsured = false;
-    public virtual async Task EnsureIndexAsync(object target)
+    public virtual async Task EnsureIndexAsync(object? target)
     {
         if (_isEnsured)
             return;
@@ -181,7 +183,7 @@ public class Index : IIndex
     public IElasticQueryBuilder QueryBuilder => _queryBuilder.Value;
     public ElasticQueryParser QueryParser => _queryParser.Value;
     public ElasticMappingResolver MappingResolver => _mappingResolver.Value;
-    public QueryFieldResolver FieldResolver => _fieldResolver.Value;
+    public QueryFieldResolver? FieldResolver => _fieldResolver.Value;
 
     public int BulkBatchSize { get; set; } = 1000;
 
@@ -194,7 +196,7 @@ public class Index : IIndex
         }
     }
 
-    protected virtual async Task CreateIndexAsync(string name, Action<CreateIndexRequestDescriptor> descriptor = null)
+    protected virtual async Task CreateIndexAsync(string name, Action<CreateIndexRequestDescriptor>? descriptor = null)
     {
         if (name == null)
             throw new ArgumentNullException(nameof(name));
@@ -205,7 +207,7 @@ public class Index : IIndex
         _logger.LogRequest(response);
 
         if (response.IsValidResponse || response.ElasticsearchServerError?.Status == 400 &&
-            response.ElasticsearchServerError.Error.Type is "index_already_exists_exception" or "resource_already_exists_exception")
+            response.ElasticsearchServerError!.Error?.Type is "index_already_exists_exception" or "resource_already_exists_exception")
         {
             _isEnsured = true;
             return;
@@ -215,7 +217,7 @@ public class Index : IIndex
         throw new RepositoryException(response.GetErrorMessage($"Error creating the index {name}"), response.OriginalException());
     }
 
-    protected virtual async Task UpdateIndexAsync(string name, Action<PutIndicesSettingsRequestDescriptor> descriptor = null)
+    protected virtual async Task UpdateIndexAsync(string name, Action<PutIndicesSettingsRequestDescriptor>? descriptor = null)
     {
         if (descriptor != null)
         {
@@ -246,7 +248,7 @@ public class Index : IIndex
         var createIndexRequestDescriptor = new CreateIndexRequestDescriptor((IndexName)name);
         ConfigureIndex(createIndexRequestDescriptor);
         CreateIndexRequest createRequest = createIndexRequestDescriptor;
-        var settings = createRequest.Settings;
+        var settings = createRequest.Settings!;
 
         // strip off non-dynamic index settings
         settings.Store = null;
@@ -389,7 +391,7 @@ public class Index : IIndex
         throw new RepositoryException(response.GetErrorMessage($"Error checking to see if index {name} exists"), response.OriginalException());
     }
 
-    public virtual Task ReindexAsync(Func<int, string, Task> progressCallbackAsync = null)
+    public virtual Task ReindexAsync(Func<int, string?, Task>? progressCallbackAsync = null)
     {
         var reindexWorkItem = new ReindexWorkItem
         {
@@ -403,7 +405,7 @@ public class Index : IIndex
         return reindexer.ReindexAsync(reindexWorkItem, progressCallbackAsync);
     }
 
-    protected virtual string GetTimeStampField()
+    protected virtual string? GetTimeStampField()
     {
         return null;
     }
@@ -427,11 +429,10 @@ public class Index : IIndex
 
 public class Index<T> : Index, IIndex<T> where T : class
 {
-    private readonly string _typeName = typeof(T).Name.ToLower();
+    private static readonly string _typeName = typeof(T).Name.ToLower();
 
-    public Index(IElasticConfiguration configuration, string name = null) : base(configuration, name)
+    public Index(IElasticConfiguration configuration, string? name = null) : base(configuration, name ?? _typeName)
     {
-        Name = name ?? _typeName;
     }
 
     protected override ElasticMappingResolver CreateMappingResolver()
@@ -462,7 +463,7 @@ public class Index<T> : Index, IIndex<T> where T : class
         });
     }
 
-    protected override async Task UpdateIndexAsync(string name, Action<PutIndicesSettingsRequestDescriptor> descriptor = null)
+    protected override async Task UpdateIndexAsync(string name, Action<PutIndicesSettingsRequestDescriptor>? descriptor = null)
     {
         await base.UpdateIndexAsync(name, descriptor).AnyContext();
 
@@ -494,7 +495,7 @@ public class Index<T> : Index, IIndex<T> where T : class
         settings.DefaultMappingFor<T>(d => d.IndexName(Name));
     }
 
-    protected override string GetTimeStampField()
+    protected override string? GetTimeStampField()
     {
         if (typeof(IHaveDates).IsAssignableFrom(typeof(T)))
             return InferField(f => ((IHaveDates)f).UpdatedUtc);

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
@@ -28,21 +28,23 @@ public class Index : IIndex
     private readonly Lazy<IElasticQueryBuilder> _queryBuilder;
     private readonly Lazy<ElasticQueryParser> _queryParser;
     private readonly Lazy<ElasticMappingResolver> _mappingResolver;
-    private readonly Lazy<QueryFieldResolver> _fieldResolver;
+    private readonly Lazy<QueryFieldResolver?> _fieldResolver;
     private readonly ConcurrentDictionary<string, ICustomFieldType> _customFieldTypes = new();
     private readonly AsyncLock _lock = new();
     private readonly CancellationTokenSource _disposedCancellationTokenSource = new();
     private int _disposed;
     protected readonly ILogger _logger;
 
-    public Index(IElasticConfiguration configuration, string name = null)
+    public Index(IElasticConfiguration configuration, string name)
     {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
         Name = name;
         Configuration = configuration;
         _queryBuilder = new Lazy<IElasticQueryBuilder>(CreateQueryBuilder);
         _queryParser = new Lazy<ElasticQueryParser>(CreateQueryParser);
         _mappingResolver = new Lazy<ElasticMappingResolver>(CreateMappingResolver);
-        _fieldResolver = new Lazy<QueryFieldResolver>(CreateQueryFieldResolver);
+        _fieldResolver = new Lazy<QueryFieldResolver?>(CreateQueryFieldResolver);
         _logger = configuration.LoggerFactory?.CreateLogger(GetType()) ?? NullLogger.Instance;
     }
 
@@ -103,7 +105,7 @@ public class Index : IIndex
         return parser;
     }
 
-    protected virtual QueryFieldResolver CreateQueryFieldResolver() => null;
+    protected virtual QueryFieldResolver? CreateQueryFieldResolver() => null;
 
     protected virtual void ConfigureQueryParser(ElasticQueryParserConfiguration config) { }
 
@@ -125,7 +127,7 @@ public class Index : IIndex
         };
     }
 
-    private string[] _indexes;
+    private string[]? _indexes;
     public virtual string[] GetIndexesByQuery(IRepositoryQuery query)
     {
         return _indexes ??= new[] { Name };
@@ -150,7 +152,7 @@ public class Index : IIndex
     }
 
     private bool _isEnsured = false;
-    public virtual async Task EnsureIndexAsync(object target)
+    public virtual async Task EnsureIndexAsync(object? target)
     {
         if (_isEnsured)
             return;
@@ -178,7 +180,7 @@ public class Index : IIndex
     public IElasticQueryBuilder QueryBuilder => _queryBuilder.Value;
     public ElasticQueryParser QueryParser => _queryParser.Value;
     public ElasticMappingResolver MappingResolver => _mappingResolver.Value;
-    public QueryFieldResolver FieldResolver => _fieldResolver.Value;
+    public QueryFieldResolver? FieldResolver => _fieldResolver.Value;
 
     public int BulkBatchSize { get; set; } = 1000;
 
@@ -191,7 +193,7 @@ public class Index : IIndex
         }
     }
 
-    protected virtual async Task CreateIndexAsync(string name, Func<CreateIndexDescriptor, CreateIndexDescriptor> descriptor = null)
+    protected virtual async Task CreateIndexAsync(string name, Func<CreateIndexDescriptor, CreateIndexDescriptor>? descriptor = null)
     {
         if (name == null)
             throw new ArgumentNullException(nameof(name));
@@ -212,7 +214,7 @@ public class Index : IIndex
         throw new RepositoryException(response.GetErrorMessage($"Error creating the index {name}"), response.OriginalException);
     }
 
-    protected virtual async Task UpdateIndexAsync(string name, Func<UpdateIndexSettingsDescriptor, UpdateIndexSettingsDescriptor> descriptor = null)
+    protected virtual async Task UpdateIndexAsync(string name, Func<UpdateIndexSettingsDescriptor, UpdateIndexSettingsDescriptor>? descriptor = null)
     {
         var updateIndexDescriptor = new UpdateIndexSettingsDescriptor(name);
         if (descriptor != null)
@@ -343,7 +345,7 @@ public class Index : IIndex
         throw new RepositoryException(response.GetErrorMessage($"Error checking to see if index {name} exists"), response.OriginalException);
     }
 
-    public virtual Task ReindexAsync(Func<int, string, Task> progressCallbackAsync = null)
+    public virtual Task ReindexAsync(Func<int, string?, Task>? progressCallbackAsync = null)
     {
         var reindexWorkItem = new ReindexWorkItem
         {
@@ -357,7 +359,7 @@ public class Index : IIndex
         return reindexer.ReindexAsync(reindexWorkItem, progressCallbackAsync);
     }
 
-    protected virtual string GetTimeStampField()
+    protected virtual string? GetTimeStampField()
     {
         return null;
     }
@@ -381,11 +383,10 @@ public class Index : IIndex
 
 public class Index<T> : Index, IIndex<T> where T : class
 {
-    private readonly string _typeName = typeof(T).Name.ToLower();
+    private static readonly string _typeName = typeof(T).Name.ToLower();
 
-    public Index(IElasticConfiguration configuration, string name = null) : base(configuration, name)
+    public Index(IElasticConfiguration configuration, string? name = null) : base(configuration, name ?? _typeName)
     {
-        Name = name ?? _typeName;
     }
 
     protected override ElasticMappingResolver CreateMappingResolver()
@@ -418,7 +419,7 @@ public class Index<T> : Index, IIndex<T> where T : class
         });
     }
 
-    protected override async Task UpdateIndexAsync(string name, Func<UpdateIndexSettingsDescriptor, UpdateIndexSettingsDescriptor> descriptor = null)
+    protected override async Task UpdateIndexAsync(string name, Func<UpdateIndexSettingsDescriptor, UpdateIndexSettingsDescriptor>? descriptor = null)
     {
         await base.UpdateIndexAsync(name, descriptor).AnyContext();
 
@@ -454,7 +455,7 @@ public class Index<T> : Index, IIndex<T> where T : class
         settings.DefaultMappingFor<T>(d => d.IndexName(Name));
     }
 
-    protected override string GetTimeStampField()
+    protected override string? GetTimeStampField()
     {
         if (typeof(IHaveDates).IsAssignableFrom(typeof(T)))
             return InferField(f => ((IHaveDates)f).UpdatedUtc);

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
@@ -507,6 +507,6 @@ public class Index<T> : Index, IIndex<T> where T : class
     }
 
     public Inferrer Infer => Configuration.Client.Infer;
-    public string InferField(Expression<Func<T, object>> objectPath) => Infer.Field(objectPath);
-    public string InferPropertyName(Expression<Func<T, object>> objectPath) => Infer.PropertyName(objectPath);
+    public string InferField(Expression<Func<T, object?>> objectPath) => Infer.Field(objectPath);
+    public string InferPropertyName(Expression<Func<T, object?>> objectPath) => Infer.PropertyName(objectPath);
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/MonthlyIndex.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/MonthlyIndex.cs
@@ -9,7 +9,7 @@ namespace Foundatio.Repositories.Elasticsearch.Configuration;
 
 public class MonthlyIndex : DailyIndex
 {
-    public MonthlyIndex(IElasticConfiguration configuration, string name, int version = 1, Func<object, DateTime> getDocumentDateUtc = null)
+    public MonthlyIndex(IElasticConfiguration configuration, string name, int version = 1, Func<object, DateTime>? getDocumentDateUtc = null)
         : base(configuration, name, version, getDocumentDateUtc)
     {
         DateFormat = "yyyy.MM";
@@ -54,11 +54,10 @@ public class MonthlyIndex : DailyIndex
 
 public class MonthlyIndex<T> : MonthlyIndex where T : class
 {
-    private readonly string _typeName = typeof(T).Name.ToLower();
+    private static readonly string _typeName = typeof(T).Name.ToLower();
 
-    public MonthlyIndex(IElasticConfiguration configuration, string name = null, int version = 1, Func<object, DateTime> getDocumentDateUtc = null) : base(configuration, name, version, getDocumentDateUtc)
+    public MonthlyIndex(IElasticConfiguration configuration, string? name = null, int version = 1, Func<object, DateTime>? getDocumentDateUtc = null) : base(configuration, name ?? _typeName, version, getDocumentDateUtc)
     {
-        Name = name ?? _typeName;
     }
 
     protected override ElasticMappingResolver CreateMappingResolver()

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/MonthlyIndex.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/MonthlyIndex.cs
@@ -11,7 +11,7 @@ namespace Foundatio.Repositories.Elasticsearch.Configuration;
 
 public class MonthlyIndex : DailyIndex
 {
-    public MonthlyIndex(IElasticConfiguration configuration, string name, int version = 1, Func<object, DateTime> getDocumentDateUtc = null)
+    public MonthlyIndex(IElasticConfiguration configuration, string name, int version = 1, Func<object, DateTime>? getDocumentDateUtc = null)
         : base(configuration, name, version, getDocumentDateUtc)
     {
         DateFormat = "yyyy.MM";
@@ -56,11 +56,10 @@ public class MonthlyIndex : DailyIndex
 
 public class MonthlyIndex<T> : MonthlyIndex where T : class
 {
-    private readonly string _typeName = typeof(T).Name.ToLower();
+    private static readonly string _typeName = typeof(T).Name.ToLower();
 
-    public MonthlyIndex(IElasticConfiguration configuration, string name = null, int version = 1, Func<object, DateTime> getDocumentDateUtc = null) : base(configuration, name, version, getDocumentDateUtc)
+    public MonthlyIndex(IElasticConfiguration configuration, string? name = null, int version = 1, Func<object, DateTime>? getDocumentDateUtc = null) : base(configuration, name ?? _typeName, version, getDocumentDateUtc)
     {
-        Name = name ?? _typeName;
     }
 
     protected override ElasticMappingResolver CreateMappingResolver()

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/VersionedIndex.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/VersionedIndex.cs
@@ -42,10 +42,10 @@ public class VersionedIndex : Index, IVersionedIndex
     public bool DiscardIndexesOnReindex { get; set; } = true;
     private List<ReindexScript> ReindexScripts { get; } = new List<ReindexScript>();
 
-    private class ReindexScript
+    private record ReindexScript
     {
-        public int Version { get; set; }
-        public string Script { get; set; }
+        public int Version { get; init; }
+        public required string Script { get; init; }
     }
 
     protected virtual void AddReindexScript(int versionNumber, string script)
@@ -235,7 +235,7 @@ public class VersionedIndex : Index, IVersionedIndex
         return reindexWorkItem;
     }
 
-    protected string GetReindexScripts(int currentVersion)
+    protected string? GetReindexScripts(int currentVersion)
     {
         var scripts = ReindexScripts.Where(s => s.Version > currentVersion && Version >= s.Version).OrderBy(s => s.Version).ToList();
         if (scripts.Count == 0)
@@ -256,7 +256,7 @@ public class VersionedIndex : Index, IVersionedIndex
         return sb.ToString();
     }
 
-    public override async Task ReindexAsync(Func<int, string, Task> progressCallbackAsync = null)
+    public override async Task ReindexAsync(Func<int, string?, Task>? progressCallbackAsync = null)
     {
         int currentVersion = await GetCurrentVersionAsync().AnyContext();
         if (currentVersion < 0 || currentVersion >= Version)
@@ -406,22 +406,21 @@ public class VersionedIndex : Index, IVersionedIndex
     }
 
     [DebuggerDisplay("{Index} (Date: {DateUtc} Version: {Version} CurrentVersion: {CurrentVersion})")]
-    protected class IndexInfo
+    protected record IndexInfo
     {
-        public string Index { get; set; }
-        public int Version { get; set; }
+        public required string Index { get; init; }
+        public int Version { get; init; }
         public int CurrentVersion { get; set; } = -1;
-        public DateTime DateUtc { get; set; }
+        public DateTime DateUtc { get; init; }
     }
 }
 
 public class VersionedIndex<T> : VersionedIndex, IIndex<T> where T : class
 {
-    private readonly string _typeName = typeof(T).Name.ToLower();
+    private static readonly string _typeName = typeof(T).Name.ToLower();
 
-    public VersionedIndex(IElasticConfiguration configuration, string name = null, int version = 1) : base(configuration, name, version)
+    public VersionedIndex(IElasticConfiguration configuration, string? name = null, int version = 1) : base(configuration, name ?? _typeName, version)
     {
-        Name = name ?? _typeName;
     }
 
     protected override ElasticMappingResolver CreateMappingResolver()
@@ -452,7 +451,7 @@ public class VersionedIndex<T> : VersionedIndex, IIndex<T> where T : class
         });
     }
 
-    protected override async Task UpdateIndexAsync(string name, Action<PutIndicesSettingsRequestDescriptor> descriptor = null)
+    protected override async Task UpdateIndexAsync(string name, Action<PutIndicesSettingsRequestDescriptor>? descriptor = null)
     {
         await base.UpdateIndexAsync(name, descriptor).AnyContext();
 
@@ -486,7 +485,7 @@ public class VersionedIndex<T> : VersionedIndex, IIndex<T> where T : class
         settings.DefaultMappingFor<T>(d => d.IndexName(Name));
     }
 
-    protected override string GetTimeStampField()
+    protected override string? GetTimeStampField()
     {
         if (typeof(IHaveDates).IsAssignableFrom(typeof(T)))
             return InferField(f => ((IHaveDates)f).UpdatedUtc);

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/VersionedIndex.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/VersionedIndex.cs
@@ -497,6 +497,6 @@ public class VersionedIndex<T> : VersionedIndex, IIndex<T> where T : class
     }
 
     public Inferrer Infer => Configuration.Client.Infer;
-    public string InferField(Expression<Func<T, object>> objectPath) => Infer.Field(objectPath);
-    public string InferPropertyName(Expression<Func<T, object>> objectPath) => Infer.PropertyName(objectPath);
+    public string InferField(Expression<Func<T, object?>> objectPath) => Infer.Field(objectPath);
+    public string InferPropertyName(Expression<Func<T, object?>> objectPath) => Infer.PropertyName(objectPath);
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/VersionedIndex.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/VersionedIndex.cs
@@ -40,10 +40,10 @@ public class VersionedIndex : Index, IVersionedIndex
     public bool DiscardIndexesOnReindex { get; set; } = true;
     private List<ReindexScript> ReindexScripts { get; } = new List<ReindexScript>();
 
-    private class ReindexScript
+    private record ReindexScript
     {
-        public int Version { get; set; }
-        public string Script { get; set; }
+        public int Version { get; init; }
+        public required string Script { get; init; }
     }
 
     protected virtual void AddReindexScript(int versionNumber, string script)
@@ -223,7 +223,7 @@ public class VersionedIndex : Index, IVersionedIndex
         return reindexWorkItem;
     }
 
-    protected string GetReindexScripts(int currentVersion)
+    protected string? GetReindexScripts(int currentVersion)
     {
         var scripts = ReindexScripts.Where(s => s.Version > currentVersion && Version >= s.Version).OrderBy(s => s.Version).ToList();
         if (scripts.Count == 0)
@@ -244,7 +244,7 @@ public class VersionedIndex : Index, IVersionedIndex
         return sb.ToString();
     }
 
-    public override async Task ReindexAsync(Func<int, string, Task> progressCallbackAsync = null)
+    public override async Task ReindexAsync(Func<int, string?, Task>? progressCallbackAsync = null)
     {
         int currentVersion = await GetCurrentVersionAsync().AnyContext();
         if (currentVersion < 0 || currentVersion >= Version)
@@ -375,22 +375,21 @@ public class VersionedIndex : Index, IVersionedIndex
     }
 
     [DebuggerDisplay("{Index} (Date: {DateUtc} Version: {Version} CurrentVersion: {CurrentVersion})")]
-    protected class IndexInfo
+    protected record IndexInfo
     {
-        public string Index { get; set; }
-        public int Version { get; set; }
+        public required string Index { get; init; }
+        public int Version { get; init; }
         public int CurrentVersion { get; set; } = -1;
-        public DateTime DateUtc { get; set; }
+        public DateTime DateUtc { get; init; }
     }
 }
 
 public class VersionedIndex<T> : VersionedIndex, IIndex<T> where T : class
 {
-    private readonly string _typeName = typeof(T).Name.ToLower();
+    private static readonly string _typeName = typeof(T).Name.ToLower();
 
-    public VersionedIndex(IElasticConfiguration configuration, string name = null, int version = 1) : base(configuration, name, version)
+    public VersionedIndex(IElasticConfiguration configuration, string? name = null, int version = 1) : base(configuration, name ?? _typeName, version)
     {
-        Name = name ?? _typeName;
     }
 
     protected override ElasticMappingResolver CreateMappingResolver()
@@ -423,7 +422,7 @@ public class VersionedIndex<T> : VersionedIndex, IIndex<T> where T : class
         });
     }
 
-    protected override async Task UpdateIndexAsync(string name, Func<UpdateIndexSettingsDescriptor, UpdateIndexSettingsDescriptor> descriptor = null)
+    protected override async Task UpdateIndexAsync(string name, Func<UpdateIndexSettingsDescriptor, UpdateIndexSettingsDescriptor>? descriptor = null)
     {
         await base.UpdateIndexAsync(name, descriptor).AnyContext();
 
@@ -461,7 +460,7 @@ public class VersionedIndex<T> : VersionedIndex, IIndex<T> where T : class
         settings.DefaultMappingFor<T>(d => d.IndexName(Name));
     }
 
-    protected override string GetTimeStampField()
+    protected override string? GetTimeStampField()
     {
         if (typeof(IHaveDates).IsAssignableFrom(typeof(T)))
             return InferField(f => ((IHaveDates)f).UpdatedUtc);

--- a/src/Foundatio.Repositories.Elasticsearch/CustomFields/CustomFieldDefinition.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/CustomFields/CustomFieldDefinition.cs
@@ -7,28 +7,28 @@ namespace Foundatio.Repositories.Elasticsearch.CustomFields;
 
 public record CustomFieldDefinition : IIdentity, IHaveDates, ISupportSoftDeletes, IHaveData
 {
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     /// <summary>
     /// The entity type that this custom field is for.
     /// </summary>
-    public string EntityType { get; set; }
+    public string EntityType { get; set; } = null!;
 
     /// <summary>
     /// The tenant key which could be a composite key that this custom field belongs to. Each tenant can have it's own
     /// set of custom fields for an entity.
     /// </summary>
-    public string TenantKey { get; set; }
+    public string TenantKey { get; set; } = null!;
 
     /// <summary>
     /// The friendly custom field name.
     /// </summary>
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     /// <summary>
     /// The custom field description.
     /// </summary>
-    public string Description { get; set; }
+    public string? Description { get; set; }
 
     /// <summary>
     /// Gets or sets the display order.
@@ -51,7 +51,7 @@ public record CustomFieldDefinition : IIdentity, IHaveDates, ISupportSoftDeletes
     /// <summary>
     /// The type of index this custom field value should be stored in. (ie. string, number, float, address)
     /// </summary>
-    public string IndexType { get; set; }
+    public string IndexType { get; set; } = null!;
 
     /// <summary>
     /// The reserved indexing slot for this custom field. This name will be pooled across tenants for the same index
@@ -79,7 +79,7 @@ public record CustomFieldDefinition : IIdentity, IHaveDates, ISupportSoftDeletes
     /// </summary>
     public bool IsDeleted { get; set; }
 
-    private string _idxName = null;
+    private string? _idxName = null;
     /// <summary>
     /// Returns the Elasticsearch sub-field name used under the <c>idx</c> object for this definition.
     /// The format is <c>{IndexType}-{IndexSlot}</c> (e.g., <c>"string-1"</c>, <c>"int-3"</c>).

--- a/src/Foundatio.Repositories.Elasticsearch/CustomFields/CustomFieldDefinitionRepository.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/CustomFields/CustomFieldDefinitionRepository.cs
@@ -308,11 +308,11 @@ public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomField
         await base.InvalidateCacheByQueryAsync(query).AnyContext();
 
         var conditions = query.GetFieldConditions();
-        var entityTypeCondition = conditions.FirstOrDefault(c => c.Field == InferField(d => d.EntityType) && c.Operator == ComparisonOperator.Equals);
+        var entityTypeCondition = conditions.FirstOrDefault(c => String.Equals(Infer.Field(c.Field), InferField(d => d.EntityType), StringComparison.Ordinal) && c.Operator == ComparisonOperator.Equals);
         if (entityTypeCondition is null || String.IsNullOrEmpty(entityTypeCondition.Value?.ToString()))
             return;
 
-        var tenantKeyCondition = conditions.FirstOrDefault(c => String.Equals(c.Field, InferField(d => d.TenantKey), StringComparison.Ordinal) && c.Operator == ComparisonOperator.Equals);
+        var tenantKeyCondition = conditions.FirstOrDefault(c => String.Equals(Infer.Field(c.Field), InferField(d => d.TenantKey), StringComparison.Ordinal) && c.Operator == ComparisonOperator.Equals);
         string? tenantKey = tenantKeyCondition?.Value?.ToString();
         if (String.IsNullOrEmpty(tenantKey))
             return;

--- a/src/Foundatio.Repositories.Elasticsearch/CustomFields/CustomFieldDefinitionRepository.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/CustomFields/CustomFieldDefinitionRepository.cs
@@ -312,7 +312,7 @@ public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomField
         if (entityTypeCondition is null || String.IsNullOrEmpty(entityTypeCondition.Value?.ToString()))
             return;
 
-        var tenantKeyCondition = conditions.FirstOrDefault(c => c.Field == InferField(d => d.TenantKey) && c.Operator == ComparisonOperator.Equals);
+        var tenantKeyCondition = conditions.FirstOrDefault(c => String.Equals(c.Field, InferField(d => d.TenantKey), StringComparison.Ordinal) && c.Operator == ComparisonOperator.Equals);
         string? tenantKey = tenantKeyCondition?.Value?.ToString();
         if (String.IsNullOrEmpty(tenantKey))
             return;

--- a/src/Foundatio.Repositories.Elasticsearch/CustomFields/CustomFieldDefinitionRepository.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/CustomFields/CustomFieldDefinitionRepository.cs
@@ -309,10 +309,15 @@ public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomField
 
         var conditions = query.GetFieldConditions();
         var entityTypeCondition = conditions.FirstOrDefault(c => c.Field == InferField(d => d.EntityType) && c.Operator == ComparisonOperator.Equals);
-        if (entityTypeCondition == null || String.IsNullOrEmpty(entityTypeCondition.Value?.ToString()))
+        if (entityTypeCondition is null || String.IsNullOrEmpty(entityTypeCondition.Value?.ToString()))
             return;
 
-        await _cache.RemoveAsync(GetMappingCacheKey(entityTypeCondition.Value!.ToString()!, GetTenantKey(query)!)).AnyContext();
+        var tenantKeyCondition = conditions.FirstOrDefault(c => c.Field == InferField(d => d.TenantKey) && c.Operator == ComparisonOperator.Equals);
+        string? tenantKey = tenantKeyCondition?.Value?.ToString();
+        if (String.IsNullOrEmpty(tenantKey))
+            return;
+
+        await _cache.RemoveAsync(GetMappingCacheKey(entityTypeCondition.Value!.ToString()!, tenantKey)).AnyContext();
     }
 
     protected override async Task InvalidateCacheAsync(IReadOnlyCollection<ModifiedDocument<CustomFieldDefinition>> documents, ChangeType? changeType = null)

--- a/src/Foundatio.Repositories.Elasticsearch/CustomFields/CustomFieldDefinitionRepository.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/CustomFields/CustomFieldDefinitionRepository.cs
@@ -48,7 +48,7 @@ public interface ICustomFieldDefinitionRepository : ISearchableRepository<Custom
     /// <exception cref="Foundatio.Repositories.Exceptions.DocumentValidationException">
     /// Thrown when a definition with the same name but a different type already exists for this tenant.
     /// </exception>
-    Task<CustomFieldDefinition> AddFieldAsync(string entityType, string tenantKey, string name, string indexType, string description = null, int displayOrder = 0, IDictionary<string, object> data = null);
+    Task<CustomFieldDefinition> AddFieldAsync(string entityType, string tenantKey, string name, string indexType, string? description = null, int displayOrder = 0, IDictionary<string, object>? data = null);
 }
 
 public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomFieldDefinition>, ICustomFieldDefinitionRepository
@@ -117,7 +117,7 @@ public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomField
         return RemoveAllAsync(q => q.FieldEquals(cf => cf.EntityType, entityType).FieldEquals(cf => cf.TenantKey, tenantKey));
     }
 
-    public Task<CustomFieldDefinition> AddFieldAsync(string entityType, string tenantKey, string name, string indexType, string description = null, int displayOrder = 0, IDictionary<string, object> data = null)
+    public Task<CustomFieldDefinition> AddFieldAsync(string entityType, string tenantKey, string name, string indexType, string? description = null, int displayOrder = 0, IDictionary<string, object>? data = null)
     {
         var customField = new CustomFieldDefinition
         {
@@ -135,7 +135,7 @@ public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomField
         return AddAsync(customField);
     }
 
-    public override async Task AddAsync(IEnumerable<CustomFieldDefinition> documents, ICommandOptions options = null)
+    public override async Task AddAsync(IEnumerable<CustomFieldDefinition> documents, ICommandOptions? options = null)
     {
         var documentArray = documents as CustomFieldDefinition[] ?? documents.ToArray();
         _logger.LogTrace("Adding {DocumentCount} new custom field definitions", documentArray.Length);
@@ -246,18 +246,21 @@ public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomField
         return Task.CompletedTask;
     }
 
-    private async Task OnDocumentsChanged(object source, DocumentsChangeEventArgs<CustomFieldDefinition> args)
+    private async Task OnDocumentsChanged(object? source, DocumentsChangeEventArgs<CustomFieldDefinition> args)
     {
         if (args.ChangeType == ChangeType.Saved)
         {
             foreach (var doc in args.Documents)
             {
-                if (doc.Original.EntityType != doc.Value.EntityType)
-                    throw new DocumentValidationException("EntityType can't be changed.");
-                if (doc.Original.TenantKey != doc.Value.TenantKey)
-                    throw new DocumentValidationException("TenantKey can't be changed.");
-                if (doc.Original.IndexSlot != doc.Value.IndexSlot)
-                    throw new DocumentValidationException("IndexSlot can't be changed.");
+                if (doc.Original is not null)
+                {
+                    if (doc.Original.EntityType != doc.Value.EntityType)
+                        throw new DocumentValidationException("EntityType can't be changed.");
+                    if (doc.Original.TenantKey != doc.Value.TenantKey)
+                        throw new DocumentValidationException("TenantKey can't be changed.");
+                    if (doc.Original.IndexSlot != doc.Value.IndexSlot)
+                        throw new DocumentValidationException("IndexSlot can't be changed.");
+                }
 
                 if (doc.Value.IsDeleted)
                 {
@@ -307,7 +310,7 @@ public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomField
         if (entityTypeCondition == null || String.IsNullOrEmpty(entityTypeCondition.Value?.ToString()))
             return;
 
-        await _cache.RemoveAsync(GetMappingCacheKey(entityTypeCondition.Value.ToString(), GetTenantKey(query))).AnyContext();
+        await _cache.RemoveAsync(GetMappingCacheKey(entityTypeCondition.Value!.ToString()!, GetTenantKey(query)!)).AnyContext();
     }
 
     protected override async Task InvalidateCacheAsync(IReadOnlyCollection<ModifiedDocument<CustomFieldDefinition>> documents, ChangeType? changeType = null)

--- a/src/Foundatio.Repositories.Elasticsearch/CustomFields/CustomFieldDefinitionRepository.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/CustomFields/CustomFieldDefinitionRepository.cs
@@ -50,7 +50,7 @@ public interface ICustomFieldDefinitionRepository : ISearchableRepository<Custom
     /// <exception cref="Foundatio.Repositories.Exceptions.DocumentValidationException">
     /// Thrown when a definition with the same name but a different type already exists for this tenant.
     /// </exception>
-    Task<CustomFieldDefinition> AddFieldAsync(string entityType, string tenantKey, string name, string indexType, string description = null, int displayOrder = 0, IDictionary<string, object> data = null);
+    Task<CustomFieldDefinition> AddFieldAsync(string entityType, string tenantKey, string name, string indexType, string? description = null, int displayOrder = 0, IDictionary<string, object>? data = null);
 }
 
 public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomFieldDefinition>, ICustomFieldDefinitionRepository
@@ -119,7 +119,7 @@ public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomField
         return RemoveAllAsync(q => q.FieldEquals(cf => cf.EntityType, entityType).FieldEquals(cf => cf.TenantKey, tenantKey));
     }
 
-    public Task<CustomFieldDefinition> AddFieldAsync(string entityType, string tenantKey, string name, string indexType, string description = null, int displayOrder = 0, IDictionary<string, object> data = null)
+    public Task<CustomFieldDefinition> AddFieldAsync(string entityType, string tenantKey, string name, string indexType, string? description = null, int displayOrder = 0, IDictionary<string, object>? data = null)
     {
         var customField = new CustomFieldDefinition
         {
@@ -137,7 +137,7 @@ public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomField
         return AddAsync(customField);
     }
 
-    public override async Task AddAsync(IEnumerable<CustomFieldDefinition> documents, ICommandOptions options = null)
+    public override async Task AddAsync(IEnumerable<CustomFieldDefinition> documents, ICommandOptions? options = null)
     {
         var documentArray = documents as CustomFieldDefinition[] ?? documents.ToArray();
         _logger.LogTrace("Adding {DocumentCount} new custom field definitions", documentArray.Length);
@@ -248,18 +248,21 @@ public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomField
         return Task.CompletedTask;
     }
 
-    private async Task OnDocumentsChanged(object source, DocumentsChangeEventArgs<CustomFieldDefinition> args)
+    private async Task OnDocumentsChanged(object? source, DocumentsChangeEventArgs<CustomFieldDefinition> args)
     {
         if (args.ChangeType == ChangeType.Saved)
         {
             foreach (var doc in args.Documents)
             {
-                if (doc.Original.EntityType != doc.Value.EntityType)
-                    throw new DocumentValidationException("EntityType can't be changed.");
-                if (doc.Original.TenantKey != doc.Value.TenantKey)
-                    throw new DocumentValidationException("TenantKey can't be changed.");
-                if (doc.Original.IndexSlot != doc.Value.IndexSlot)
-                    throw new DocumentValidationException("IndexSlot can't be changed.");
+                if (doc.Original is not null)
+                {
+                    if (doc.Original.EntityType != doc.Value.EntityType)
+                        throw new DocumentValidationException("EntityType can't be changed.");
+                    if (doc.Original.TenantKey != doc.Value.TenantKey)
+                        throw new DocumentValidationException("TenantKey can't be changed.");
+                    if (doc.Original.IndexSlot != doc.Value.IndexSlot)
+                        throw new DocumentValidationException("IndexSlot can't be changed.");
+                }
 
                 if (doc.Value.IsDeleted)
                 {
@@ -309,7 +312,7 @@ public class CustomFieldDefinitionRepository : ElasticRepositoryBase<CustomField
         if (entityTypeCondition == null || String.IsNullOrEmpty(entityTypeCondition.Value?.ToString()))
             return;
 
-        await _cache.RemoveAsync(GetMappingCacheKey(entityTypeCondition.Value.ToString(), GetTenantKey(query))).AnyContext();
+        await _cache.RemoveAsync(GetMappingCacheKey(entityTypeCondition.Value!.ToString()!, GetTenantKey(query)!)).AnyContext();
     }
 
     protected override async Task InvalidateCacheAsync(IReadOnlyCollection<ModifiedDocument<CustomFieldDefinition>> documents, ChangeType? changeType = null)

--- a/src/Foundatio.Repositories.Elasticsearch/CustomFields/ICustomFieldType.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/CustomFields/ICustomFieldType.cs
@@ -42,13 +42,13 @@ public class ProcessFieldValueResult
     /// <summary>
     /// The processed value to store back in the document's <c>Data</c> dictionary.
     /// </summary>
-    public object Value { get; set; }
+    public object? Value { get; set; }
 
     /// <summary>
     /// An optional separate value to store in the <c>Idx</c> dictionary for indexing.
     /// When <c>null</c>, <see cref="Value"/> is used for both storage and indexing.
     /// </summary>
-    public object Idx { get; set; }
+    public object? Idx { get; set; }
 
     /// <summary>
     /// Set to <c>true</c> if the processor modified the <see cref="CustomFieldDefinition"/> itself

--- a/src/Foundatio.Repositories.Elasticsearch/CustomFields/ICustomFieldType.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/CustomFields/ICustomFieldType.cs
@@ -41,13 +41,13 @@ public class ProcessFieldValueResult
     /// <summary>
     /// The processed value to store back in the document's <c>Data</c> dictionary.
     /// </summary>
-    public object Value { get; set; }
+    public object? Value { get; set; }
 
     /// <summary>
     /// An optional separate value to store in the <c>Idx</c> dictionary for indexing.
     /// When <c>null</c>, <see cref="Value"/> is used for both storage and indexing.
     /// </summary>
-    public object Idx { get; set; }
+    public object? Idx { get; set; }
 
     /// <summary>
     /// Set to <c>true</c> if the processor modified the <see cref="CustomFieldDefinition"/> itself

--- a/src/Foundatio.Repositories.Elasticsearch/ElasticUtility.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/ElasticUtility.cs
@@ -55,7 +55,7 @@ public class ElasticUtility
             _logger.LogRequest(snapshotsResponse);
             if (snapshotsResponse.IsValidResponse)
             {
-                foreach (var snapshot in snapshotsResponse.Snapshots!)
+                foreach (var snapshot in snapshotsResponse.Snapshots ?? [])
                 {
                     if (snapshot.State == "IN_PROGRESS")
                         return true;
@@ -75,7 +75,7 @@ public class ElasticUtility
                 _logger.LogRequest(snapshotsResponse);
                 if (snapshotsResponse.IsValidResponse)
                 {
-                    foreach (var snapshot in snapshotsResponse.Snapshots!)
+                    foreach (var snapshot in snapshotsResponse.Snapshots ?? [])
                     {
                         if (snapshot.State == "IN_PROGRESS")
                             return true;
@@ -92,7 +92,7 @@ public class ElasticUtility
             return false;
         }
 
-        foreach (var node in tasksResponse.Nodes!.Values)
+        foreach (var node in tasksResponse.Nodes?.Values ?? [])
         {
             foreach (var task in node.Tasks.Values)
             {
@@ -114,7 +114,7 @@ public class ElasticUtility
             return Array.Empty<string>();
         }
 
-        return snapshotsResponse.Snapshots!.Select(s => s.Snapshot!).ToList();
+        return (snapshotsResponse.Snapshots ?? []).Select(s => s.Snapshot).OfType<string>().ToList();
     }
 
     public async Task<ICollection<string>> GetIndexListAsync()

--- a/src/Foundatio.Repositories.Elasticsearch/ElasticUtility.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/ElasticUtility.cs
@@ -155,11 +155,11 @@ public class ElasticUtility
 
 public delegate DateTime? ExtractDateFunc(string name);
 
-public class CreateSnapshotOptions
+public record CreateSnapshotOptions
 {
-    public string Repository { get; set; }
-    public string Name { get; set; }
-    public ICollection<string> Indices { get; set; }
-    public bool IgnoreUnavailable { get; set; } = false;
-    public bool IncludeGlobalState { get; set; } = true;
+    public required string Repository { get; init; }
+    public string? Name { get; set; }
+    public ICollection<string>? Indices { get; init; }
+    public bool IgnoreUnavailable { get; init; } = false;
+    public bool IncludeGlobalState { get; init; } = true;
 }

--- a/src/Foundatio.Repositories.Elasticsearch/ElasticUtility.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/ElasticUtility.cs
@@ -47,7 +47,7 @@ public class ElasticUtility
         return repositoriesResponse.IsValidResponse && repositoriesResponse.Repositories.Count() > 0;
     }
 
-    public async Task<bool> SnapshotInProgressAsync(string repository = null)
+    public async Task<bool> SnapshotInProgressAsync(string? repository = null)
     {
         if (!String.IsNullOrEmpty(repository))
         {
@@ -55,7 +55,7 @@ public class ElasticUtility
             _logger.LogRequest(snapshotsResponse);
             if (snapshotsResponse.IsValidResponse)
             {
-                foreach (var snapshot in snapshotsResponse.Snapshots)
+                foreach (var snapshot in snapshotsResponse.Snapshots!)
                 {
                     if (snapshot.State == "IN_PROGRESS")
                         return true;
@@ -75,7 +75,7 @@ public class ElasticUtility
                 _logger.LogRequest(snapshotsResponse);
                 if (snapshotsResponse.IsValidResponse)
                 {
-                    foreach (var snapshot in snapshotsResponse.Snapshots)
+                    foreach (var snapshot in snapshotsResponse.Snapshots!)
                     {
                         if (snapshot.State == "IN_PROGRESS")
                             return true;
@@ -92,7 +92,7 @@ public class ElasticUtility
             return false;
         }
 
-        foreach (var node in tasksResponse.Nodes.Values)
+        foreach (var node in tasksResponse.Nodes!.Values)
         {
             foreach (var task in node.Tasks.Values)
             {
@@ -114,7 +114,7 @@ public class ElasticUtility
             return Array.Empty<string>();
         }
 
-        return snapshotsResponse.Snapshots.Select(s => s.Snapshot).ToList();
+        return snapshotsResponse.Snapshots!.Select(s => s.Snapshot!).ToList();
     }
 
     public async Task<ICollection<string>> GetIndexListAsync()
@@ -292,11 +292,11 @@ public class ElasticUtility
 
 public delegate DateTime? ExtractDateFunc(string name);
 
-public class CreateSnapshotOptions
+public record CreateSnapshotOptions
 {
-    public string Repository { get; set; }
-    public string Name { get; set; }
-    public ICollection<string> Indices { get; set; }
-    public bool IgnoreUnavailable { get; set; } = false;
-    public bool IncludeGlobalState { get; set; } = true;
+    public required string Repository { get; init; }
+    public string? Name { get; set; }
+    public ICollection<string>? Indices { get; init; }
+    public bool IgnoreUnavailable { get; init; } = false;
+    public bool IncludeGlobalState { get; init; } = true;
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
@@ -57,7 +57,7 @@ public static class ElasticIndexExtensions
         return asyncSearchRequest;
     }
 
-    public static FindResults<T> ToFindResults<T>(this SearchResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger logger = null) where T : class, new()
+    public static FindResults<T> ToFindResults<T>(this SearchResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger? logger = null) where T : class, new()
     {
         ArgumentNullException.ThrowIfNull(response);
         ArgumentNullException.ThrowIfNull(options);
@@ -75,7 +75,7 @@ public static class ElasticIndexExtensions
         var docs = response.Hits.Take(limit).ToFindHits().ToList();
 
         var data = new DataDictionary();
-        if (response.ScrollId != null)
+        if (response.ScrollId is not null)
             data.Add(ElasticDataKeys.ScrollId, response.ScrollId.ToString());
 
         var results = new FindResults<T>(docs, response.Total, response.ToAggregations(serializer, logger), null, data);
@@ -109,7 +109,7 @@ public static class ElasticIndexExtensions
         return results;
     }
 
-    public static FindResults<T> ToFindResults<T>(this SubmitAsyncSearchResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger logger = null) where T : class, new()
+    public static FindResults<T> ToFindResults<T>(this SubmitAsyncSearchResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger? logger = null) where T : class, new()
     {
         ArgumentNullException.ThrowIfNull(response);
         ArgumentNullException.ThrowIfNull(options);
@@ -128,7 +128,7 @@ public static class ElasticIndexExtensions
 
         var data = new DataDictionary
         {
-            { AsyncQueryDataKeys.AsyncQueryId, response.Id },
+            { AsyncQueryDataKeys.AsyncQueryId, response.Id! },
             { AsyncQueryDataKeys.IsRunning, response.IsRunning },
             { AsyncQueryDataKeys.IsPartial, response.IsPartial }
         };
@@ -172,7 +172,7 @@ public static class ElasticIndexExtensions
         return hits.Select(h => h.ToFindHit());
     }
 
-    public static CountResult ToCountResult<T>(this SearchResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger logger = null) where T : class, new()
+    public static CountResult ToCountResult<T>(this SearchResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger? logger = null) where T : class, new()
     {
         if (!response.IsValidResponse)
         {
@@ -183,13 +183,13 @@ public static class ElasticIndexExtensions
         }
 
         var data = new DataDictionary();
-        if (response.ScrollId != null)
+        if (response.ScrollId is not null)
             data.Add(ElasticDataKeys.ScrollId, response.ScrollId.ToString());
 
         return new CountResult(response.Total, response.ToAggregations(serializer, logger), data);
     }
 
-    public static CountResult ToCountResult<T>(this SubmitAsyncSearchResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger logger = null) where T : class, new()
+    public static CountResult ToCountResult<T>(this SubmitAsyncSearchResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger? logger = null) where T : class, new()
     {
         if (!response.IsValidResponse)
         {
@@ -201,7 +201,7 @@ public static class ElasticIndexExtensions
 
         var data = new DataDictionary
         {
-            { AsyncQueryDataKeys.AsyncQueryId, response.Id },
+            { AsyncQueryDataKeys.AsyncQueryId, response.Id! },
             { AsyncQueryDataKeys.IsRunning, response.IsRunning },
             { AsyncQueryDataKeys.IsPartial, response.IsPartial }
         };
@@ -212,7 +212,7 @@ public static class ElasticIndexExtensions
         return new CountResult(response.Response.Total, response.ToAggregations(serializer, logger), data);
     }
 
-    public static FindResults<T> ToFindResults<T>(this GetAsyncSearchResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger logger = null) where T : class, new()
+    public static FindResults<T> ToFindResults<T>(this GetAsyncSearchResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger? logger = null) where T : class, new()
     {
         ArgumentNullException.ThrowIfNull(response);
         ArgumentNullException.ThrowIfNull(options);
@@ -231,7 +231,7 @@ public static class ElasticIndexExtensions
 
         var data = new DataDictionary
         {
-            { AsyncQueryDataKeys.AsyncQueryId, response.Id },
+            { AsyncQueryDataKeys.AsyncQueryId, response.Id! },
             { AsyncQueryDataKeys.IsRunning, response.IsRunning },
             { AsyncQueryDataKeys.IsPartial, response.IsPartial }
         };
@@ -269,7 +269,7 @@ public static class ElasticIndexExtensions
         return results;
     }
 
-    public static CountResult ToCountResult<T>(this GetAsyncSearchResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger logger = null) where T : class, new()
+    public static CountResult ToCountResult<T>(this GetAsyncSearchResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger? logger = null) where T : class, new()
     {
         if (!response.IsValidResponse)
         {
@@ -281,7 +281,7 @@ public static class ElasticIndexExtensions
 
         var data = new DataDictionary
         {
-            { AsyncQueryDataKeys.AsyncQueryId, response.Id },
+            { AsyncQueryDataKeys.AsyncQueryId, response.Id! },
             { AsyncQueryDataKeys.IsRunning, response.IsRunning },
             { AsyncQueryDataKeys.IsPartial, response.IsPartial }
         };
@@ -292,7 +292,7 @@ public static class ElasticIndexExtensions
         return new CountResult(response.Response.Total, response.ToAggregations(serializer, logger), data);
     }
 
-    public static FindResults<T> ToFindResults<T>(this ScrollResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger logger = null) where T : class, new()
+    public static FindResults<T> ToFindResults<T>(this ScrollResponse<T> response, ICommandOptions options, ITextSerializer serializer, ILogger? logger = null) where T : class, new()
     {
         ArgumentNullException.ThrowIfNull(response);
         ArgumentNullException.ThrowIfNull(options);
@@ -310,7 +310,7 @@ public static class ElasticIndexExtensions
         var docs = response.Hits.Take(limit).ToFindHits().ToList();
 
         var data = new DataDictionary();
-        if (response.ScrollId != null)
+        if (response.ScrollId is not null)
             data.Add(ElasticDataKeys.ScrollId, response.ScrollId.ToString());
 
         var results = new FindResults<T>(docs, response.Total, response.ToAggregations(serializer, logger), null, data);
@@ -402,14 +402,15 @@ public static class ElasticIndexExtensions
         return new FindHit<T>(hit.Id, hit.Source, hit.Score.GetValueOrDefault(), hit.GetElasticVersion(), hit.Routing, data);
     }
 
-    public static IEnumerable<FindHit<T>> ToFindHits<T>(this MultiGetResponse<T> response, ILogger logger = null) where T : class
+    public static IEnumerable<FindHit<T>> ToFindHits<T>(this MultiGetResponse<T> response, ILogger? logger = null) where T : class
     {
         foreach (var doc in response.Docs)
         {
-            FindHit<T> findHit = null;
+            FindHit<T>? findHit = null;
             doc.Match(
                 result =>
                 {
+                    if (result is null) return;
                     if (result.Found)
                     {
                         var data = new DataDictionary { { ElasticDataKeys.Index, result.Index } };
@@ -430,6 +431,7 @@ public static class ElasticIndexExtensions
                 },
                 error =>
                 {
+                    if (error is null) return;
                     logger?.LogWarning("MultiGet document error: index={Index}, id={Id}, reason={Reason}", error.Index, error.Id, error.Error?.Reason);
                 }
             );
@@ -444,7 +446,7 @@ public static class ElasticIndexExtensions
     private static readonly IReadOnlyDictionary<string, object> _rangeBucketData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "@type", "range" } });
     private static readonly IReadOnlyDictionary<string, object> _geohashBucketData = new ReadOnlyDictionary<string, object>(new Dictionary<string, object> { { "@type", "geohash" } });
 
-    public static IAggregate ToAggregate(this ElasticAggregations.IAggregate aggregate, string key, ITextSerializer serializer, ILogger logger = null)
+    public static IAggregate? ToAggregate(this ElasticAggregations.IAggregate aggregate, string key, ITextSerializer serializer, ILogger? logger = null)
     {
         switch (aggregate)
         {
@@ -508,12 +510,13 @@ public static class ElasticIndexExtensions
                 var rawHits = topHits.Hits?.Hits?
                     .Select(h => h.Source != null ? serializer.SerializeToString(h.Source) : null)
                     .Where(s => s != null)
+                    .Cast<string>()
                     .ToList();
-                return new TopHitsAggregate(docs)
+                return new TopHitsAggregate(docs ?? [])
                 {
-                    Total = topHits.Hits?.Total?.Match<long>(t => t.Value, l => l) ?? 0,
+                    Total = topHits.Hits?.Total?.Match<long>(t => t!.Value, l => l) ?? 0,
                     MaxScore = topHits.Hits?.MaxScore,
-                    Hits = rawHits,
+                    Hits = rawHits ?? [],
                     Data = topHits.Meta.ToReadOnlyData<TopHitsAggregate>()
                 };
 
@@ -600,25 +603,21 @@ public static class ElasticIndexExtensions
         }
     }
 
-    private static BucketAggregate ToDateHistogramBucketAggregate(ElasticAggregations.DateHistogramAggregate aggregate, ITextSerializer serializer, ILogger logger = null)
+    private static BucketAggregate ToDateHistogramBucketAggregate(ElasticAggregations.DateHistogramAggregate aggregate, ITextSerializer serializer, ILogger? logger = null)
     {
-        var data = aggregate.Meta != null ? new Dictionary<string, object>(aggregate.Meta) : new Dictionary<string, object>();
+        var data = aggregate.Meta is not null ? new Dictionary<string, object>(aggregate.Meta) : new Dictionary<string, object>();
 
-        // Check if there's a timezone offset in the metadata
-        bool hasTimezone = data.TryGetValue("@timezone", out object timezoneValue) && timezoneValue != null;
+        bool hasTimezone = data.TryGetValue("@timezone", out object? timezoneValue) && timezoneValue is not null;
 
         var buckets = aggregate.Buckets.Select(b =>
         {
-            // When there's a timezone, the bucket key from Elasticsearch already represents the local time boundary
-            // We use Unspecified kind since the dates are adjusted for the timezone
             DateTime date = hasTimezone
                 ? DateTime.SpecifyKind(b.Key.UtcDateTime, DateTimeKind.Unspecified)
                 : b.Key.UtcDateTime;
             var keyAsLong = b.Key.ToUnixTimeMilliseconds();
-            // Propagate timezone metadata to bucket data for round-trip serialization
             var bucketData = new Dictionary<string, object> { { "@type", "datehistogram" } };
             if (hasTimezone)
-                bucketData["@timezone"] = timezoneValue;
+                bucketData["@timezone"] = timezoneValue!;
 
             return (IBucket)new DateHistogramBucket(date, b.ToAggregations(serializer, logger))
             {
@@ -636,16 +635,16 @@ public static class ElasticIndexExtensions
         };
     }
 
-    private static BucketAggregate ToTermsBucketAggregate(ElasticAggregations.StringTermsAggregate aggregate, string name, ITextSerializer serializer, ILogger logger = null)
+    private static BucketAggregate ToTermsBucketAggregate(ElasticAggregations.StringTermsAggregate aggregate, string name, ITextSerializer serializer, ILogger? logger = null)
     {
-        var data = aggregate.Meta != null ? new Dictionary<string, object>(aggregate.Meta) : new Dictionary<string, object>();
+        var data = aggregate.Meta is not null ? new Dictionary<string, object>(aggregate.Meta) : new Dictionary<string, object>();
         if (aggregate.DocCountErrorUpperBound.GetValueOrDefault() > 0)
         {
             logger?.LogWarning("Terms aggregation {AggregationName} has doc_count_error_upper_bound of {DocCountErrorUpperBound}. Results may be inaccurate. Consider increasing shard_size.", name, aggregate.DocCountErrorUpperBound);
-            data.Add(nameof(aggregate.DocCountErrorUpperBound), aggregate.DocCountErrorUpperBound);
+            data.Add(nameof(aggregate.DocCountErrorUpperBound), aggregate.DocCountErrorUpperBound!);
         }
         if (aggregate.SumOtherDocCount.GetValueOrDefault() > 0)
-            data.Add(nameof(aggregate.SumOtherDocCount), aggregate.SumOtherDocCount);
+            data.Add(nameof(aggregate.SumOtherDocCount), aggregate.SumOtherDocCount!);
 
         var buckets = aggregate.Buckets.Select(b => (IBucket)new KeyedBucket<string>(b.ToAggregations(serializer, logger))
         {
@@ -662,16 +661,16 @@ public static class ElasticIndexExtensions
         };
     }
 
-    private static BucketAggregate ToTermsBucketAggregate(ElasticAggregations.LongTermsAggregate aggregate, string name, ITextSerializer serializer, ILogger logger = null)
+    private static BucketAggregate ToTermsBucketAggregate(ElasticAggregations.LongTermsAggregate aggregate, string name, ITextSerializer serializer, ILogger? logger = null)
     {
         var data = aggregate.Meta != null ? new Dictionary<string, object>(aggregate.Meta) : new Dictionary<string, object>();
         if (aggregate.DocCountErrorUpperBound.GetValueOrDefault() > 0)
         {
             logger?.LogWarning("Terms aggregation {AggregationName} has doc_count_error_upper_bound of {DocCountErrorUpperBound}. Results may be inaccurate. Consider increasing shard_size.", name, aggregate.DocCountErrorUpperBound);
-            data.Add(nameof(aggregate.DocCountErrorUpperBound), aggregate.DocCountErrorUpperBound);
+            data.Add(nameof(aggregate.DocCountErrorUpperBound), aggregate.DocCountErrorUpperBound!);
         }
         if (aggregate.SumOtherDocCount.GetValueOrDefault() > 0)
-            data.Add(nameof(aggregate.SumOtherDocCount), aggregate.SumOtherDocCount);
+            data.Add(nameof(aggregate.SumOtherDocCount), aggregate.SumOtherDocCount!);
 
         var buckets = aggregate.Buckets.Select(b => (IBucket)new KeyedBucket<double>(b.ToAggregations(serializer, logger))
         {
@@ -688,16 +687,16 @@ public static class ElasticIndexExtensions
         };
     }
 
-    private static BucketAggregate ToTermsBucketAggregate(ElasticAggregations.DoubleTermsAggregate aggregate, string name, ITextSerializer serializer, ILogger logger = null)
+    private static BucketAggregate ToTermsBucketAggregate(ElasticAggregations.DoubleTermsAggregate aggregate, string name, ITextSerializer serializer, ILogger? logger = null)
     {
         var data = aggregate.Meta != null ? new Dictionary<string, object>(aggregate.Meta) : new Dictionary<string, object>();
         if (aggregate.DocCountErrorUpperBound.GetValueOrDefault() > 0)
         {
             logger?.LogWarning("Terms aggregation {AggregationName} has doc_count_error_upper_bound of {DocCountErrorUpperBound}. Results may be inaccurate. Consider increasing shard_size.", name, aggregate.DocCountErrorUpperBound);
-            data.Add(nameof(aggregate.DocCountErrorUpperBound), aggregate.DocCountErrorUpperBound);
+            data.Add(nameof(aggregate.DocCountErrorUpperBound), aggregate.DocCountErrorUpperBound!);
         }
         if (aggregate.SumOtherDocCount.GetValueOrDefault() > 0)
-            data.Add(nameof(aggregate.SumOtherDocCount), aggregate.SumOtherDocCount);
+            data.Add(nameof(aggregate.SumOtherDocCount), aggregate.SumOtherDocCount!);
 
         var buckets = aggregate.Buckets.Select(b => (IBucket)new KeyedBucket<double>(b.ToAggregations(serializer, logger))
         {
@@ -714,7 +713,7 @@ public static class ElasticIndexExtensions
         };
     }
 
-    private static BucketAggregate ToRangeBucketAggregate(ElasticAggregations.DateRangeAggregate aggregate, ITextSerializer serializer, ILogger logger = null)
+    private static BucketAggregate ToRangeBucketAggregate(ElasticAggregations.DateRangeAggregate aggregate, ITextSerializer serializer, ILogger? logger = null)
     {
         var data = aggregate.Meta != null ? new Dictionary<string, object>(aggregate.Meta) : new Dictionary<string, object>();
 
@@ -736,7 +735,7 @@ public static class ElasticIndexExtensions
         };
     }
 
-    private static BucketAggregate ToRangeBucketAggregate(ElasticAggregations.RangeAggregate aggregate, ITextSerializer serializer, ILogger logger = null)
+    private static BucketAggregate ToRangeBucketAggregate(ElasticAggregations.RangeAggregate aggregate, ITextSerializer serializer, ILogger? logger = null)
     {
         var data = aggregate.Meta != null ? new Dictionary<string, object>(aggregate.Meta) : new Dictionary<string, object>();
 
@@ -758,7 +757,7 @@ public static class ElasticIndexExtensions
         };
     }
 
-    private static BucketAggregate ToGeohashGridBucketAggregate(ElasticAggregations.GeohashGridAggregate aggregate, ITextSerializer serializer, ILogger logger = null)
+    private static BucketAggregate ToGeohashGridBucketAggregate(ElasticAggregations.GeohashGridAggregate aggregate, ITextSerializer serializer, ILogger? logger = null)
     {
         var data = aggregate.Meta != null ? new Dictionary<string, object>(aggregate.Meta) : new Dictionary<string, object>();
 
@@ -777,20 +776,20 @@ public static class ElasticIndexExtensions
         };
     }
 
-    private static IAggregate ToValueAggregate(double? value, IReadOnlyDictionary<string, object> meta)
+    private static IAggregate? ToValueAggregate(double? value, IReadOnlyDictionary<string, object>? meta)
     {
-        if (meta != null && meta.TryGetValue("@field_type", out object fieldType))
+        if (meta is not null && meta.TryGetValue("@field_type", out object? fieldType))
         {
-            string type = fieldType?.ToString();
+            string? type = fieldType?.ToString();
             if (type == "date" && value.HasValue)
             {
                 var kind = DateTimeKind.Utc;
                 long ticks = _epochTicks + ((long)value.Value * TimeSpan.TicksPerMillisecond);
 
-                if (meta.TryGetValue("@timezone", out object timezoneValue) && timezoneValue != null)
+                if (meta.TryGetValue("@timezone", out object? timezoneValue) && timezoneValue is not null)
                 {
                     kind = DateTimeKind.Unspecified;
-                    ticks -= Exceptionless.DateTimeExtensions.TimeUnit.Parse(timezoneValue.ToString()).Ticks;
+                    ticks -= Exceptionless.DateTimeExtensions.TimeUnit.Parse(timezoneValue.ToString()!).Ticks;
                 }
 
                 return new ValueAggregate<DateTime>
@@ -815,85 +814,85 @@ public static class ElasticIndexExtensions
         return new DateTime(ticks, kind);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this ElasticAggregations.AggregateDictionary aggregations, ITextSerializer serializer, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this ElasticAggregations.AggregateDictionary? aggregations, ITextSerializer serializer, ILogger? logger = null)
     {
-        if (aggregations == null)
+        if (aggregations is null)
             return null;
 
-        return aggregations.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger));
+        return aggregations.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this ElasticAggregations.DateHistogramBucket bucket, ITextSerializer serializer, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this ElasticAggregations.DateHistogramBucket bucket, ITextSerializer serializer, ILogger? logger = null)
     {
-        return bucket.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger));
+        return bucket.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this ElasticAggregations.StringTermsBucket bucket, ITextSerializer serializer, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this ElasticAggregations.StringTermsBucket bucket, ITextSerializer serializer, ILogger? logger = null)
     {
-        return bucket.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger));
+        return bucket.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this ElasticAggregations.LongTermsBucket bucket, ITextSerializer serializer, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this ElasticAggregations.LongTermsBucket bucket, ITextSerializer serializer, ILogger? logger = null)
     {
-        return bucket.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger));
+        return bucket.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this ElasticAggregations.DoubleTermsBucket bucket, ITextSerializer serializer, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this ElasticAggregations.DoubleTermsBucket bucket, ITextSerializer serializer, ILogger? logger = null)
     {
-        return bucket.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger));
+        return bucket.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this ElasticAggregations.RangeBucket bucket, ITextSerializer serializer, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this ElasticAggregations.RangeBucket bucket, ITextSerializer serializer, ILogger? logger = null)
     {
-        return bucket.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger));
+        return bucket.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this ElasticAggregations.GeohashGridBucket bucket, ITextSerializer serializer, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this ElasticAggregations.GeohashGridBucket bucket, ITextSerializer serializer, ILogger? logger = null)
     {
-        return bucket.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger));
+        return bucket.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this ElasticAggregations.FilterAggregate aggregate, ITextSerializer serializer, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this ElasticAggregations.FilterAggregate aggregate, ITextSerializer serializer, ILogger? logger = null)
     {
-        return aggregate.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger));
+        return aggregate.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this ElasticAggregations.GlobalAggregate aggregate, ITextSerializer serializer, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this ElasticAggregations.GlobalAggregate aggregate, ITextSerializer serializer, ILogger? logger = null)
     {
-        return aggregate.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger));
+        return aggregate.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this ElasticAggregations.MissingAggregate aggregate, ITextSerializer serializer, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this ElasticAggregations.MissingAggregate aggregate, ITextSerializer serializer, ILogger? logger = null)
     {
-        return aggregate.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger));
+        return aggregate.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this ElasticAggregations.NestedAggregate aggregate, ITextSerializer serializer, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this ElasticAggregations.NestedAggregate aggregate, ITextSerializer serializer, ILogger? logger = null)
     {
-        return aggregate.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger));
+        return aggregate.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this ElasticAggregations.ReverseNestedAggregate aggregate, ITextSerializer serializer, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this ElasticAggregations.ReverseNestedAggregate aggregate, ITextSerializer serializer, ILogger? logger = null)
     {
-        return aggregate.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger));
+        return aggregate.Aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, serializer, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations<T>(this SearchResponse<T> res, ITextSerializer serializer, ILogger logger = null) where T : class
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations<T>(this SearchResponse<T> res, ITextSerializer serializer, ILogger? logger = null) where T : class
     {
         return res.Aggregations.ToAggregations(serializer, logger);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations<T>(this SubmitAsyncSearchResponse<T> res, ITextSerializer serializer, ILogger logger = null) where T : class
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations<T>(this SubmitAsyncSearchResponse<T> res, ITextSerializer serializer, ILogger? logger = null) where T : class
     {
         return res.Response?.Aggregations.ToAggregations(serializer, logger);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations<T>(this GetAsyncSearchResponse<T> res, ITextSerializer serializer, ILogger logger = null) where T : class
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations<T>(this GetAsyncSearchResponse<T> res, ITextSerializer serializer, ILogger? logger = null) where T : class
     {
         return res.Response?.Aggregations.ToAggregations(serializer, logger);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations<T>(this ScrollResponse<T> res, ITextSerializer serializer, ILogger logger = null) where T : class
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations<T>(this ScrollResponse<T> res, ITextSerializer serializer, ILogger? logger = null) where T : class
     {
         return res.Aggregations.ToAggregations(serializer, logger);
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
@@ -649,10 +649,10 @@ public static class ElasticIndexExtensions
         if (aggregate.DocCountErrorUpperBound.GetValueOrDefault() > 0)
         {
             logger?.LogWarning("Terms aggregation {AggregationName} has doc_count_error_upper_bound of {DocCountErrorUpperBound}. Results may be inaccurate. Consider increasing shard_size.", name, aggregate.DocCountErrorUpperBound);
-            data.Add(nameof(aggregate.DocCountErrorUpperBound), aggregate.DocCountErrorUpperBound!);
+            data.Add(nameof(aggregate.DocCountErrorUpperBound), aggregate.DocCountErrorUpperBound.GetValueOrDefault());
         }
         if (aggregate.SumOtherDocCount.GetValueOrDefault() > 0)
-            data.Add(nameof(aggregate.SumOtherDocCount), aggregate.SumOtherDocCount!);
+            data.Add(nameof(aggregate.SumOtherDocCount), aggregate.SumOtherDocCount.GetValueOrDefault());
 
         var buckets = aggregate.Buckets.Select(b => (IBucket)new KeyedBucket<string>(b.ToAggregations(serializer, logger))
         {
@@ -675,10 +675,10 @@ public static class ElasticIndexExtensions
         if (aggregate.DocCountErrorUpperBound.GetValueOrDefault() > 0)
         {
             logger?.LogWarning("Terms aggregation {AggregationName} has doc_count_error_upper_bound of {DocCountErrorUpperBound}. Results may be inaccurate. Consider increasing shard_size.", name, aggregate.DocCountErrorUpperBound);
-            data.Add(nameof(aggregate.DocCountErrorUpperBound), aggregate.DocCountErrorUpperBound!);
+            data.Add(nameof(aggregate.DocCountErrorUpperBound), aggregate.DocCountErrorUpperBound.GetValueOrDefault());
         }
         if (aggregate.SumOtherDocCount.GetValueOrDefault() > 0)
-            data.Add(nameof(aggregate.SumOtherDocCount), aggregate.SumOtherDocCount!);
+            data.Add(nameof(aggregate.SumOtherDocCount), aggregate.SumOtherDocCount.GetValueOrDefault());
 
         var buckets = aggregate.Buckets.Select(b => (IBucket)new KeyedBucket<double>(b.ToAggregations(serializer, logger))
         {
@@ -701,10 +701,10 @@ public static class ElasticIndexExtensions
         if (aggregate.DocCountErrorUpperBound.GetValueOrDefault() > 0)
         {
             logger?.LogWarning("Terms aggregation {AggregationName} has doc_count_error_upper_bound of {DocCountErrorUpperBound}. Results may be inaccurate. Consider increasing shard_size.", name, aggregate.DocCountErrorUpperBound);
-            data.Add(nameof(aggregate.DocCountErrorUpperBound), aggregate.DocCountErrorUpperBound!);
+            data.Add(nameof(aggregate.DocCountErrorUpperBound), aggregate.DocCountErrorUpperBound.GetValueOrDefault());
         }
         if (aggregate.SumOtherDocCount.GetValueOrDefault() > 0)
-            data.Add(nameof(aggregate.SumOtherDocCount), aggregate.SumOtherDocCount!);
+            data.Add(nameof(aggregate.SumOtherDocCount), aggregate.SumOtherDocCount.GetValueOrDefault());
 
         var buckets = aggregate.Buckets.Select(b => (IBucket)new KeyedBucket<double>(b.ToAggregations(serializer, logger))
         {

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
@@ -611,18 +611,21 @@ public static class ElasticIndexExtensions
     {
         var data = aggregate.Meta is not null ? new Dictionary<string, object>(aggregate.Meta) : new Dictionary<string, object>();
 
-        object? timezoneValue = data.TryGetValue("@timezone", out object? tz) ? tz : null;
-        bool hasTimezone = timezoneValue is not null;
+        // Check if there's a timezone offset in the metadata
+        bool hasTimezone = data.TryGetValue("@timezone", out object? timezoneValue) && timezoneValue is not null;
 
         var buckets = aggregate.Buckets.Select(b =>
         {
+            // When there's a timezone, the bucket key from Elasticsearch already represents the local time boundary
+            // We use Unspecified kind since the dates are adjusted for the timezone
             DateTime date = hasTimezone
                 ? DateTime.SpecifyKind(b.Key.UtcDateTime, DateTimeKind.Unspecified)
                 : b.Key.UtcDateTime;
             var keyAsLong = b.Key.ToUnixTimeMilliseconds();
+            // Propagate timezone metadata to bucket data for round-trip serialization
             var bucketData = new Dictionary<string, object> { { "@type", "datehistogram" } };
-            if (timezoneValue is not null)
-                bucketData["@timezone"] = timezoneValue;
+            if (hasTimezone)
+                bucketData["@timezone"] = timezoneValue!;
 
             return (IBucket)new DateHistogramBucket(date, b.ToAggregations(serializer, logger))
             {

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
@@ -410,7 +410,9 @@ public static class ElasticIndexExtensions
             doc.Match(
                 result =>
                 {
-                    if (result is null) return;
+                    if (result is null)
+                        return;
+
                     if (result.Found)
                     {
                         var data = new DataDictionary { { ElasticDataKeys.Index, result.Index } };
@@ -431,7 +433,9 @@ public static class ElasticIndexExtensions
                 },
                 error =>
                 {
-                    if (error is null) return;
+                    if (error is null)
+                        return;
+
                     logger?.LogWarning("MultiGet document error: index={Index}, id={Id}, reason={Reason}", error.Index, error.Id, error.Error?.Reason);
                 }
             );
@@ -607,14 +611,18 @@ public static class ElasticIndexExtensions
     {
         var data = aggregate.Meta is not null ? new Dictionary<string, object>(aggregate.Meta) : new Dictionary<string, object>();
 
+        // Check if there's a timezone offset in the metadata
         bool hasTimezone = data.TryGetValue("@timezone", out object? timezoneValue) && timezoneValue is not null;
 
         var buckets = aggregate.Buckets.Select(b =>
         {
+            // When there's a timezone, the bucket key from Elasticsearch already represents the local time boundary
+            // We use Unspecified kind since the dates are adjusted for the timezone
             DateTime date = hasTimezone
                 ? DateTime.SpecifyKind(b.Key.UtcDateTime, DateTimeKind.Unspecified)
                 : b.Key.UtcDateTime;
             var keyAsLong = b.Key.ToUnixTimeMilliseconds();
+            // Propagate timezone metadata to bucket data for round-trip serialization
             var bucketData = new Dictionary<string, object> { { "@type", "datehistogram" } };
             if (hasTimezone)
                 bucketData["@timezone"] = timezoneValue!;

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
@@ -611,21 +611,18 @@ public static class ElasticIndexExtensions
     {
         var data = aggregate.Meta is not null ? new Dictionary<string, object>(aggregate.Meta) : new Dictionary<string, object>();
 
-        // Check if there's a timezone offset in the metadata
-        bool hasTimezone = data.TryGetValue("@timezone", out object? timezoneValue) && timezoneValue is not null;
+        object? timezoneValue = data.TryGetValue("@timezone", out object? tz) ? tz : null;
+        bool hasTimezone = timezoneValue is not null;
 
         var buckets = aggregate.Buckets.Select(b =>
         {
-            // When there's a timezone, the bucket key from Elasticsearch already represents the local time boundary
-            // We use Unspecified kind since the dates are adjusted for the timezone
             DateTime date = hasTimezone
                 ? DateTime.SpecifyKind(b.Key.UtcDateTime, DateTimeKind.Unspecified)
                 : b.Key.UtcDateTime;
             var keyAsLong = b.Key.ToUnixTimeMilliseconds();
-            // Propagate timezone metadata to bucket data for round-trip serialization
             var bucketData = new Dictionary<string, object> { { "@type", "datehistogram" } };
-            if (hasTimezone)
-                bucketData["@timezone"] = timezoneValue!;
+            if (timezoneValue is not null)
+                bucketData["@timezone"] = timezoneValue;
 
             return (IBucket)new DateHistogramBucket(date, b.ToAggregations(serializer, logger))
             {

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
@@ -59,7 +59,7 @@ public static class ElasticIndexExtensions
         return asyncSearchDescriptor;
     }
 
-    public static FindResults<T> ToFindResults<T>(this Nest.ISearchResponse<T> response, ICommandOptions options, ILogger logger = null) where T : class, new()
+    public static FindResults<T> ToFindResults<T>(this Nest.ISearchResponse<T> response, ICommandOptions options, ILogger? logger = null) where T : class, new()
     {
         if (!response.IsValid)
         {
@@ -107,7 +107,7 @@ public static class ElasticIndexExtensions
         return results;
     }
 
-    public static FindResults<T> ToFindResults<T>(this Nest.IAsyncSearchResponse<T> response, ICommandOptions options, ILogger logger = null) where T : class, new()
+    public static FindResults<T> ToFindResults<T>(this Nest.IAsyncSearchResponse<T> response, ICommandOptions options, ILogger? logger = null) where T : class, new()
     {
         if (!response.IsValid)
         {
@@ -166,7 +166,7 @@ public static class ElasticIndexExtensions
         return hits.Select(h => h.ToFindHit());
     }
 
-    public static CountResult ToCountResult<T>(this Nest.ISearchResponse<T> response, ICommandOptions options, ILogger logger = null) where T : class, new()
+    public static CountResult ToCountResult<T>(this Nest.ISearchResponse<T> response, ICommandOptions options, ILogger? logger = null) where T : class, new()
     {
         if (!response.IsValid)
         {
@@ -183,7 +183,7 @@ public static class ElasticIndexExtensions
         return new CountResult(response.Total, response.ToAggregations(logger), data);
     }
 
-    public static CountResult ToCountResult<T>(this Nest.IAsyncSearchResponse<T> response, ICommandOptions options, ILogger logger = null) where T : class, new()
+    public static CountResult ToCountResult<T>(this Nest.IAsyncSearchResponse<T> response, ICommandOptions options, ILogger? logger = null) where T : class, new()
     {
         if (!response.IsValid)
         {
@@ -306,20 +306,20 @@ public static class ElasticIndexExtensions
 
     private static readonly long _epochTicks = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero).Ticks;
 
-    private static readonly Lazy<Func<Nest.TopHitsAggregate, IList<Nest.LazyDocument>>> _getHits =
+    private static readonly Lazy<Func<Nest.TopHitsAggregate, IList<Nest.LazyDocument>?>> _getHits =
         new(() =>
         {
             var hitsField = typeof(Nest.TopHitsAggregate).GetField("_hits", BindingFlags.GetField | BindingFlags.NonPublic | BindingFlags.Instance);
             return agg => hitsField?.GetValue(agg) as IList<Nest.LazyDocument>;
         });
 
-    public static IAggregate ToAggregate(this Nest.IAggregate aggregate, string name = null, ILogger logger = null)
+    public static IAggregate? ToAggregate(this Nest.IAggregate aggregate, string? name = null, ILogger? logger = null)
     {
         if (aggregate is Nest.ValueAggregate valueAggregate)
         {
-            if (valueAggregate.Meta != null && valueAggregate.Meta.TryGetValue("@field_type", out object value))
+            if (valueAggregate.Meta is not null && valueAggregate.Meta.TryGetValue("@field_type", out object? value))
             {
-                string type = value.ToString();
+                string? type = value.ToString();
                 if (type == "date" && valueAggregate.Value.HasValue)
                 {
                     return new ValueAggregate<DateTime>
@@ -330,7 +330,7 @@ public static class ElasticIndexExtensions
                 }
             }
 
-            return new ValueAggregate { Value = valueAggregate.Value, Data = valueAggregate.Meta.ToReadOnlyData<ValueAggregate>() };
+            return new ValueAggregate { Value = valueAggregate.Value, Data = valueAggregate.Meta?.ToReadOnlyData<ValueAggregate>() };
         }
 
         if (aggregate is Nest.ScriptedMetricAggregate scriptedAggregate)
@@ -375,7 +375,7 @@ public static class ElasticIndexExtensions
             var hits = _getHits.Value(topHitsAggregate);
             var docs = hits?.Select(h => new ElasticLazyDocument(h)).Cast<ILazyDocument>().ToList();
 
-            return new TopHitsAggregate(docs)
+            return new TopHitsAggregate(docs ?? [])
             {
                 Total = topHitsAggregate.Total.Value,
                 MaxScore = topHitsAggregate.MaxScore,
@@ -402,14 +402,14 @@ public static class ElasticIndexExtensions
             if (bucketAggregation.DocCountErrorUpperBound.GetValueOrDefault() > 0)
             {
                 logger?.LogWarning("Terms aggregation {AggregationName} has doc_count_error_upper_bound of {DocCountErrorUpperBound}. Results may be inaccurate. Consider increasing shard_size.", name, bucketAggregation.DocCountErrorUpperBound);
-                data.Add(nameof(bucketAggregation.DocCountErrorUpperBound), bucketAggregation.DocCountErrorUpperBound);
+                data.Add(nameof(bucketAggregation.DocCountErrorUpperBound), bucketAggregation.DocCountErrorUpperBound!);
             }
             if (bucketAggregation.SumOtherDocCount.GetValueOrDefault() > 0)
-                data.Add(nameof(bucketAggregation.SumOtherDocCount), bucketAggregation.SumOtherDocCount);
+                data.Add(nameof(bucketAggregation.SumOtherDocCount), bucketAggregation.SumOtherDocCount!);
 
             return new BucketAggregate
             {
-                Items = bucketAggregation.Items.Select(i => i.ToBucket(data, logger)).ToList(),
+                Items = bucketAggregation.Items.Select(i => i.ToBucket(data, logger)).ToList()!,
                 Data = new ReadOnlyDictionary<string, object>(data).ToReadOnlyData<BucketAggregate>(),
                 Total = bucketAggregation.DocCount
             };
@@ -426,10 +426,10 @@ public static class ElasticIndexExtensions
         var kind = DateTimeKind.Utc;
         long ticks = _epochTicks + ((long)valueAggregate.Value * TimeSpan.TicksPerMillisecond);
 
-        if (valueAggregate.Meta.TryGetValue("@timezone", out object value) && value != null)
+        if (valueAggregate.Meta.TryGetValue("@timezone", out object? value) && value is not null)
         {
             kind = DateTimeKind.Unspecified;
-            ticks -= Exceptionless.DateTimeExtensions.TimeUnit.Parse(value.ToString()).Ticks;
+            ticks -= Exceptionless.DateTimeExtensions.TimeUnit.Parse(value.ToString()!).Ticks;
         }
 
         return GetDate(ticks, kind);
@@ -446,7 +446,7 @@ public static class ElasticIndexExtensions
         return new DateTime(ticks, kind);
     }
 
-    public static IBucket ToBucket(this Nest.IBucket bucket, IDictionary<string, object> parentData = null, ILogger logger = null)
+    public static IBucket? ToBucket(this Nest.IBucket bucket, IDictionary<string, object>? parentData = null, ILogger? logger = null)
     {
         if (bucket is Nest.DateHistogramBucket dateHistogramBucket)
         {
@@ -457,7 +457,7 @@ public static class ElasticIndexExtensions
             var data = new Dictionary<string, object> { { "@type", "datehistogram" } };
 
             if (hasTimezone)
-                data.Add("@timezone", parentData["@timezone"]);
+                data.Add("@timezone", parentData!["@timezone"]);
 
             return new DateHistogramBucket(date, dateHistogramBucket.ToAggregations(logger))
             {
@@ -510,17 +510,17 @@ public static class ElasticIndexExtensions
         return null;
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations(this IReadOnlyDictionary<string, Nest.IAggregate> aggregations, ILogger logger = null)
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations(this IReadOnlyDictionary<string, Nest.IAggregate> aggregations, ILogger? logger = null)
     {
-        return aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, logger));
+        return aggregations?.ToDictionary(a => a.Key, a => a.Value.ToAggregate(a.Key, logger)!);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations<T>(this Nest.ISearchResponse<T> res, ILogger logger = null) where T : class
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations<T>(this Nest.ISearchResponse<T> res, ILogger? logger = null) where T : class
     {
         return res.Aggregations.ToAggregations(logger);
     }
 
-    public static IReadOnlyDictionary<string, IAggregate> ToAggregations<T>(this Nest.IAsyncSearchResponse<T> res, ILogger logger = null) where T : class
+    public static IReadOnlyDictionary<string, IAggregate>? ToAggregations<T>(this Nest.IAsyncSearchResponse<T> res, ILogger? logger = null) where T : class
     {
         return res.Response.Aggregations.ToAggregations(logger);
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticLazyDocument.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticLazyDocument.cs
@@ -10,21 +10,21 @@ namespace Foundatio.Repositories.Elasticsearch.Extensions;
 public class ElasticLazyDocument : ILazyDocument
 {
     private readonly Nest.ILazyDocument _inner;
-    private IElasticsearchSerializer _requestResponseSerializer;
+    private IElasticsearchSerializer? _requestResponseSerializer;
 
     public ElasticLazyDocument(Nest.ILazyDocument inner)
     {
         _inner = inner;
     }
 
-    private static readonly Lazy<Func<Nest.ILazyDocument, IElasticsearchSerializer>> _getSerializer =
+    private static readonly Lazy<Func<Nest.ILazyDocument, IElasticsearchSerializer?>> _getSerializer =
         new(() =>
         {
             var serializerField = typeof(Nest.LazyDocument).GetField("_requestResponseSerializer", BindingFlags.GetField | BindingFlags.NonPublic | BindingFlags.Instance);
             return lazyDocument =>
             {
                 var d = lazyDocument as Nest.LazyDocument;
-                if (d == null)
+                if (d is null)
                     return null;
 
                 var serializer = serializerField?.GetValue(d) as IElasticsearchSerializer;
@@ -32,14 +32,14 @@ public class ElasticLazyDocument : ILazyDocument
             };
         });
 
-    private static readonly Lazy<Func<Nest.ILazyDocument, byte[]>> _getBytes =
+    private static readonly Lazy<Func<Nest.ILazyDocument, byte[]?>> _getBytes =
         new(() =>
         {
             var bytesProperty = typeof(Nest.LazyDocument).GetProperty("Bytes", BindingFlags.GetProperty | BindingFlags.NonPublic | BindingFlags.Instance);
             return lazyDocument =>
             {
                 var d = lazyDocument as Nest.LazyDocument;
-                if (d == null)
+                if (d is null)
                     return null;
 
                 var bytes = bytesProperty?.GetValue(d) as byte[];
@@ -47,17 +47,19 @@ public class ElasticLazyDocument : ILazyDocument
             };
         });
 
-    public T As<T>() where T : class
+    public T? As<T>() where T : class
     {
-        if (_requestResponseSerializer == null)
-            _requestResponseSerializer = _getSerializer.Value(_inner);
+        _requestResponseSerializer ??= _getSerializer.Value(_inner);
 
         var bytes = _getBytes.Value(_inner);
+        if (bytes is null || _requestResponseSerializer is null)
+            return null;
+
         var hit = _requestResponseSerializer.Deserialize<IHit<T>>(new MemoryStream(bytes));
         return hit?.Source;
     }
 
-    public object As(Type objectType)
+    public object? As(Type objectType)
     {
         var hitType = typeof(IHit<>).MakeGenericType(objectType);
         return _inner.As(hitType);

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticLazyDocument.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticLazyDocument.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json;
 using Elastic.Clients.Elasticsearch.Core.Search;
 using Foundatio.Serializer;
@@ -17,7 +17,7 @@ public class ElasticLazyDocument : ILazyDocument
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
     }
 
-    public T As<T>() where T : class
+    public T? As<T>() where T : class
     {
         if (_hit?.Source is null)
             return null;
@@ -31,7 +31,7 @@ public class ElasticLazyDocument : ILazyDocument
         return _serializer.Deserialize<T>(_serializer.SerializeToString(_hit.Source));
     }
 
-    public object As(Type objectType)
+    public object? As(Type objectType)
     {
         if (_hit?.Source is null)
             return null;

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
@@ -21,11 +21,13 @@ public static class FindHitExtensions
         if (hit is null || !hit.Data.TryGetValue(ElasticDataKeys.Sorts, out object? sorts))
             return Array.Empty<object>();
 
+        // Handle different collection types - new ES client returns IReadOnlyCollection<FieldValue>
         if (sorts is object[] sortsArray)
             return sortsArray;
 
         if (sorts is IEnumerable<FieldValue> fieldValues)
         {
+            // Extract actual values from FieldValue objects
             return fieldValues.Select(GetFieldValueAsObject).ToArray()!;
         }
 
@@ -37,6 +39,8 @@ public static class FindHitExtensions
 
     private static object? GetFieldValueAsObject(FieldValue fv)
     {
+        // FieldValue is a tagged union in the new ES client
+        // We need to extract the actual value based on the variant
         if (fv.TryGetLong(out var longVal))
             return longVal;
         if (fv.TryGetDouble(out var doubleVal))
@@ -48,6 +52,7 @@ public static class FindHitExtensions
         if (fv.IsNull)
             return null;
 
+        // Fallback - return the FieldValue itself
         return fv;
     }
 

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,24 +11,22 @@ namespace Foundatio.Repositories.Elasticsearch.Extensions;
 
 public static class FindHitExtensions
 {
-    public static string GetIndex<T>(this FindHit<T> hit)
+    public static string? GetIndex<T>(this FindHit<T> hit)
     {
         return hit?.Data?.GetString(ElasticDataKeys.Index);
     }
 
-    public static object[] GetSorts<T>(this FindHit<T> hit)
+    public static object[]? GetSorts<T>(this FindHit<T> hit)
     {
-        if (hit == null || !hit.Data.TryGetValue(ElasticDataKeys.Sorts, out object sorts))
+        if (hit is null || !hit.Data.TryGetValue(ElasticDataKeys.Sorts, out object? sorts))
             return Array.Empty<object>();
 
-        // Handle different collection types - new ES client returns IReadOnlyCollection<FieldValue>
         if (sorts is object[] sortsArray)
             return sortsArray;
 
         if (sorts is IEnumerable<FieldValue> fieldValues)
         {
-            // Extract actual values from FieldValue objects
-            return fieldValues.Select(GetFieldValueAsObject).ToArray();
+            return fieldValues.Select(GetFieldValueAsObject).ToArray()!;
         }
 
         if (sorts is IEnumerable<object> sortsList)
@@ -37,10 +35,8 @@ public static class FindHitExtensions
         return Array.Empty<object>();
     }
 
-    private static object GetFieldValueAsObject(FieldValue fv)
+    private static object? GetFieldValueAsObject(FieldValue fv)
     {
-        // FieldValue is a tagged union in the new ES client
-        // We need to extract the actual value based on the variant
         if (fv.TryGetLong(out var longVal))
             return longVal;
         if (fv.TryGetDouble(out var doubleVal))
@@ -52,11 +48,10 @@ public static class FindHitExtensions
         if (fv.IsNull)
             return null;
 
-        // Fallback - return the FieldValue itself
         return fv;
     }
 
-    public static string GetSearchBeforeToken<T>(this FindResults<T> results) where T : class
+    public static string? GetSearchBeforeToken<T>(this FindResults<T> results) where T : class
     {
         if (results == null || results.Hits.Count == 0)
             return null;
@@ -64,7 +59,7 @@ public static class FindHitExtensions
         return results.Data.GetString(ElasticDataKeys.SearchBeforeToken, null);
     }
 
-    public static string GetSearchAfterToken<T>(this FindResults<T> results) where T : class
+    public static string? GetSearchAfterToken<T>(this FindResults<T> results) where T : class
     {
         if (results == null || results.Hits.Count == 0)
             return null;
@@ -77,7 +72,7 @@ public static class FindHitExtensions
         if (results == null || results.Hits.Count == 0)
             return;
 
-        string token = results.Hits.First().GetSortToken(serializer);
+        string? token = results.Hits.First().GetSortToken(serializer);
         if (!String.IsNullOrEmpty(token))
             results.Data[ElasticDataKeys.SearchBeforeToken] = token;
     }
@@ -87,21 +82,21 @@ public static class FindHitExtensions
         if (results == null || results.Hits.Count == 0)
             return;
 
-        string token = results.Hits.Last().GetSortToken(serializer);
+        string? token = results.Hits.Last().GetSortToken(serializer);
         if (!String.IsNullOrEmpty(token))
             results.Data[ElasticDataKeys.SearchAfterToken] = token;
     }
 
-    public static string GetSortToken<T>(this FindHit<T> hit, ITextSerializer serializer)
+    public static string? GetSortToken<T>(this FindHit<T> hit, ITextSerializer serializer)
     {
-        object[] sorts = hit?.GetSorts();
+        object[]? sorts = hit?.GetSorts();
         if (sorts == null || sorts.Length == 0)
             return null;
 
         return Encode(serializer.SerializeToString(sorts));
     }
 
-    public static SortOptions ReverseOrder(this SortOptions sort)
+    public static SortOptions? ReverseOrder(this SortOptions? sort)
     {
         if (sort == null)
             return null;
@@ -131,7 +126,7 @@ public static class FindHitExtensions
         return sort;
     }
 
-    public static IEnumerable<SortOptions> ReverseOrder(this IEnumerable<SortOptions> sorts)
+    public static IEnumerable<SortOptions>? ReverseOrder(this IEnumerable<SortOptions>? sorts)
     {
         if (sorts == null)
             return null;
@@ -141,7 +136,7 @@ public static class FindHitExtensions
         return sortList;
     }
 
-    public static object[] DecodeSortToken(string sortToken, ITextSerializer serializer)
+    public static object[]? DecodeSortToken(string sortToken, ITextSerializer serializer)
     {
         return serializer.Deserialize<object[]>(Decode(sortToken));
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
@@ -19,21 +19,21 @@ public static class FindHitExtensions
         _options.Converters.Add(new ObjectConverter());
     }
 
-    public static string GetIndex<T>(this FindHit<T> hit)
+    public static string? GetIndex<T>(this FindHit<T> hit)
     {
         return hit?.Data?.GetString(ElasticDataKeys.Index);
     }
 
-    public static object[] GetSorts<T>(this FindHit<T> hit)
+    public static object[]? GetSorts<T>(this FindHit<T> hit)
     {
-        if (hit == null || !hit.Data.TryGetValue(ElasticDataKeys.Sorts, out object sorts))
+        if (hit is null || !hit.Data.TryGetValue(ElasticDataKeys.Sorts, out object? sorts))
             return Array.Empty<object>();
 
-        object[] sortsArray = sorts as object[];
+        object[]? sortsArray = sorts as object[];
         return sortsArray;
     }
 
-    public static string GetSearchBeforeToken<T>(this FindResults<T> results) where T : class
+    public static string? GetSearchBeforeToken<T>(this FindResults<T> results) where T : class
     {
         if (results == null || results.Hits.Count == 0)
             return null;
@@ -41,7 +41,7 @@ public static class FindHitExtensions
         return results.Data.GetString(ElasticDataKeys.SearchBeforeToken, null);
     }
 
-    public static string GetSearchAfterToken<T>(this FindResults<T> results) where T : class
+    public static string? GetSearchAfterToken<T>(this FindResults<T> results) where T : class
     {
         if (results == null || results.Hits.Count == 0)
             return null;
@@ -54,7 +54,7 @@ public static class FindHitExtensions
         if (results == null || results.Hits.Count == 0)
             return;
 
-        string token = results.Hits.First().GetSortToken();
+        string? token = results.Hits.First().GetSortToken();
         if (!String.IsNullOrEmpty(token))
             results.Data[ElasticDataKeys.SearchBeforeToken] = token;
     }
@@ -64,21 +64,21 @@ public static class FindHitExtensions
         if (results == null || results.Hits.Count == 0)
             return;
 
-        string token = results.Hits.Last().GetSortToken();
+        string? token = results.Hits.Last().GetSortToken();
         if (!String.IsNullOrEmpty(token))
             results.Data[ElasticDataKeys.SearchAfterToken] = token;
     }
 
-    public static string GetSortToken<T>(this FindHit<T> hit)
+    public static string? GetSortToken<T>(this FindHit<T> hit)
     {
-        object[] sorts = hit?.GetSorts();
+        object[]? sorts = hit?.GetSorts();
         if (sorts == null || sorts.Length == 0)
             return null;
 
         return Encode(JsonSerializer.Serialize(sorts));
     }
 
-    public static ISort ReverseOrder(this ISort sort)
+    public static ISort? ReverseOrder(this ISort? sort)
     {
         if (sort == null)
             return null;
@@ -87,7 +87,7 @@ public static class FindHitExtensions
         return sort;
     }
 
-    public static IEnumerable<ISort> ReverseOrder(this IEnumerable<ISort> sorts)
+    public static IEnumerable<ISort>? ReverseOrder(this IEnumerable<ISort>? sorts)
     {
         if (sorts == null)
             return null;
@@ -97,10 +97,9 @@ public static class FindHitExtensions
         return sortList;
     }
 
-    public static object[] DecodeSortToken(string sortToken)
+    public static object[]? DecodeSortToken(string sortToken)
     {
-        object[] tokens = JsonSerializer.Deserialize<object[]>(Decode(sortToken), _options);
-        return tokens;
+        return JsonSerializer.Deserialize<object[]>(Decode(sortToken), _options);
     }
 
     private static string Encode(string text)
@@ -140,7 +139,7 @@ public static class ElasticDataKeys
 
 public class ObjectConverter : JsonConverter<object>
 {
-    public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         return reader.TokenType switch
         {
@@ -148,7 +147,8 @@ public class ObjectConverter : JsonConverter<object>
             JsonTokenType.String => reader.GetString(),
             JsonTokenType.True => reader.GetBoolean(),
             JsonTokenType.False => reader.GetBoolean(),
-            _ => null
+            JsonTokenType.Null => null,
+            _ => throw new JsonException($"Unexpected token type: {reader.TokenType}")
         };
     }
 

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/FindResultsExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/FindResultsExtensions.cs
@@ -4,7 +4,7 @@ namespace Foundatio.Repositories.Elasticsearch.Extensions;
 
 public static class FindResultsExtensions
 {
-    public static string GetScrollId(this IHaveData results)
+    public static string? GetScrollId(this IHaveData results)
     {
         return results.Data.GetString(ElasticDataKeys.ScrollId, null);
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/IBodyWithApiCallDetailsExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/IBodyWithApiCallDetailsExtensions.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Repositories.Elasticsearch.Extensions;
 
 internal static class IBodyWithApiCallDetailsExtensions
 {
-    public static T DeserializeRaw<T>(this ElasticsearchResponse call, ITextSerializer serializer) where T : class, new()
+    public static T? DeserializeRaw<T>(this ElasticsearchResponse call, ITextSerializer serializer) where T : class, new()
     {
         ArgumentNullException.ThrowIfNull(serializer);
 
@@ -16,7 +16,7 @@ internal static class IBodyWithApiCallDetailsExtensions
         return serializer.Deserialize<T>(call.ApiCallDetails.ResponseBodyInBytes);
     }
 
-    public static Exception OriginalException(this ElasticsearchResponse response)
+    public static Exception? OriginalException(this ElasticsearchResponse response)
     {
         return response?.ApiCallDetails?.OriginalException;
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/IBodyWithApiCallDetailsExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/IBodyWithApiCallDetailsExtensions.cs
@@ -8,7 +8,7 @@ internal static class IBodyWithApiCallDetailsExtensions
 {
     private static readonly JsonSerializerOptions _options = new() { PropertyNameCaseInsensitive = true, };
 
-    public static T DeserializeRaw<T>(this IResponse call) where T : class, new()
+    public static T? DeserializeRaw<T>(this IResponse call) where T : class, new()
     {
         if (call?.ApiCall?.ResponseBodyInBytes == null)
             return default;

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/LoggerExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/LoggerExtensions.cs
@@ -14,12 +14,6 @@ namespace Foundatio.Repositories.Elasticsearch.Extensions;
 
 public static class LoggerExtensions
 {
-    [Obsolete("Use LogRequest instead")]
-    public static void LogTraceRequest(this ILogger logger, IElasticsearchResponse elasticResponse, LogLevel logLevel = LogLevel.Trace)
-    {
-        LogRequest(logger, elasticResponse, logLevel);
-    }
-
     public static void LogRequest(this ILogger logger, IElasticsearchResponse elasticResponse, LogLevel logLevel = LogLevel.Trace)
     {
         if (elasticResponse == null || !logger.IsEnabled(logLevel))

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/LoggerExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/LoggerExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -24,28 +24,28 @@ public static class LoggerExtensions
             string body = Encoding.UTF8.GetString(apiCall.RequestBodyInBytes);
             body = JsonUtility.Normalize(body);
 
-            logger.Log(logLevel, "[{HttpStatusCode}] {HttpMethod} {HttpPathAndQuery}\r\n{HttpBody}", apiCall.HttpStatusCode, apiCall.HttpMethod, apiCall.Uri.PathAndQuery, body);
+            logger.Log(logLevel, "[{HttpStatusCode}] {HttpMethod} {HttpPathAndQuery}\r\n{HttpBody}", apiCall.HttpStatusCode, apiCall.HttpMethod, apiCall.Uri?.PathAndQuery, body);
         }
         else if (apiCall != null)
         {
-            logger.Log(logLevel, "[{HttpStatusCode}] {HttpMethod} {HttpPathAndQuery}", apiCall.HttpStatusCode, apiCall.HttpMethod, apiCall.Uri.PathAndQuery);
+            logger.Log(logLevel, "[{HttpStatusCode}] {HttpMethod} {HttpPathAndQuery}", apiCall?.HttpStatusCode, apiCall?.HttpMethod, apiCall?.Uri?.PathAndQuery);
         }
     }
 
-    public static void LogErrorRequest(this ILogger logger, ElasticsearchResponse elasticResponse, string message, params object[] args)
+    public static void LogErrorRequest(this ILogger logger, ElasticsearchResponse? elasticResponse, string message, params object?[] args)
     {
         LogErrorRequest(logger, null, elasticResponse, message, args);
     }
 
-    public static void LogErrorRequest(this ILogger logger, Exception ex, ElasticsearchResponse elasticResponse, string message, params object[] args)
+    public static void LogErrorRequest(this ILogger logger, Exception? ex, ElasticsearchResponse? elasticResponse, string message, params object?[] args)
     {
         if (elasticResponse == null || !logger.IsEnabled(LogLevel.Error))
             return;
 
         var originalException = elasticResponse.ApiCallDetails?.OriginalException;
 
-        AggregateException aggEx = null;
-        if (ex != null && originalException != null)
+        AggregateException? aggEx = null;
+        if (ex is not null && originalException is not null)
             aggEx = new AggregateException(ex, originalException);
 
         var allArgs = new object[args.Length + 1];

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/LoggerExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/LoggerExtensions.cs
@@ -28,30 +28,30 @@ public static class LoggerExtensions
         var apiCall = elasticResponse?.ApiCall;
         if (apiCall?.RequestBodyInBytes != null)
         {
-            string body = Encoding.UTF8.GetString(apiCall?.RequestBodyInBytes);
+            string body = Encoding.UTF8.GetString(apiCall.RequestBodyInBytes);
             body = JsonUtility.Normalize(body);
 
-            logger.Log(logLevel, "[{HttpStatusCode}] {HttpMethod} {HttpPathAndQuery}\r\n{HttpBody}", apiCall.HttpStatusCode, apiCall.HttpMethod, apiCall.Uri.PathAndQuery, body);
+            logger.Log(logLevel, "[{HttpStatusCode}] {HttpMethod} {HttpPathAndQuery}\r\n{HttpBody}", apiCall.HttpStatusCode, apiCall.HttpMethod, apiCall.Uri?.PathAndQuery, body);
         }
         else
         {
-            logger.Log(logLevel, "[{HttpStatusCode}] {HttpMethod} {HttpPathAndQuery}", apiCall.HttpStatusCode, apiCall.HttpMethod, apiCall.Uri.PathAndQuery);
+            logger.Log(logLevel, "[{HttpStatusCode}] {HttpMethod} {HttpPathAndQuery}", apiCall?.HttpStatusCode, apiCall?.HttpMethod, apiCall?.Uri?.PathAndQuery);
         }
     }
 
-    public static void LogErrorRequest(this ILogger logger, IElasticsearchResponse elasticResponse, string message, params object[] args)
+    public static void LogErrorRequest(this ILogger logger, IElasticsearchResponse? elasticResponse, string message, params object?[] args)
     {
         LogErrorRequest(logger, null, elasticResponse, message, args);
     }
 
-    public static void LogErrorRequest(this ILogger logger, Exception ex, IElasticsearchResponse elasticResponse, string message, params object[] args)
+    public static void LogErrorRequest(this ILogger logger, Exception? ex, IElasticsearchResponse? elasticResponse, string message, params object?[] args)
     {
         if (elasticResponse == null || !logger.IsEnabled(LogLevel.Error))
             return;
 
         var response = elasticResponse as IResponse;
 
-        AggregateException aggEx = null;
+        AggregateException? aggEx = null;
         if (ex != null && response?.OriginalException != null)
             aggEx = new AggregateException(ex, response.OriginalException);
 

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ResolverExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ResolverExtensions.cs
@@ -21,7 +21,7 @@ public static class ResolverExtensions
         if (sorts.Count == 0)
             return sorts;
 
-        return sorts.Select(sort => ResolveFieldSort(resolver, sort)!).ToList();
+        return sorts.Select(sort => ResolveFieldSort(resolver, sort)).OfType<SortOptions>().ToList();;
     }
 
     public static Field ResolveFieldName(this ElasticMappingResolver resolver, Field field)

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ResolverExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ResolverExtensions.cs
@@ -21,7 +21,7 @@ public static class ResolverExtensions
         if (sorts.Count == 0)
             return sorts;
 
-        return sorts.Select(sort => ResolveFieldSort(resolver, sort)).ToList();
+        return sorts.Select(sort => ResolveFieldSort(resolver, sort)!).ToList();
     }
 
     public static Field ResolveFieldName(this ElasticMappingResolver resolver, Field field)
@@ -32,7 +32,7 @@ public static class ResolverExtensions
         return new Field(resolver.GetResolvedField(field), field.Boost);
     }
 
-    public static SortOptions ResolveFieldSort(this ElasticMappingResolver resolver, SortOptions sort)
+    public static SortOptions? ResolveFieldSort(this ElasticMappingResolver resolver, SortOptions? sort)
     {
         // SortOptions is a discriminated union - check if it's a field sort
         if (sort?.Field != null)

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ResolverExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ResolverExtensions.cs
@@ -21,7 +21,7 @@ public static class ResolverExtensions
         if (sorts.Count == 0)
             return sorts;
 
-        return sorts.Select(sort => ResolveFieldSort(resolver, sort)).OfType<SortOptions>().ToList();;
+        return sorts.Select(sort => ResolveFieldSort(resolver, sort)).OfType<SortOptions>().ToList();
     }
 
     public static Field ResolveFieldName(this ElasticMappingResolver resolver, Field field)

--- a/src/Foundatio.Repositories.Elasticsearch/Jobs/CleanupIndexesJob.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Jobs/CleanupIndexesJob.cs
@@ -69,16 +69,16 @@ public class CleanupIndexesJob : IJob
         }
 
         var indexes = new List<IndexDate>();
-        if (result.IsValid && result.Records != null)
-            indexes = result.Records?.Select(r => GetIndexDate(r.Index)).Where(r => r != null).ToList();
+        if (result.IsValid && result.Records is not null)
+            indexes = result.Records.Select(r => GetIndexDate(r.Index)).OfType<IndexDate>().ToList();
 
-        if (indexes == null || indexes.Count == 0)
+        if (indexes.Count is 0)
             return JobResult.Success;
 
         var now = _timeProvider.GetUtcNow().UtcDateTime;
         var indexesToDelete = indexes.Where(r => r.Date < now.Subtract(r.MaxAge)).ToList();
 
-        if (indexesToDelete.Count == 0)
+        if (indexesToDelete.Count is 0)
         {
             _logger.LogInformation("No indexes selected for deletion.");
             return JobResult.Success;
@@ -135,7 +135,7 @@ public class CleanupIndexesJob : IJob
         return Task.CompletedTask;
     }
 
-    public virtual Task<bool> OnIndexDeleteFailure(string indexName, TimeSpan duration, DeleteIndexResponse response, Exception ex)
+    public virtual Task<bool> OnIndexDeleteFailure(string indexName, TimeSpan duration, DeleteIndexResponse? response, Exception? ex)
     {
         _logger.LogErrorRequest(ex, response, "Failed to delete index {IndexName} after {Duration:g}", indexName, duration);
         return Task.FromResult(true);
@@ -147,9 +147,9 @@ public class CleanupIndexesJob : IJob
         return Task.CompletedTask;
     }
 
-    private IndexDate GetIndexDate(string name)
+    private IndexDate? GetIndexDate(string name)
     {
-        if (_indexes.Count == 0)
+        if (_indexes.Count is 0)
         {
             AddIndex("logstash", TimeSpan.FromDays(7));
             AddIndex(".marvel", TimeSpan.FromDays(7));
@@ -179,10 +179,10 @@ public class CleanupIndexesJob : IJob
         public ExtractDateFunc GetDate { get; }
     }
 
-    private class IndexDate
+    private record IndexDate
     {
-        public string Index { get; set; }
-        public DateTime Date { get; set; }
-        public TimeSpan MaxAge { get; set; }
+        public required string Index { get; init; }
+        public DateTime Date { get; init; }
+        public TimeSpan MaxAge { get; init; }
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Jobs/CleanupIndexesJob.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Jobs/CleanupIndexesJob.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -71,16 +71,16 @@ public class CleanupIndexesJob : IJob
         }
 
         var indexes = new List<IndexDate>();
-        if (result.IsValidResponse && result.Indices != null)
-            indexes = result.Indices?.Keys.Select(k => GetIndexDate(k.ToString())).Where(r => r != null).ToList();
+        if (result.IsValidResponse && result.Indices is not null)
+            indexes = result.Indices?.Keys.Select(k => GetIndexDate(k.ToString())).OfType<IndexDate>().ToList() ?? [];
 
-        if (indexes == null || indexes.Count == 0)
+        if (indexes.Count is 0)
             return JobResult.Success;
 
         var now = _timeProvider.GetUtcNow().UtcDateTime;
         var indexesToDelete = indexes.Where(r => r.Date < now.Subtract(r.MaxAge)).ToList();
 
-        if (indexesToDelete.Count == 0)
+        if (indexesToDelete.Count is 0)
         {
             _logger.LogInformation("No indexes selected for deletion.");
             return JobResult.Success;
@@ -137,7 +137,7 @@ public class CleanupIndexesJob : IJob
         return Task.CompletedTask;
     }
 
-    public virtual Task<bool> OnIndexDeleteFailure(string indexName, TimeSpan duration, DeleteIndexResponse response, Exception ex)
+    public virtual Task<bool> OnIndexDeleteFailure(string indexName, TimeSpan duration, DeleteIndexResponse? response, Exception? ex)
     {
         _logger.LogErrorRequest(ex, response, "Failed to delete index {IndexName} after {Duration:g}", indexName, duration);
         return Task.FromResult(true);
@@ -149,9 +149,9 @@ public class CleanupIndexesJob : IJob
         return Task.CompletedTask;
     }
 
-    private IndexDate GetIndexDate(string name)
+    private IndexDate? GetIndexDate(string name)
     {
-        if (_indexes.Count == 0)
+        if (_indexes.Count is 0)
         {
             AddIndex("logstash", TimeSpan.FromDays(7));
             AddIndex(".marvel", TimeSpan.FromDays(7));
@@ -181,10 +181,10 @@ public class CleanupIndexesJob : IJob
         public ExtractDateFunc GetDate { get; }
     }
 
-    private class IndexDate
+    private record IndexDate
     {
-        public string Index { get; set; }
-        public DateTime Date { get; set; }
-        public TimeSpan MaxAge { get; set; }
+        public required string Index { get; init; }
+        public DateTime Date { get; init; }
+        public TimeSpan MaxAge { get; init; }
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Jobs/CleanupSnapshotJob.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Jobs/CleanupSnapshotJob.cs
@@ -157,7 +157,7 @@ public class CleanupSnapshotJob : IJob
         return Task.CompletedTask;
     }
 
-    public virtual Task<bool> OnSnapshotDeleteFailure(string snapshotName, TimeSpan duration, DeleteSnapshotResponse response, Exception ex)
+    public virtual Task<bool> OnSnapshotDeleteFailure(string snapshotName, TimeSpan duration, DeleteSnapshotResponse? response, Exception? ex)
     {
         _logger.LogErrorRequest(ex, response, "Failed to delete snapshot(s) {SnapshotName} after {Duration:g}", snapshotName, duration);
         return Task.FromResult(true);
@@ -169,17 +169,17 @@ public class CleanupSnapshotJob : IJob
     }
 
     [DebuggerDisplay("{Name}")]
-    private class RepositoryMaxAge
+    private record RepositoryMaxAge
     {
-        public string Name { get; set; }
-        public TimeSpan MaxAge { get; set; }
+        public required string Name { get; init; }
+        public TimeSpan MaxAge { get; init; }
     }
 
     [DebuggerDisplay("{Name} ({Date})")]
-    private class SnapshotDate
+    private record SnapshotDate
     {
-        public string Name { get; set; }
-        public DateTime Date { get; set; }
+        public required string Name { get; init; }
+        public DateTime Date { get; init; }
     }
 }
 

--- a/src/Foundatio.Repositories.Elasticsearch/Jobs/CleanupSnapshotJob.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Jobs/CleanupSnapshotJob.cs
@@ -158,7 +158,7 @@ public class CleanupSnapshotJob : IJob
         return Task.CompletedTask;
     }
 
-    public virtual Task<bool> OnSnapshotDeleteFailure(string snapshotName, TimeSpan duration, DeleteSnapshotResponse response, Exception ex)
+    public virtual Task<bool> OnSnapshotDeleteFailure(string snapshotName, TimeSpan duration, DeleteSnapshotResponse? response, Exception? ex)
     {
         _logger.LogErrorRequest(ex, response, "Failed to delete snapshot(s) {SnapshotName} after {Duration:g}", snapshotName, duration);
         return Task.FromResult(true);
@@ -170,17 +170,17 @@ public class CleanupSnapshotJob : IJob
     }
 
     [DebuggerDisplay("{Name}")]
-    private class RepositoryMaxAge
+    private record RepositoryMaxAge
     {
-        public string Name { get; set; }
-        public TimeSpan MaxAge { get; set; }
+        public required string Name { get; init; }
+        public TimeSpan MaxAge { get; init; }
     }
 
     [DebuggerDisplay("{Name} ({Date})")]
-    private class SnapshotDate
+    private record SnapshotDate
     {
-        public string Name { get; set; }
-        public DateTime Date { get; set; }
+        public required string Name { get; init; }
+        public DateTime Date { get; init; }
     }
 }
 

--- a/src/Foundatio.Repositories.Elasticsearch/Jobs/ElasticMigrationJob.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Jobs/ElasticMigrationJob.cs
@@ -15,7 +15,7 @@ public abstract class ElasticMigrationJobBase : JobBase
     protected readonly IElasticConfiguration _configuration;
     protected readonly Lazy<MigrationManager> _migrationManager;
 
-    public ElasticMigrationJobBase(MigrationManager migrationManager, IElasticConfiguration configuration, ILoggerFactory loggerFactory = null)
+    public ElasticMigrationJobBase(MigrationManager migrationManager, IElasticConfiguration configuration, ILoggerFactory? loggerFactory = null)
         : base(loggerFactory)
     {
         _migrationManager = new Lazy<MigrationManager>(() =>

--- a/src/Foundatio.Repositories.Elasticsearch/Jobs/ReindexWorkItem.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Jobs/ReindexWorkItem.cs
@@ -2,13 +2,13 @@
 
 namespace Foundatio.Repositories.Elasticsearch.Jobs;
 
-public class ReindexWorkItem
+public record ReindexWorkItem
 {
-    public string OldIndex { get; set; }
-    public string NewIndex { get; set; }
-    public string Alias { get; set; }
-    public string Script { get; set; }
+    public required string OldIndex { get; init; }
+    public required string NewIndex { get; init; }
+    public string? Alias { get; init; }
+    public string? Script { get; init; }
     public bool DeleteOld { get; set; }
-    public string TimestampField { get; set; }
-    public DateTime? StartUtc { get; set; }
+    public string? TimestampField { get; init; }
+    public DateTime? StartUtc { get; init; }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Jobs/ReindexWorkItemHandler.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Jobs/ReindexWorkItemHandler.cs
@@ -14,7 +14,7 @@ public class ReindexWorkItemHandler : WorkItemHandlerBase
     private readonly ElasticReindexer _reindexer;
     private readonly ILockProvider _lockProvider;
 
-    public ReindexWorkItemHandler(ElasticsearchClient client, ITextSerializer serializer, ILockProvider lockProvider, ILoggerFactory loggerFactory = null)
+    public ReindexWorkItemHandler(ElasticsearchClient client, ITextSerializer serializer, ILockProvider lockProvider, ILoggerFactory? loggerFactory = null)
         : base(loggerFactory)
     {
         _reindexer = new ElasticReindexer(client, serializer, loggerFactory?.CreateLogger<ReindexWorkItemHandler>());
@@ -22,17 +22,17 @@ public class ReindexWorkItemHandler : WorkItemHandlerBase
         AutoRenewLockOnProgress = true;
     }
 
-    public override Task<ILock> GetWorkItemLockAsync(object workItem, CancellationToken cancellationToken = default)
+    public override Task<ILock?> GetWorkItemLockAsync(object workItem, CancellationToken cancellationToken = default)
     {
         if (workItem is not ReindexWorkItem reindexWorkItem)
-            return null;
+            return Task.FromResult<ILock?>(null);
 
-        return _lockProvider.AcquireAsync(String.Join(":", "reindex", reindexWorkItem.Alias, reindexWorkItem.OldIndex, reindexWorkItem.NewIndex), TimeSpan.FromMinutes(20), cancellationToken);
+        return _lockProvider.AcquireAsync(String.Join(":", "reindex", reindexWorkItem.Alias, reindexWorkItem.OldIndex, reindexWorkItem.NewIndex), TimeSpan.FromMinutes(20), cancellationToken)!;
     }
 
     public override Task HandleItemAsync(WorkItemContext context)
     {
         var workItem = context.GetData<ReindexWorkItem>();
-        return _reindexer.ReindexAsync(workItem, context.ReportProgressAsync);
+        return _reindexer.ReindexAsync(workItem!, context.ReportProgressAsync);
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Jobs/ReindexWorkItemHandler.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Jobs/ReindexWorkItemHandler.cs
@@ -13,24 +13,24 @@ public class ReindexWorkItemHandler : WorkItemHandlerBase
     private readonly ElasticReindexer _reindexer;
     private readonly ILockProvider _lockProvider;
 
-    public ReindexWorkItemHandler(IElasticClient client, ILockProvider lockProvider, ILoggerFactory loggerFactory = null) : base(loggerFactory)
+    public ReindexWorkItemHandler(IElasticClient client, ILockProvider lockProvider, ILoggerFactory? loggerFactory = null) : base(loggerFactory)
     {
         _reindexer = new ElasticReindexer(client, loggerFactory?.CreateLogger<ReindexWorkItemHandler>());
         _lockProvider = lockProvider;
         AutoRenewLockOnProgress = true;
     }
 
-    public override Task<ILock> GetWorkItemLockAsync(object workItem, CancellationToken cancellationToken = default)
+    public override Task<ILock?> GetWorkItemLockAsync(object workItem, CancellationToken cancellationToken = default)
     {
         if (workItem is not ReindexWorkItem reindexWorkItem)
-            return null;
+            return Task.FromResult<ILock?>(null);
 
-        return _lockProvider.AcquireAsync(String.Join(":", "reindex", reindexWorkItem.Alias, reindexWorkItem.OldIndex, reindexWorkItem.NewIndex), TimeSpan.FromMinutes(20), cancellationToken);
+        return _lockProvider.AcquireAsync(String.Join(":", "reindex", reindexWorkItem.Alias, reindexWorkItem.OldIndex, reindexWorkItem.NewIndex), TimeSpan.FromMinutes(20), cancellationToken)!;
     }
 
     public override Task HandleItemAsync(WorkItemContext context)
     {
         var workItem = context.GetData<ReindexWorkItem>();
-        return _reindexer.ReindexAsync(workItem, context.ReportProgressAsync);
+        return _reindexer.ReindexAsync(workItem!, context.ReportProgressAsync);
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Jobs/SnapshotJob.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Jobs/SnapshotJob.cs
@@ -51,7 +51,7 @@ public class SnapshotJob : IJob
             if (hasSnapshotRepositoryResponse.ApiCallDetails.HttpStatusCode == 404)
                 return JobResult.CancelledWithMessage($"Snapshot repository {Repository} has not been configured.");
 
-            return JobResult.FromException(hasSnapshotRepositoryResponse.OriginalException(), hasSnapshotRepositoryResponse.GetErrorMessage());
+            return JobResult.FromException(hasSnapshotRepositoryResponse.OriginalException()!, hasSnapshotRepositoryResponse.GetErrorMessage());
         }
 
         string snapshotName = _timeProvider.GetUtcNow().UtcDateTime.ToString("'" + Repository + "-'yyyy-MM-dd-HH-mm");

--- a/src/Foundatio.Repositories.Elasticsearch/Options/ElasticCommandOptions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Options/ElasticCommandOptions.cs
@@ -4,6 +4,7 @@ using Foundatio.Parsers.ElasticQueries;
 using Foundatio.Parsers.LuceneQueries.Visitors;
 using Foundatio.Repositories.Elasticsearch.Configuration;
 using Foundatio.Repositories.Elasticsearch.Extensions;
+using Foundatio.Repositories.Exceptions;
 using Foundatio.Repositories.Options;
 using Foundatio.Utility;
 
@@ -45,8 +46,11 @@ namespace Foundatio.Repositories
 
         public static T SnapshotPagingScrollId<T>(this T options, IHaveData target) where T : ICommandOptions
         {
+            string scrollId = target.GetScrollId()
+                ?? throw new RepositoryException("ScrollId is required for snapshot paging but was not found in the target data.");
+
             options.Values.Set(SnapshotPagingKey, true);
-            options.Values.Set(SnapshotPagingScrollIdKey, target.GetScrollId());
+            options.Values.Set(SnapshotPagingScrollIdKey, scrollId);
 
             return options;
         }
@@ -69,7 +73,7 @@ namespace Foundatio.Repositories.Options
             return options.SafeGetOption<IIndex>(ElasticIndexKey);
         }
 
-        public static ElasticMappingResolver GetMappingResolver(this ICommandOptions options)
+        public static ElasticMappingResolver? GetMappingResolver(this ICommandOptions options)
         {
             return options.GetElasticIndex()?.MappingResolver;
         }
@@ -99,7 +103,7 @@ namespace Foundatio.Repositories.Options
         }
 
         internal const string ParentDocumentTypeKey = "@ParentDocumentType";
-        public static T ParentDocumentType<T>(this T options, Type parentDocumentType) where T : ICommandOptions
+        public static T ParentDocumentType<T>(this T options, Type? parentDocumentType) where T : ICommandOptions
         {
             if (parentDocumentType != null)
                 return options.BuildOption(ParentDocumentTypeKey, parentDocumentType);
@@ -148,9 +152,9 @@ namespace Foundatio.Repositories.Options
             return options.SafeHasOption(SetElasticOptionsExtensions.SnapshotPagingScrollIdKey);
         }
 
-        public static string GetSnapshotScrollId(this ICommandOptions options)
+        public static string? GetSnapshotScrollId(this ICommandOptions options)
         {
-            return options.SafeGetOption<string>(SetElasticOptionsExtensions.SnapshotPagingScrollIdKey, null);
+            return options.SafeGetOption<string?>(SetElasticOptionsExtensions.SnapshotPagingScrollIdKey, null);
         }
 
         public static bool HasSnapshotLifetime(this ICommandOptions options)

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/AggregationsQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/AggregationsQueryBuilder.cs
@@ -21,9 +21,9 @@ namespace Foundatio.Repositories.Options
 {
     public static class ReadAggregationQueryExtensions
     {
-        public static string GetAggregationsExpression(this IRepositoryQuery query)
+        public static string? GetAggregationsExpression(this IRepositoryQuery query)
         {
-            return query.SafeGetOption<string>(AggregationQueryExtensions.AggregationsKey, null);
+            return query.SafeGetOption<string?>(AggregationQueryExtensions.AggregationsKey, null);
         }
     }
 }
@@ -38,7 +38,7 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
             if (elasticIndex?.QueryParser == null)
                 return;
 
-            string aggregations = ctx.Source.GetAggregationsExpression();
+            string? aggregations = ctx.Source.GetAggregationsExpression();
             if (String.IsNullOrEmpty(aggregations))
                 return;
 

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ChildQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ChildQueryBuilder.cs
@@ -61,7 +61,7 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
             {
                 var childOptions = ctx.Options.Clone();
                 childOptions.DocumentType(childQuery.GetDocumentType());
-                var childContext = new QueryBuilderContext<object>(childQuery, childOptions, null);
+                var childContext = new QueryBuilderContext<object>(childQuery, childOptions);
 
                 await index.QueryBuilder.BuildAsync(childContext);
 

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ChildQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ChildQueryBuilder.cs
@@ -62,7 +62,7 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
             {
                 var childOptions = ctx.Options.Clone();
                 childOptions.DocumentType(childQuery.GetDocumentType());
-                var childContext = new QueryBuilderContext<object>(childQuery, childOptions, null);
+                var childContext = new QueryBuilderContext<object>(childQuery, childOptions);
 
                 await index.QueryBuilder.BuildAsync(childContext).AnyContext();
 

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/DateRangeQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/DateRangeQueryBuilder.cs
@@ -62,7 +62,7 @@ public record DateRange
             });
         }
 
-        public static T DateRange<T, TModel>(this T query, DateTime? utcStart, DateTime? utcEnd, Expression<Func<TModel, object>> objectPath, string? timeZone = null) where T : IRepositoryQuery
+        public static T DateRange<T, TModel>(this T query, DateTime? utcStart, DateTime? utcEnd, Expression<Func<TModel, object?>> objectPath, string? timeZone = null) where T : IRepositoryQuery
         {
             if (objectPath == null)
                 throw new ArgumentNullException(nameof(objectPath));

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/DateRangeQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/DateRangeQueryBuilder.cs
@@ -13,12 +13,12 @@ using Nest;
 namespace Foundatio.Repositories
 {
     [DebuggerDisplay("{Field}: {StartDate} - {EndDate}")]
-    public class DateRange
-    {
-        public DateTime? StartDate { get; set; }
-        public DateTime? EndDate { get; set; }
-        public string TimeZone { get; set; }
-        public Field Field { get; set; }
+public record DateRange
+{
+    public DateTime? StartDate { get; init; }
+    public DateTime? EndDate { get; init; }
+    public string? TimeZone { get; init; }
+    public required Field Field { get; init; }
 
         public bool UseStartDate => StartDate.HasValue && StartDate.Value > DateTime.MinValue;
 
@@ -41,7 +41,7 @@ namespace Foundatio.Repositories
     {
         internal const string DateRangesKey = "@DateRanges";
 
-        public static T DateRange<T>(this T query, DateTime? utcStart, DateTime? utcEnd, Field field, string timeZone = null) where T : IRepositoryQuery
+        public static T DateRange<T>(this T query, DateTime? utcStart, DateTime? utcEnd, Field field, string? timeZone = null) where T : IRepositoryQuery
         {
             if (field == null)
                 throw new ArgumentNullException(nameof(field));
@@ -61,7 +61,7 @@ namespace Foundatio.Repositories
             });
         }
 
-        public static T DateRange<T, TModel>(this T query, DateTime? utcStart, DateTime? utcEnd, Expression<Func<TModel, object>> objectPath, string timeZone = null) where T : IRepositoryQuery
+        public static T DateRange<T, TModel>(this T query, DateTime? utcStart, DateTime? utcEnd, Expression<Func<TModel, object>> objectPath, string? timeZone = null) where T : IRepositoryQuery
         {
             if (objectPath == null)
                 throw new ArgumentNullException(nameof(objectPath));

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/DateRangeQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/DateRangeQueryBuilder.cs
@@ -14,12 +14,12 @@ using Foundatio.Repositories.Options;
 namespace Foundatio.Repositories
 {
     [DebuggerDisplay("{Field}: {StartDate} - {EndDate}")]
-    public class DateRange
-    {
-        public DateTime? StartDate { get; set; }
-        public DateTime? EndDate { get; set; }
-        public string TimeZone { get; set; }
-        public Field Field { get; set; }
+public record DateRange
+{
+    public DateTime? StartDate { get; init; }
+    public DateTime? EndDate { get; init; }
+    public string? TimeZone { get; init; }
+    public required Field Field { get; init; }
 
         public bool UseStartDate => StartDate.HasValue && StartDate.Value > DateTime.MinValue;
 
@@ -42,7 +42,7 @@ namespace Foundatio.Repositories
     {
         internal const string DateRangesKey = "@DateRanges";
 
-        public static T DateRange<T>(this T query, DateTime? utcStart, DateTime? utcEnd, Field field, string timeZone = null) where T : IRepositoryQuery
+        public static T DateRange<T>(this T query, DateTime? utcStart, DateTime? utcEnd, Field field, string? timeZone = null) where T : IRepositoryQuery
         {
             if (field == null)
                 throw new ArgumentNullException(nameof(field));
@@ -62,7 +62,7 @@ namespace Foundatio.Repositories
             });
         }
 
-        public static T DateRange<T, TModel>(this T query, DateTime? utcStart, DateTime? utcEnd, Expression<Func<TModel, object>> objectPath, string timeZone = null) where T : IRepositoryQuery
+        public static T DateRange<T, TModel>(this T query, DateTime? utcStart, DateTime? utcEnd, Expression<Func<TModel, object>> objectPath, string? timeZone = null) where T : IRepositoryQuery
         {
             if (objectPath == null)
                 throw new ArgumentNullException(nameof(objectPath));

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/DefaultSortQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/DefaultSortQueryBuilder.cs
@@ -14,7 +14,7 @@ public class DefaultSortQueryBuilder : IElasticQueryBuilder
     public Task BuildAsync<T>(QueryBuilderContext<T> ctx) where T : class, new()
     {
         // Get existing sorts from context data (set by SortQueryBuilder or ExpressionQueryBuilder)
-        List<SortOptions> sortFields = null;
+        List<SortOptions>? sortFields = null;
         if (ctx.Data.TryGetValue(SortQueryBuilder.SortFieldsKey, out var sortsObj) && sortsObj is List<SortOptions> sorts)
         {
             sortFields = sorts;

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ElasticQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ElasticQueryBuilder.cs
@@ -12,7 +12,7 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders;
 public class ElasticQueryBuilder : IElasticQueryBuilder
 {
     private readonly List<ElasticQueryBuilderRegistration> _registrations = new();
-    private IElasticQueryBuilder[] _queryBuilders = null;
+    private IElasticQueryBuilder[]? _queryBuilders = null;
 
     public ElasticQueryBuilder(bool registerDefaultBuilders = true)
     {

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ExpressionQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ExpressionQueryBuilder.cs
@@ -35,8 +35,14 @@ namespace Foundatio.Repositories
         /// <summary>
         /// Default Search operator is AND. Does boolean matching and no scoring will occur.
         /// </summary>
-        public static T FilterExpression<T>(this T query, string filter) where T : IRepositoryQuery
+        public static T FilterExpression<T>(this T query, string? filter) where T : IRepositoryQuery
         {
+            if (String.IsNullOrEmpty(filter))
+            {
+                query.Values.Remove(FilterKey);
+                return query;
+            }
+
             return query.BuildOption(FilterKey, filter);
         }
 
@@ -46,16 +52,29 @@ namespace Foundatio.Repositories
         /// <summary>
         /// Default Search operator is OR and scoring will occur.
         /// </summary>
-        public static T SearchExpression<T>(this T query, string search, SearchOperator defaultOperator = SearchOperator.Or) where T : IRepositoryQuery
+        public static T SearchExpression<T>(this T query, string? search, SearchOperator defaultOperator = SearchOperator.Or) where T : IRepositoryQuery
         {
+            if (String.IsNullOrEmpty(search))
+            {
+                query.Values.Remove(SearchKey);
+                query.Values.Remove(CriteriaDefaultOperatorKey);
+                return query;
+            }
+
             query.Values.Set(SearchKey, search);
             return query.BuildOption(CriteriaDefaultOperatorKey, defaultOperator);
         }
 
         internal const string SortKey = "@SortExpression";
 
-        public static T SortExpression<T>(this T query, string sort) where T : IRepositoryQuery
+        public static T SortExpression<T>(this T query, string? sort) where T : IRepositoryQuery
         {
+            if (String.IsNullOrEmpty(sort))
+            {
+                query.Values.Remove(SortKey);
+                return query;
+            }
+
             return query.BuildOption(SortKey, sort);
         }
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ExpressionQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ExpressionQueryBuilder.cs
@@ -37,8 +37,14 @@ namespace Foundatio.Repositories
         /// <summary>
         /// Default Search operator is AND. Does boolean matching and no scoring will occur.
         /// </summary>
-        public static T FilterExpression<T>(this T query, string filter) where T : IRepositoryQuery
+        public static T FilterExpression<T>(this T query, string? filter) where T : IRepositoryQuery
         {
+            if (String.IsNullOrEmpty(filter))
+            {
+                query.Values.Remove(FilterKey);
+                return query;
+            }
+
             return query.BuildOption(FilterKey, filter);
         }
 
@@ -48,16 +54,29 @@ namespace Foundatio.Repositories
         /// <summary>
         /// Default Search operator is OR and scoring will occur.
         /// </summary>
-        public static T SearchExpression<T>(this T query, string search, SearchOperator defaultOperator = SearchOperator.Or) where T : IRepositoryQuery
+        public static T SearchExpression<T>(this T query, string? search, SearchOperator defaultOperator = SearchOperator.Or) where T : IRepositoryQuery
         {
+            if (String.IsNullOrEmpty(search))
+            {
+                query.Values.Remove(SearchKey);
+                query.Values.Remove(CriteriaDefaultOperatorKey);
+                return query;
+            }
+
             query.Values.Set(SearchKey, search);
             return query.BuildOption(CriteriaDefaultOperatorKey, defaultOperator);
         }
 
         internal const string SortKey = "@SortExpression";
 
-        public static T SortExpression<T>(this T query, string sort) where T : IRepositoryQuery
+        public static T SortExpression<T>(this T query, string? sort) where T : IRepositoryQuery
         {
+            if (String.IsNullOrEmpty(sort))
+            {
+                query.Values.Remove(SortKey);
+                return query;
+            }
+
             return query.BuildOption(SortKey, sort);
         }
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldCondition.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldCondition.cs
@@ -307,13 +307,13 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldCondition(Expression<Func<T, object>> objectPath, ComparisonOperator op, object? value)
+    public FieldConditionGroup<T> FieldCondition(Expression<Func<T, object?>> objectPath, ComparisonOperator op, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = op });
         return this;
     }
 
-    public FieldConditionGroup<T> FieldCondition(Expression<Func<T, object>> objectPath, ComparisonOperator op, params object[] values)
+    public FieldConditionGroup<T> FieldCondition(Expression<Func<T, object?>> objectPath, ComparisonOperator op, params object[] values)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = values, Operator = op });
         return this;
@@ -331,13 +331,13 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldContains(Expression<Func<T, object>> objectPath, object? value)
+    public FieldConditionGroup<T> FieldContains(Expression<Func<T, object?>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.Contains });
         return this;
     }
 
-    public FieldConditionGroup<T> FieldContains(Expression<Func<T, object>> objectPath, params object[] values)
+    public FieldConditionGroup<T> FieldContains(Expression<Func<T, object?>> objectPath, params object[] values)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = values, Operator = ComparisonOperator.Contains });
         return this;
@@ -355,13 +355,13 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldNotContains(Expression<Func<T, object>> objectPath, object? value)
+    public FieldConditionGroup<T> FieldNotContains(Expression<Func<T, object?>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.NotContains });
         return this;
     }
 
-    public FieldConditionGroup<T> FieldNotContains(Expression<Func<T, object>> objectPath, params object[] values)
+    public FieldConditionGroup<T> FieldNotContains(Expression<Func<T, object?>> objectPath, params object[] values)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = values, Operator = ComparisonOperator.NotContains });
         return this;
@@ -373,7 +373,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldEmpty(Expression<Func<T, object>> objectPath)
+    public FieldConditionGroup<T> FieldEmpty(Expression<Func<T, object?>> objectPath)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Operator = ComparisonOperator.IsEmpty });
         return this;
@@ -385,7 +385,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldHasValue(Expression<Func<T, object>> objectPath)
+    public FieldConditionGroup<T> FieldHasValue(Expression<Func<T, object?>> objectPath)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Operator = ComparisonOperator.HasValue });
         return this;
@@ -403,13 +403,13 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldEquals(Expression<Func<T, object>> objectPath, object? value)
+    public FieldConditionGroup<T> FieldEquals(Expression<Func<T, object?>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.Equals });
         return this;
     }
 
-    public FieldConditionGroup<T> FieldEquals(Expression<Func<T, object>> objectPath, params object[] values)
+    public FieldConditionGroup<T> FieldEquals(Expression<Func<T, object?>> objectPath, params object[] values)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = values, Operator = ComparisonOperator.Equals });
         return this;
@@ -427,13 +427,13 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldNotEquals(Expression<Func<T, object>> objectPath, object? value)
+    public FieldConditionGroup<T> FieldNotEquals(Expression<Func<T, object?>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.NotEquals });
         return this;
     }
 
-    public FieldConditionGroup<T> FieldNotEquals(Expression<Func<T, object>> objectPath, params object[] values)
+    public FieldConditionGroup<T> FieldNotEquals(Expression<Func<T, object?>> objectPath, params object[] values)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = values, Operator = ComparisonOperator.NotEquals });
         return this;
@@ -445,7 +445,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldGreaterThan(Expression<Func<T, object>> objectPath, object? value)
+    public FieldConditionGroup<T> FieldGreaterThan(Expression<Func<T, object?>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.GreaterThan });
         return this;
@@ -457,7 +457,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldGreaterThanOrEqual(Expression<Func<T, object>> objectPath, object? value)
+    public FieldConditionGroup<T> FieldGreaterThanOrEqual(Expression<Func<T, object?>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.GreaterThanOrEqual });
         return this;
@@ -469,7 +469,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldLessThan(Expression<Func<T, object>> objectPath, object? value)
+    public FieldConditionGroup<T> FieldLessThan(Expression<Func<T, object?>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.LessThan });
         return this;
@@ -481,7 +481,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldLessThanOrEqual(Expression<Func<T, object>> objectPath, object? value)
+    public FieldConditionGroup<T> FieldLessThanOrEqual(Expression<Func<T, object?>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.LessThanOrEqual });
         return this;

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldCondition.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldCondition.cs
@@ -15,10 +15,10 @@ namespace Foundatio.Repositories;
 /// translates these into the appropriate Elasticsearch query (TermQuery, TermsQuery,
 /// MatchQuery, ExistsQuery, DateRangeQuery, NumericRangeQuery, etc.) at build time.
 /// </remarks>
-public class FieldCondition
+public record FieldCondition
 {
-    public Field Field { get; set; }
-    public object Value { get; set; }
+    public required Field Field { get; init; }
+    public object? Value { get; init; }
     public ComparisonOperator Operator { get; set; }
 }
 
@@ -138,7 +138,7 @@ public class FieldConditionGroup
     public List<FieldCondition> Conditions { get; } = new();
     public List<FieldConditionGroup> Children { get; } = new();
 
-    public FieldConditionGroup FieldCondition(Field field, ComparisonOperator op, object value)
+    public FieldConditionGroup FieldCondition(Field field, ComparisonOperator op, object? value)
     {
         Conditions.Add(new FieldCondition { Field = field, Value = value, Operator = op });
         return this;
@@ -150,7 +150,7 @@ public class FieldConditionGroup
         return this;
     }
 
-    public FieldConditionGroup FieldContains(Field field, object value)
+    public FieldConditionGroup FieldContains(Field field, object? value)
     {
         Conditions.Add(new FieldCondition { Field = field, Value = value, Operator = ComparisonOperator.Contains });
         return this;
@@ -162,7 +162,7 @@ public class FieldConditionGroup
         return this;
     }
 
-    public FieldConditionGroup FieldNotContains(Field field, object value)
+    public FieldConditionGroup FieldNotContains(Field field, object? value)
     {
         Conditions.Add(new FieldCondition { Field = field, Value = value, Operator = ComparisonOperator.NotContains });
         return this;
@@ -186,7 +186,7 @@ public class FieldConditionGroup
         return this;
     }
 
-    public FieldConditionGroup FieldEquals(Field field, object value)
+    public FieldConditionGroup FieldEquals(Field field, object? value)
     {
         Conditions.Add(new FieldCondition { Field = field, Value = value, Operator = ComparisonOperator.Equals });
         return this;
@@ -198,7 +198,7 @@ public class FieldConditionGroup
         return this;
     }
 
-    public FieldConditionGroup FieldNotEquals(Field field, object value)
+    public FieldConditionGroup FieldNotEquals(Field field, object? value)
     {
         Conditions.Add(new FieldCondition { Field = field, Value = value, Operator = ComparisonOperator.NotEquals });
         return this;
@@ -210,25 +210,25 @@ public class FieldConditionGroup
         return this;
     }
 
-    public FieldConditionGroup FieldGreaterThan(Field field, object value)
+    public FieldConditionGroup FieldGreaterThan(Field field, object? value)
     {
         Conditions.Add(new FieldCondition { Field = field, Value = value, Operator = ComparisonOperator.GreaterThan });
         return this;
     }
 
-    public FieldConditionGroup FieldGreaterThanOrEqual(Field field, object value)
+    public FieldConditionGroup FieldGreaterThanOrEqual(Field field, object? value)
     {
         Conditions.Add(new FieldCondition { Field = field, Value = value, Operator = ComparisonOperator.GreaterThanOrEqual });
         return this;
     }
 
-    public FieldConditionGroup FieldLessThan(Field field, object value)
+    public FieldConditionGroup FieldLessThan(Field field, object? value)
     {
         Conditions.Add(new FieldCondition { Field = field, Value = value, Operator = ComparisonOperator.LessThan });
         return this;
     }
 
-    public FieldConditionGroup FieldLessThanOrEqual(Field field, object value)
+    public FieldConditionGroup FieldLessThanOrEqual(Field field, object? value)
     {
         Conditions.Add(new FieldCondition { Field = field, Value = value, Operator = ComparisonOperator.LessThanOrEqual });
         return this;
@@ -295,7 +295,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
     /// <summary>Creates a NOT group. No child condition must match (AND-NOT semantics).</summary>
     public static FieldConditionGroup<T> Not() => new(FieldConditionGroupOperator.Not);
 
-    public new FieldConditionGroup<T> FieldCondition(Field field, ComparisonOperator op, object value)
+    public new FieldConditionGroup<T> FieldCondition(Field field, ComparisonOperator op, object? value)
     {
         base.FieldCondition(field, op, value);
         return this;
@@ -307,7 +307,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldCondition(Expression<Func<T, object>> objectPath, ComparisonOperator op, object value)
+    public FieldConditionGroup<T> FieldCondition(Expression<Func<T, object>> objectPath, ComparisonOperator op, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = op });
         return this;
@@ -319,7 +319,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public new FieldConditionGroup<T> FieldContains(Field field, object value)
+    public new FieldConditionGroup<T> FieldContains(Field field, object? value)
     {
         base.FieldContains(field, value);
         return this;
@@ -331,7 +331,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldContains(Expression<Func<T, object>> objectPath, object value)
+    public FieldConditionGroup<T> FieldContains(Expression<Func<T, object>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.Contains });
         return this;
@@ -343,7 +343,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public new FieldConditionGroup<T> FieldNotContains(Field field, object value)
+    public new FieldConditionGroup<T> FieldNotContains(Field field, object? value)
     {
         base.FieldNotContains(field, value);
         return this;
@@ -355,7 +355,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldNotContains(Expression<Func<T, object>> objectPath, object value)
+    public FieldConditionGroup<T> FieldNotContains(Expression<Func<T, object>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.NotContains });
         return this;
@@ -391,7 +391,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public new FieldConditionGroup<T> FieldEquals(Field field, object value)
+    public new FieldConditionGroup<T> FieldEquals(Field field, object? value)
     {
         base.FieldEquals(field, value);
         return this;
@@ -403,7 +403,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldEquals(Expression<Func<T, object>> objectPath, object value)
+    public FieldConditionGroup<T> FieldEquals(Expression<Func<T, object>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.Equals });
         return this;
@@ -415,7 +415,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public new FieldConditionGroup<T> FieldNotEquals(Field field, object value)
+    public new FieldConditionGroup<T> FieldNotEquals(Field field, object? value)
     {
         base.FieldNotEquals(field, value);
         return this;
@@ -427,7 +427,7 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public FieldConditionGroup<T> FieldNotEquals(Expression<Func<T, object>> objectPath, object value)
+    public FieldConditionGroup<T> FieldNotEquals(Expression<Func<T, object>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.NotEquals });
         return this;
@@ -439,49 +439,49 @@ public class FieldConditionGroup<T> : FieldConditionGroup where T : class
         return this;
     }
 
-    public new FieldConditionGroup<T> FieldGreaterThan(Field field, object value)
+    public new FieldConditionGroup<T> FieldGreaterThan(Field field, object? value)
     {
         base.FieldGreaterThan(field, value);
         return this;
     }
 
-    public FieldConditionGroup<T> FieldGreaterThan(Expression<Func<T, object>> objectPath, object value)
+    public FieldConditionGroup<T> FieldGreaterThan(Expression<Func<T, object>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.GreaterThan });
         return this;
     }
 
-    public new FieldConditionGroup<T> FieldGreaterThanOrEqual(Field field, object value)
+    public new FieldConditionGroup<T> FieldGreaterThanOrEqual(Field field, object? value)
     {
         base.FieldGreaterThanOrEqual(field, value);
         return this;
     }
 
-    public FieldConditionGroup<T> FieldGreaterThanOrEqual(Expression<Func<T, object>> objectPath, object value)
+    public FieldConditionGroup<T> FieldGreaterThanOrEqual(Expression<Func<T, object>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.GreaterThanOrEqual });
         return this;
     }
 
-    public new FieldConditionGroup<T> FieldLessThan(Field field, object value)
+    public new FieldConditionGroup<T> FieldLessThan(Field field, object? value)
     {
         base.FieldLessThan(field, value);
         return this;
     }
 
-    public FieldConditionGroup<T> FieldLessThan(Expression<Func<T, object>> objectPath, object value)
+    public FieldConditionGroup<T> FieldLessThan(Expression<Func<T, object>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.LessThan });
         return this;
     }
 
-    public new FieldConditionGroup<T> FieldLessThanOrEqual(Field field, object value)
+    public new FieldConditionGroup<T> FieldLessThanOrEqual(Field field, object? value)
     {
         base.FieldLessThanOrEqual(field, value);
         return this;
     }
 
-    public FieldConditionGroup<T> FieldLessThanOrEqual(Expression<Func<T, object>> objectPath, object value)
+    public FieldConditionGroup<T> FieldLessThanOrEqual(Expression<Func<T, object>> objectPath, object? value)
     {
         Conditions.Add(new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.LessThanOrEqual });
         return this;

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldConditionQueryExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldConditionQueryExtensions.cs
@@ -37,23 +37,23 @@ namespace Foundatio.Repositories
             return condition ? query.FieldCondition(field, op, value) : query;
         }
 
-        public static IRepositoryQuery<T> FieldCondition<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, ComparisonOperator op, object? value) where T : class
+        public static IRepositoryQuery<T> FieldCondition<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, ComparisonOperator op, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = op });
         }
 
-        public static IRepositoryQuery<T> FieldCondition<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, ComparisonOperator op, params object[] values) where T : class
+        public static IRepositoryQuery<T> FieldCondition<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, ComparisonOperator op, params object[] values) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = values, Operator = op });
         }
 
-        public static IRepositoryQuery<TModel> FieldConditionIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, ComparisonOperator op, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldConditionIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, ComparisonOperator op, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldCondition(objectPath, op, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldConditionIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, ComparisonOperator op, TValue? value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldConditionIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, ComparisonOperator op, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldCondition(objectPath, op, value) : query;
         }
@@ -68,7 +68,7 @@ namespace Foundatio.Repositories
         /// <para>Throws <see cref="Foundatio.Repositories.Exceptions.QueryValidationException"/> at build time if the field
         /// is a non-analyzed (keyword) field.</para>
         /// </remarks>
-        public static IRepositoryQuery<T> FieldContains<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
+        public static IRepositoryQuery<T> FieldContains<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.Contains });
         }
@@ -77,18 +77,18 @@ namespace Foundatio.Repositories
         /// Full-text token match with multiple values joined as space-separated tokens.
         /// All tokens must be present (AND semantics, order-independent).
         /// </summary>
-        public static IRepositoryQuery<T> FieldContains<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, params object[] values) where T : class
+        public static IRepositoryQuery<T> FieldContains<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, params object[] values) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = values, Operator = ComparisonOperator.Contains });
         }
 
-        public static IRepositoryQuery<TModel> FieldContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldContains(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldContains(objectPath, value) : query;
         }
@@ -96,23 +96,23 @@ namespace Foundatio.Repositories
         /// <summary>
         /// Negated full-text token match. Generates <c>BoolQuery { MustNot = MatchQuery }</c>.
         /// </summary>
-        public static IRepositoryQuery<T> FieldNotContains<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
+        public static IRepositoryQuery<T> FieldNotContains<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.NotContains });
         }
 
-        public static IRepositoryQuery<T> FieldNotContains<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, params object[] values) where T : class
+        public static IRepositoryQuery<T> FieldNotContains<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, params object[] values) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = values, Operator = ComparisonOperator.NotContains });
         }
 
-        public static IRepositoryQuery<TModel> FieldNotContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldNotContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldNotContains(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldNotContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldNotContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldNotContains(objectPath, value) : query;
         }
@@ -127,12 +127,12 @@ namespace Foundatio.Repositories
             return condition ? query.FieldEmpty(field) : query;
         }
 
-        public static IRepositoryQuery<T> FieldEmpty<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath) where T : class
+        public static IRepositoryQuery<T> FieldEmpty<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Operator = ComparisonOperator.IsEmpty });
         }
 
-        public static IRepositoryQuery<T> FieldEmptyIf<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, bool condition) where T : class
+        public static IRepositoryQuery<T> FieldEmptyIf<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, bool condition) where T : class
         {
             return condition ? query.FieldEmpty(objectPath) : query;
         }
@@ -150,12 +150,12 @@ namespace Foundatio.Repositories
             return condition ? query.FieldHasValue(field) : query;
         }
 
-        public static IRepositoryQuery<T> FieldHasValue<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath) where T : class
+        public static IRepositoryQuery<T> FieldHasValue<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Operator = ComparisonOperator.HasValue });
         }
 
-        public static IRepositoryQuery<T> FieldHasValueIf<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, bool condition) where T : class
+        public static IRepositoryQuery<T> FieldHasValueIf<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, bool condition) where T : class
         {
             return condition ? query.FieldHasValue(objectPath) : query;
         }
@@ -192,23 +192,23 @@ namespace Foundatio.Repositories
             return condition ? query.FieldEquals(field, value) : query;
         }
 
-        public static IRepositoryQuery<T> FieldEquals<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
+        public static IRepositoryQuery<T> FieldEquals<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.Equals });
         }
 
-        public static IRepositoryQuery<T> FieldEquals<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, params object[] values) where T : class
+        public static IRepositoryQuery<T> FieldEquals<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, params object[] values) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = values, Operator = ComparisonOperator.Equals });
         }
 
-        public static IRepositoryQuery<TModel> FieldEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldEquals(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldEquals(objectPath, value) : query;
         }
@@ -239,23 +239,23 @@ namespace Foundatio.Repositories
             return condition ? query.FieldNotEquals(field, value) : query;
         }
 
-        public static IRepositoryQuery<T> FieldNotEquals<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
+        public static IRepositoryQuery<T> FieldNotEquals<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.NotEquals });
         }
 
-        public static IRepositoryQuery<T> FieldNotEquals<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, params object[] values) where T : class
+        public static IRepositoryQuery<T> FieldNotEquals<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, params object[] values) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = values, Operator = ComparisonOperator.NotEquals });
         }
 
-        public static IRepositoryQuery<TModel> FieldNotEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldNotEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldNotEquals(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldNotEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldNotEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldNotEquals(objectPath, value) : query;
         }
@@ -264,18 +264,18 @@ namespace Foundatio.Repositories
         /// Strictly greater than comparison. Generates <c>DateRangeQuery</c> (DateTime/DateTimeOffset),
         /// <c>NumericRangeQuery</c> (numeric types), or <c>TermRangeQuery</c> (string).
         /// </summary>
-        public static IRepositoryQuery<T> FieldGreaterThan<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
+        public static IRepositoryQuery<T> FieldGreaterThan<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.GreaterThan });
         }
 
-        public static IRepositoryQuery<TModel> FieldGreaterThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldGreaterThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldGreaterThan(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldGreaterThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldGreaterThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldGreaterThan(objectPath, value) : query;
         }
@@ -283,18 +283,18 @@ namespace Foundatio.Repositories
         /// <summary>
         /// Greater than or equal comparison.
         /// </summary>
-        public static IRepositoryQuery<T> FieldGreaterThanOrEqual<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
+        public static IRepositoryQuery<T> FieldGreaterThanOrEqual<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.GreaterThanOrEqual });
         }
 
-        public static IRepositoryQuery<TModel> FieldGreaterThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldGreaterThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldGreaterThanOrEqual(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldGreaterThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldGreaterThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldGreaterThanOrEqual(objectPath, value) : query;
         }
@@ -302,18 +302,18 @@ namespace Foundatio.Repositories
         /// <summary>
         /// Strictly less than comparison.
         /// </summary>
-        public static IRepositoryQuery<T> FieldLessThan<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
+        public static IRepositoryQuery<T> FieldLessThan<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.LessThan });
         }
 
-        public static IRepositoryQuery<TModel> FieldLessThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldLessThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldLessThan(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldLessThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldLessThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldLessThan(objectPath, value) : query;
         }
@@ -321,18 +321,18 @@ namespace Foundatio.Repositories
         /// <summary>
         /// Less than or equal comparison.
         /// </summary>
-        public static IRepositoryQuery<T> FieldLessThanOrEqual<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
+        public static IRepositoryQuery<T> FieldLessThanOrEqual<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.LessThanOrEqual });
         }
 
-        public static IRepositoryQuery<TModel> FieldLessThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldLessThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldLessThanOrEqual(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldLessThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldLessThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object?>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldLessThanOrEqual(objectPath, value) : query;
         }

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldConditionQueryExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldConditionQueryExtensions.cs
@@ -16,7 +16,7 @@ namespace Foundatio.Repositories
         internal const string FieldConditionsKey = "@FieldConditionsKey";
         internal const string FieldConditionGroupsKey = "@FieldConditionGroupsKey";
 
-        public static T FieldCondition<T>(this T query, Field field, ComparisonOperator op, object value) where T : IRepositoryQuery
+        public static T FieldCondition<T>(this T query, Field field, ComparisonOperator op, object? value) where T : IRepositoryQuery
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = field, Value = value, Operator = op });
         }
@@ -26,18 +26,18 @@ namespace Foundatio.Repositories
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = field, Value = values, Operator = op });
         }
 
-        public static TQuery FieldConditionIf<TQuery, TValue>(this TQuery query, Field field, ComparisonOperator op, TValue value = default, Func<TValue, bool> condition = null) where TQuery : IRepositoryQuery
+        public static TQuery FieldConditionIf<TQuery, TValue>(this TQuery query, Field field, ComparisonOperator op, TValue? value = default, Func<TValue?, bool>? condition = null) where TQuery : IRepositoryQuery
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldCondition(field, op, value) : query;
         }
 
-        public static TQuery FieldConditionIf<TQuery, TValue>(this TQuery query, Field field, ComparisonOperator op, TValue value = default, bool condition = true) where TQuery : IRepositoryQuery
+        public static TQuery FieldConditionIf<TQuery, TValue>(this TQuery query, Field field, ComparisonOperator op, TValue? value = default, bool condition = true) where TQuery : IRepositoryQuery
         {
             return condition ? query.FieldCondition(field, op, value) : query;
         }
 
-        public static IRepositoryQuery<T> FieldCondition<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, ComparisonOperator op, object value) where T : class
+        public static IRepositoryQuery<T> FieldCondition<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, ComparisonOperator op, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = op });
         }
@@ -47,13 +47,13 @@ namespace Foundatio.Repositories
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = values, Operator = op });
         }
 
-        public static IRepositoryQuery<TModel> FieldConditionIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, ComparisonOperator op, TValue value = default, Func<TValue, bool> condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldConditionIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, ComparisonOperator op, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldCondition(objectPath, op, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldConditionIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, ComparisonOperator op, TValue value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldConditionIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, ComparisonOperator op, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldCondition(objectPath, op, value) : query;
         }
@@ -68,7 +68,7 @@ namespace Foundatio.Repositories
         /// <para>Throws <see cref="Foundatio.Repositories.Exceptions.QueryValidationException"/> at build time if the field
         /// is a non-analyzed (keyword) field.</para>
         /// </remarks>
-        public static IRepositoryQuery<T> FieldContains<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object value) where T : class
+        public static IRepositoryQuery<T> FieldContains<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.Contains });
         }
@@ -82,13 +82,13 @@ namespace Foundatio.Repositories
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = values, Operator = ComparisonOperator.Contains });
         }
 
-        public static IRepositoryQuery<TModel> FieldContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, Func<TValue, bool> condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldContains(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldContains(objectPath, value) : query;
         }
@@ -96,7 +96,7 @@ namespace Foundatio.Repositories
         /// <summary>
         /// Negated full-text token match. Generates <c>BoolQuery { MustNot = MatchQuery }</c>.
         /// </summary>
-        public static IRepositoryQuery<T> FieldNotContains<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object value) where T : class
+        public static IRepositoryQuery<T> FieldNotContains<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.NotContains });
         }
@@ -106,13 +106,13 @@ namespace Foundatio.Repositories
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = values, Operator = ComparisonOperator.NotContains });
         }
 
-        public static IRepositoryQuery<TModel> FieldNotContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, Func<TValue, bool> condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldNotContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldNotContains(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldNotContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldNotContainsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldNotContains(objectPath, value) : query;
         }
@@ -171,7 +171,7 @@ namespace Foundatio.Repositories
         /// <para><b>Throws</b> <see cref="Foundatio.Repositories.Exceptions.QueryValidationException"/> at build time if the
         /// field is an analyzed text field with no <c>.keyword</c> sub-field.</para>
         /// </remarks>
-        public static T FieldEquals<T>(this T query, Field field, object value) where T : IRepositoryQuery
+        public static T FieldEquals<T>(this T query, Field field, object? value) where T : IRepositoryQuery
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = field, Value = value, Operator = ComparisonOperator.Equals });
         }
@@ -181,18 +181,18 @@ namespace Foundatio.Repositories
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = field, Value = values, Operator = ComparisonOperator.Equals });
         }
 
-        public static TQuery FieldEqualsIf<TQuery, TValue>(this TQuery query, Field field, TValue value = default, Func<TValue, bool> condition = null) where TQuery : IRepositoryQuery
+        public static TQuery FieldEqualsIf<TQuery, TValue>(this TQuery query, Field field, TValue? value = default, Func<TValue?, bool>? condition = null) where TQuery : IRepositoryQuery
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldEquals(field, value) : query;
         }
 
-        public static TQuery FieldEqualsIf<TQuery, TValue>(this TQuery query, Field field, TValue value = default, bool condition = true) where TQuery : IRepositoryQuery
+        public static TQuery FieldEqualsIf<TQuery, TValue>(this TQuery query, Field field, TValue? value = default, bool condition = true) where TQuery : IRepositoryQuery
         {
             return condition ? query.FieldEquals(field, value) : query;
         }
 
-        public static IRepositoryQuery<T> FieldEquals<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object value) where T : class
+        public static IRepositoryQuery<T> FieldEquals<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.Equals });
         }
@@ -202,13 +202,13 @@ namespace Foundatio.Repositories
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = values, Operator = ComparisonOperator.Equals });
         }
 
-        public static IRepositoryQuery<TModel> FieldEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, Func<TValue, bool> condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldEquals(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldEquals(objectPath, value) : query;
         }
@@ -218,7 +218,7 @@ namespace Foundatio.Repositories
         /// on the non-analyzed (<c>.keyword</c>) field.
         /// Null values are rewritten to <see cref="ComparisonOperator.HasValue"/>.
         /// </summary>
-        public static T FieldNotEquals<T>(this T query, Field field, object value) where T : IRepositoryQuery
+        public static T FieldNotEquals<T>(this T query, Field field, object? value) where T : IRepositoryQuery
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = field, Value = value, Operator = ComparisonOperator.NotEquals });
         }
@@ -228,18 +228,18 @@ namespace Foundatio.Repositories
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = field, Value = values, Operator = ComparisonOperator.NotEquals });
         }
 
-        public static TQuery FieldNotEqualsIf<TQuery, TValue>(this TQuery query, Field field, TValue value = default, Func<TValue, bool> condition = null) where TQuery : IRepositoryQuery
+        public static TQuery FieldNotEqualsIf<TQuery, TValue>(this TQuery query, Field field, TValue? value = default, Func<TValue?, bool>? condition = null) where TQuery : IRepositoryQuery
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldNotEquals(field, value) : query;
         }
 
-        public static TQuery FieldNotEqualsIf<TQuery, TValue>(this TQuery query, Field field, TValue value = default, bool condition = true) where TQuery : IRepositoryQuery
+        public static TQuery FieldNotEqualsIf<TQuery, TValue>(this TQuery query, Field field, TValue? value = default, bool condition = true) where TQuery : IRepositoryQuery
         {
             return condition ? query.FieldNotEquals(field, value) : query;
         }
 
-        public static IRepositoryQuery<T> FieldNotEquals<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object value) where T : class
+        public static IRepositoryQuery<T> FieldNotEquals<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.NotEquals });
         }
@@ -249,13 +249,13 @@ namespace Foundatio.Repositories
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = values, Operator = ComparisonOperator.NotEquals });
         }
 
-        public static IRepositoryQuery<TModel> FieldNotEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, Func<TValue, bool> condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldNotEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldNotEquals(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldNotEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldNotEqualsIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldNotEquals(objectPath, value) : query;
         }
@@ -264,18 +264,18 @@ namespace Foundatio.Repositories
         /// Strictly greater than comparison. Generates <c>DateRangeQuery</c> (DateTime/DateTimeOffset),
         /// <c>NumericRangeQuery</c> (numeric types), or <c>TermRangeQuery</c> (string).
         /// </summary>
-        public static IRepositoryQuery<T> FieldGreaterThan<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object value) where T : class
+        public static IRepositoryQuery<T> FieldGreaterThan<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.GreaterThan });
         }
 
-        public static IRepositoryQuery<TModel> FieldGreaterThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, Func<TValue, bool> condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldGreaterThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldGreaterThan(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldGreaterThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldGreaterThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldGreaterThan(objectPath, value) : query;
         }
@@ -283,18 +283,18 @@ namespace Foundatio.Repositories
         /// <summary>
         /// Greater than or equal comparison.
         /// </summary>
-        public static IRepositoryQuery<T> FieldGreaterThanOrEqual<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object value) where T : class
+        public static IRepositoryQuery<T> FieldGreaterThanOrEqual<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.GreaterThanOrEqual });
         }
 
-        public static IRepositoryQuery<TModel> FieldGreaterThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, Func<TValue, bool> condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldGreaterThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldGreaterThanOrEqual(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldGreaterThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldGreaterThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldGreaterThanOrEqual(objectPath, value) : query;
         }
@@ -302,18 +302,18 @@ namespace Foundatio.Repositories
         /// <summary>
         /// Strictly less than comparison.
         /// </summary>
-        public static IRepositoryQuery<T> FieldLessThan<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object value) where T : class
+        public static IRepositoryQuery<T> FieldLessThan<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.LessThan });
         }
 
-        public static IRepositoryQuery<TModel> FieldLessThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, Func<TValue, bool> condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldLessThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldLessThan(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldLessThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldLessThanIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldLessThan(objectPath, value) : query;
         }
@@ -321,18 +321,18 @@ namespace Foundatio.Repositories
         /// <summary>
         /// Less than or equal comparison.
         /// </summary>
-        public static IRepositoryQuery<T> FieldLessThanOrEqual<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object value) where T : class
+        public static IRepositoryQuery<T> FieldLessThanOrEqual<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, object? value) where T : class
         {
             return query.AddCollectionOptionValue(FieldConditionsKey, new FieldCondition { Field = objectPath, Value = value, Operator = ComparisonOperator.LessThanOrEqual });
         }
 
-        public static IRepositoryQuery<TModel> FieldLessThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, Func<TValue, bool> condition = null) where TModel : class
+        public static IRepositoryQuery<TModel> FieldLessThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, Func<TValue?, bool>? condition = null) where TModel : class
         {
             bool result = condition is null || condition(value);
             return result ? query.FieldLessThanOrEqual(objectPath, value) : query;
         }
 
-        public static IRepositoryQuery<TModel> FieldLessThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue value = default, bool condition = true) where TModel : class
+        public static IRepositoryQuery<TModel> FieldLessThanOrEqualIf<TModel, TValue>(this IRepositoryQuery<TModel> query, Expression<Func<TModel, object>> objectPath, TValue? value = default, bool condition = true) where TModel : class
         {
             return condition ? query.FieldLessThanOrEqual(objectPath, value) : query;
         }

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldConditionsQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldConditionsQueryBuilder.cs
@@ -180,33 +180,35 @@ public class FieldConditionsQueryBuilder : IElasticQueryBuilder
         {
             case ComparisonOperator.Equals:
                 {
+                    var conditionValue = condition.Value ?? throw new QueryValidationException($"Condition value for field '{resolvedField}' cannot be null for Equals operator.");
                     Query eqQuery;
-                    if (condition.Value is IEnumerable and not string)
+                    if (conditionValue is IEnumerable and not string)
                     {
                         var values = new List<FieldValue>();
-                        foreach (var value in (IEnumerable)condition.Value)
+                        foreach (var value in (IEnumerable)conditionValue)
                             values.Add(ToFieldValue(value));
                         eqQuery = new TermsQuery { Field = resolvedField, Terms = new TermsQueryField(values) };
                     }
                     else
                     {
-                        eqQuery = new TermQuery { Field = resolvedField, Value = ToFieldValue(condition.Value!) };
+                        eqQuery = new TermQuery { Field = resolvedField, Value = ToFieldValue(conditionValue) };
                     }
                     return eqQuery;
                 }
             case ComparisonOperator.NotEquals:
                 {
+                    var conditionValue = condition.Value ?? throw new QueryValidationException($"Condition value for field '{resolvedField}' cannot be null for NotEquals operator.");
                     Query neQuery;
-                    if (condition.Value is IEnumerable and not string)
+                    if (conditionValue is IEnumerable and not string)
                     {
                         var values = new List<FieldValue>();
-                        foreach (var value in (IEnumerable)condition.Value)
+                        foreach (var value in (IEnumerable)conditionValue)
                             values.Add(ToFieldValue(value));
                         neQuery = new TermsQuery { Field = resolvedField, Terms = new TermsQueryField(values) };
                     }
                     else
                     {
-                        neQuery = new TermQuery { Field = resolvedField, Value = ToFieldValue(condition.Value!) };
+                        neQuery = new TermQuery { Field = resolvedField, Value = ToFieldValue(conditionValue) };
                     }
                     return new BoolQuery { MustNot = new Query[] { neQuery } };
                 }
@@ -258,7 +260,8 @@ public class FieldConditionsQueryBuilder : IElasticQueryBuilder
             case ComparisonOperator.GreaterThanOrEqual:
             case ComparisonOperator.LessThan:
             case ComparisonOperator.LessThanOrEqual:
-                return BuildRangeQuery(resolvedField, condition.Operator, condition.Value!);
+                var rangeValue = condition.Value ?? throw new QueryValidationException($"Condition value for field '{resolvedField}' cannot be null for range operator.");
+                return BuildRangeQuery(resolvedField, condition.Operator, rangeValue);
             default:
                 throw new ArgumentOutOfRangeException(nameof(condition.Operator), condition.Operator, "Unknown comparison operator.");
         }

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldConditionsQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldConditionsQueryBuilder.cs
@@ -190,7 +190,7 @@ public class FieldConditionsQueryBuilder : IElasticQueryBuilder
                     }
                     else
                     {
-                        eqQuery = new TermQuery { Field = resolvedField, Value = ToFieldValue(condition.Value) };
+                        eqQuery = new TermQuery { Field = resolvedField, Value = ToFieldValue(condition.Value!) };
                     }
                     return eqQuery;
                 }
@@ -206,7 +206,7 @@ public class FieldConditionsQueryBuilder : IElasticQueryBuilder
                     }
                     else
                     {
-                        neQuery = new TermQuery { Field = resolvedField, Value = ToFieldValue(condition.Value) };
+                        neQuery = new TermQuery { Field = resolvedField, Value = ToFieldValue(condition.Value!) };
                     }
                     return new BoolQuery { MustNot = new Query[] { neQuery } };
                 }
@@ -258,6 +258,9 @@ public class FieldConditionsQueryBuilder : IElasticQueryBuilder
             case ComparisonOperator.GreaterThanOrEqual:
             case ComparisonOperator.LessThan:
             case ComparisonOperator.LessThanOrEqual:
+                if (condition.Value is null)
+                    throw new ArgumentException($"Value is required for {condition.Operator} operator on field '{resolvedField}'.");
+
                 return BuildRangeQuery(resolvedField, condition.Operator, condition.Value);
             default:
                 throw new ArgumentOutOfRangeException(nameof(condition.Operator), condition.Operator, "Unknown comparison operator.");
@@ -383,7 +386,7 @@ public class FieldConditionsQueryBuilder : IElasticQueryBuilder
         return query;
     }
 
-    private static async Task<Query> TranslateGroupAsync<T>(
+    private static async Task<Query?> TranslateGroupAsync<T>(
         FieldConditionGroup group, ElasticMappingResolver resolver, QueryBuilderContext<T> ctx) where T : class, new()
     {
         var clauses = new List<Query>();

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldConditionsQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldConditionsQueryBuilder.cs
@@ -258,10 +258,7 @@ public class FieldConditionsQueryBuilder : IElasticQueryBuilder
             case ComparisonOperator.GreaterThanOrEqual:
             case ComparisonOperator.LessThan:
             case ComparisonOperator.LessThanOrEqual:
-                if (condition.Value is null)
-                    throw new ArgumentException($"Value is required for {condition.Operator} operator on field '{resolvedField}'.");
-
-                return BuildRangeQuery(resolvedField, condition.Operator, condition.Value);
+                return BuildRangeQuery(resolvedField, condition.Operator, condition.Value!);
             default:
                 throw new ArgumentOutOfRangeException(nameof(condition.Operator), condition.Operator, "Unknown comparison operator.");
         }
@@ -425,13 +422,17 @@ public class FieldConditionsQueryBuilder : IElasticQueryBuilder
 
         if (ctx is IQueryVisitorContextWithFieldResolver { FieldResolver: not null } fieldResolverCtx)
         {
-            string customResolved = await fieldResolverCtx.FieldResolver(resolved, ctx).AnyContext();
+            string? customResolved = await fieldResolverCtx.FieldResolver(resolved, ctx).AnyContext();
             if (!String.IsNullOrWhiteSpace(customResolved))
                 resolved = customResolved;
         }
 
         if (nonAnalyzed)
-            resolved = resolver.GetNonAnalyzedFieldName(resolved);
+        {
+            string? nonAnalyzedField = resolver.GetNonAnalyzedFieldName(resolved);
+            if (nonAnalyzedField is not null)
+                resolved = nonAnalyzedField;
+        }
 
         return resolved;
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldConditionsQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldConditionsQueryBuilder.cs
@@ -254,6 +254,9 @@ public class FieldConditionsQueryBuilder : IElasticQueryBuilder
             case ComparisonOperator.GreaterThanOrEqual:
             case ComparisonOperator.LessThan:
             case ComparisonOperator.LessThanOrEqual:
+                if (condition.Value is null)
+                    throw new ArgumentException($"Value is required for {condition.Operator} operator on field '{resolvedField}'.");
+
                 return BuildRangeQuery(resolvedField, condition.Operator, condition.Value);
             default:
                 throw new ArgumentOutOfRangeException(nameof(condition.Operator), condition.Operator, "Unknown comparison operator.");
@@ -402,7 +405,7 @@ public class FieldConditionsQueryBuilder : IElasticQueryBuilder
         return query;
     }
 
-    private static async Task<QueryContainer> TranslateGroupAsync<T>(
+    private static async Task<QueryContainer?> TranslateGroupAsync<T>(
         FieldConditionGroup group, ElasticMappingResolver resolver, QueryBuilderContext<T> ctx) where T : class, new()
     {
         var clauses = new List<QueryContainer>();

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldIncludesQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldIncludesQueryBuilder.cs
@@ -40,19 +40,19 @@ namespace Foundatio.Repositories
         }
 
         /// <inheritdoc cref="Include{T}(T, Field)"/>
-        public static IRepositoryQuery Include<T>(this IRepositoryQuery query, Expression<Func<T, object>> objectPath)
+        public static IRepositoryQuery Include<T>(this IRepositoryQuery query, Expression<Func<T, object?>> objectPath)
         {
             return query.AddCollectionOptionValue<IRepositoryQuery, Field>(IncludesKey, objectPath);
         }
 
         /// <inheritdoc cref="Include{T}(T, Field)"/>
-        public static IRepositoryQuery<T> Include<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath) where T : class
+        public static IRepositoryQuery<T> Include<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath) where T : class
         {
             return query.AddCollectionOptionValue<IRepositoryQuery<T>, Field>(IncludesKey, objectPath);
         }
 
         /// <inheritdoc cref="Include{T}(T, Field)"/>
-        public static IRepositoryQuery<T> Include<T>(this IRepositoryQuery<T> query, params Expression<Func<T, object>>[] objectPaths) where T : class
+        public static IRepositoryQuery<T> Include<T>(this IRepositoryQuery<T> query, params Expression<Func<T, object?>>[] objectPaths) where T : class
         {
             if (objectPaths.Length is 0)
                 return query;
@@ -106,13 +106,13 @@ namespace Foundatio.Repositories
         }
 
         /// <inheritdoc cref="Exclude{T}(T, Field)"/>
-        public static IRepositoryQuery<T> Exclude<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath) where T : class
+        public static IRepositoryQuery<T> Exclude<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath) where T : class
         {
             return query.AddCollectionOptionValue<IRepositoryQuery<T>, Field>(ExcludesKey, objectPath);
         }
 
         /// <inheritdoc cref="Exclude{T}(T, Field)"/>
-        public static IRepositoryQuery<T> Exclude<T>(this IRepositoryQuery<T> query, params Expression<Func<T, object>>[] objectPaths) where T : class
+        public static IRepositoryQuery<T> Exclude<T>(this IRepositoryQuery<T> query, params Expression<Func<T, object?>>[] objectPaths) where T : class
         {
             if (objectPaths.Length is 0)
                 return query;
@@ -167,19 +167,19 @@ namespace Foundatio.Repositories
         }
 
         /// <inheritdoc cref="Include{T}(T, Field)"/>
-        public static ICommandOptions Include<T>(this ICommandOptions options, Expression<Func<T, object>> objectPath)
+        public static ICommandOptions Include<T>(this ICommandOptions options, Expression<Func<T, object?>> objectPath)
         {
             return options.AddCollectionOptionValue<ICommandOptions, Field>(IncludesKey, objectPath);
         }
 
         /// <inheritdoc cref="Include{T}(T, Field)"/>
-        public static ICommandOptions<T> Include<T>(this ICommandOptions<T> options, Expression<Func<T, object>> objectPath) where T : class
+        public static ICommandOptions<T> Include<T>(this ICommandOptions<T> options, Expression<Func<T, object?>> objectPath) where T : class
         {
             return options.AddCollectionOptionValue<ICommandOptions<T>, Field>(IncludesKey, objectPath);
         }
 
         /// <inheritdoc cref="Include{T}(T, Field)"/>
-        public static ICommandOptions<T> Include<T>(this ICommandOptions<T> options, params Expression<Func<T, object>>[] objectPaths) where T : class
+        public static ICommandOptions<T> Include<T>(this ICommandOptions<T> options, params Expression<Func<T, object?>>[] objectPaths) where T : class
         {
             if (objectPaths.Length is 0)
                 return options;
@@ -223,13 +223,13 @@ namespace Foundatio.Repositories
         }
 
         /// <inheritdoc cref="Exclude{T}(T, Field)"/>
-        public static ICommandOptions<T> Exclude<T>(this ICommandOptions<T> options, Expression<Func<T, object>> objectPath) where T : class
+        public static ICommandOptions<T> Exclude<T>(this ICommandOptions<T> options, Expression<Func<T, object?>> objectPath) where T : class
         {
             return options.AddCollectionOptionValue<ICommandOptions<T>, Field>(ExcludesKey, objectPath);
         }
 
         /// <inheritdoc cref="Exclude{T}(T, Field)"/>
-        public static ICommandOptions<T> Exclude<T>(this ICommandOptions<T> options, params Expression<Func<T, object>>[] objectPaths) where T : class
+        public static ICommandOptions<T> Exclude<T>(this ICommandOptions<T> options, params Expression<Func<T, object?>>[] objectPaths) where T : class
         {
             if (objectPaths.Length is 0)
                 return options;

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldIncludesQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldIncludesQueryBuilder.cs
@@ -71,8 +71,14 @@ namespace Foundatio.Repositories
         /// (e.g., <c>"id,address(street,city)"</c> expands to <c>id</c>, <c>address.street</c>, <c>address.city</c>).
         /// The parsed fields are merged with any individually added via <see cref="Include{T}(T, Field)"/>.
         /// </summary>
-        public static T IncludeMask<T>(this T options, string maskExpression) where T : IRepositoryQuery
+        public static T IncludeMask<T>(this T options, string? maskExpression) where T : IRepositoryQuery
         {
+            if (String.IsNullOrEmpty(maskExpression))
+            {
+                options.Values.Remove(IncludesMaskKey);
+                return options;
+            }
+
             return options.BuildOption(IncludesMaskKey, maskExpression);
         }
 

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldIncludesQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldIncludesQueryBuilder.cs
@@ -70,8 +70,14 @@ namespace Foundatio.Repositories
         /// (e.g., <c>"id,address(street,city)"</c> expands to <c>id</c>, <c>address.street</c>, <c>address.city</c>).
         /// The parsed fields are merged with any individually added via <see cref="Include{T}(T, Field)"/>.
         /// </summary>
-        public static T IncludeMask<T>(this T options, string maskExpression) where T : IRepositoryQuery
+        public static T IncludeMask<T>(this T options, string? maskExpression) where T : IRepositoryQuery
         {
+            if (String.IsNullOrEmpty(maskExpression))
+            {
+                options.Values.Remove(IncludesMaskKey);
+                return options;
+            }
+
             return options.BuildOption(IncludesMaskKey, maskExpression);
         }
 

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/IElasticQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/IElasticQueryBuilder.cs
@@ -20,7 +20,7 @@ public interface IElasticQueryBuilder
 
 public class QueryBuilderContext<T> : IQueryBuilderContext, IElasticQueryVisitorContext, IQueryVisitorContextWithFieldResolver, IQueryVisitorContextWithIncludeResolver, IQueryVisitorContextWithValidation where T : class, new()
 {
-    public QueryBuilderContext(IRepositoryQuery source, ICommandOptions options, SearchDescriptor<T> search = null, IQueryBuilderContext parentContext = null)
+    public QueryBuilderContext(IRepositoryQuery source, ICommandOptions options, SearchDescriptor<T>? search = null, IQueryBuilderContext? parentContext = null)
     {
         Source = source;
         Options = options;
@@ -38,29 +38,29 @@ public class QueryBuilderContext<T> : IQueryBuilderContext, IElasticQueryVisitor
         }
     }
 
-    public IQueryBuilderContext Parent { get; }
+    public IQueryBuilderContext? Parent { get; }
     public IRepositoryQuery Source { get; }
     public ICommandOptions Options { get; }
-    public QueryContainer Query { get; set; }
-    public QueryContainer Filter { get; set; }
+    public QueryContainer Query { get; set; } = null!;
+    public QueryContainer Filter { get; set; } = null!;
     public SearchDescriptor<T> Search { get; }
     public IDictionary<string, object> Data { get; } = new Dictionary<string, object>();
-    public QueryValidationOptions ValidationOptions { get; set; }
-    public QueryValidationResult ValidationResult { get; set; }
-    QueryFieldResolver IQueryVisitorContextWithFieldResolver.FieldResolver { get; set; }
-    IncludeResolver IQueryVisitorContextWithIncludeResolver.IncludeResolver { get; set; }
-    ElasticMappingResolver IElasticQueryVisitorContext.MappingResolver { get; set; }
+    public QueryValidationOptions ValidationOptions { get; set; } = null!;
+    public QueryValidationResult ValidationResult { get; set; } = null!;
+    QueryFieldResolver IQueryVisitorContextWithFieldResolver.FieldResolver { get; set; } = null!;
+    IncludeResolver IQueryVisitorContextWithIncludeResolver.IncludeResolver { get; set; } = null!;
+    ElasticMappingResolver IElasticQueryVisitorContext.MappingResolver { get; set; } = null!;
     ICollection<ElasticRuntimeField> IElasticQueryVisitorContext.RuntimeFields { get; } = new List<ElasticRuntimeField>();
     bool? IElasticQueryVisitorContext.EnableRuntimeFieldResolver { get; set; }
-    RuntimeFieldResolver IElasticQueryVisitorContext.RuntimeFieldResolver { get; set; }
+    RuntimeFieldResolver IElasticQueryVisitorContext.RuntimeFieldResolver { get; set; } = null!;
 
     GroupOperator IQueryVisitorContext.DefaultOperator { get; set; }
-    Func<Task<string>> IElasticQueryVisitorContext.DefaultTimeZone { get; set; }
+    Func<Task<string>>? IElasticQueryVisitorContext.DefaultTimeZone { get; set; }
     bool IElasticQueryVisitorContext.UseScoring { get; set; }
-    string[] IQueryVisitorContext.DefaultFields { get; set; }
-    string IQueryVisitorContext.QueryType { get; set; }
+    string[]? IQueryVisitorContext.DefaultFields { get; set; }
+    string? IQueryVisitorContext.QueryType { get; set; }
 
-    private DateRange GetDateRange()
+    private DateRange? GetDateRange()
     {
         foreach (var dateRange in Source.GetDateRanges())
         {
@@ -74,7 +74,7 @@ public class QueryBuilderContext<T> : IQueryBuilderContext, IElasticQueryVisitor
 
 public interface IQueryBuilderContext
 {
-    IQueryBuilderContext Parent { get; }
+    IQueryBuilderContext? Parent { get; }
     IRepositoryQuery Source { get; }
     ICommandOptions Options { get; }
     QueryContainer Query { get; set; }
@@ -100,13 +100,13 @@ public static class QueryBuilderContextExtensions
         elasticContext.DefaultTimeZone = () => Task.FromResult(timeZone);
     }
 
-    public static Task<string> GetTimeZoneAsync(this IQueryBuilderContext context)
+    public static async Task<string?> GetTimeZoneAsync(this IQueryBuilderContext context)
     {
         var elasticContext = context as IElasticQueryVisitorContext;
-        if (elasticContext?.DefaultTimeZone != null)
-            return elasticContext.DefaultTimeZone.Invoke();
+        if (elasticContext?.DefaultTimeZone is not null)
+            return await elasticContext.DefaultTimeZone.Invoke();
 
-        return Task.FromResult<string>(null);
+        return null;
     }
 }
 

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/IElasticQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/IElasticQueryBuilder.cs
@@ -106,7 +106,7 @@ public static class QueryBuilderContextExtensions
     {
         var elasticContext = context as IElasticQueryVisitorContext;
         if (elasticContext?.DefaultTimeZone is not null)
-            return await elasticContext.DefaultTimeZone.Invoke();
+            return await elasticContext.DefaultTimeZone.Invoke().AnyContext();
 
         return null;
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/IElasticQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/IElasticQueryBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
@@ -21,7 +21,7 @@ public interface IElasticQueryBuilder
 
 public class QueryBuilderContext<T> : IQueryBuilderContext, IElasticQueryVisitorContext, IQueryVisitorContextWithFieldResolver, IQueryVisitorContextWithIncludeResolver, IQueryVisitorContextWithValidation where T : class, new()
 {
-    public QueryBuilderContext(IRepositoryQuery source, ICommandOptions options, SearchRequestDescriptor<T>? search = null, IQueryBuilderContext parentContext = null)
+    public QueryBuilderContext(IRepositoryQuery source, ICommandOptions options, SearchRequestDescriptor<T>? search = null, IQueryBuilderContext? parentContext = null)
     {
         Source = source;
         Options = options;
@@ -39,30 +39,30 @@ public class QueryBuilderContext<T> : IQueryBuilderContext, IElasticQueryVisitor
         }
     }
 
-    public IQueryBuilderContext Parent { get; }
+    public IQueryBuilderContext? Parent { get; }
     public IRepositoryQuery Source { get; }
     public ICommandOptions Options { get; }
-    public Query Query { get; set; }
-    public Query Filter { get; set; }
+    public Query Query { get; set; } = null!;
+    public Query Filter { get; set; } = null!;
     public SearchRequestDescriptor<T> Search { get; }
     public IDictionary<string, object> Data { get; } = new Dictionary<string, object>();
-    public QueryValidationOptions ValidationOptions { get; set; }
-    public QueryValidationResult ValidationResult { get; set; }
-    QueryFieldResolver IQueryVisitorContextWithFieldResolver.FieldResolver { get; set; }
-    IncludeResolver IQueryVisitorContextWithIncludeResolver.IncludeResolver { get; set; }
-    ElasticMappingResolver IElasticQueryVisitorContext.MappingResolver { get; set; }
+    public QueryValidationOptions ValidationOptions { get; set; } = null!;
+    public QueryValidationResult ValidationResult { get; set; } = null!;
+    QueryFieldResolver IQueryVisitorContextWithFieldResolver.FieldResolver { get; set; } = null!;
+    IncludeResolver IQueryVisitorContextWithIncludeResolver.IncludeResolver { get; set; } = null!;
+    ElasticMappingResolver IElasticQueryVisitorContext.MappingResolver { get; set; } = null!;
     ICollection<ElasticRuntimeField> IElasticQueryVisitorContext.RuntimeFields { get; } = new List<ElasticRuntimeField>();
     bool? IElasticQueryVisitorContext.EnableRuntimeFieldResolver { get; set; }
-    RuntimeFieldResolver IElasticQueryVisitorContext.RuntimeFieldResolver { get; set; }
-    Func<string, Task<string>> IElasticQueryVisitorContext.GeoLocationResolver { get; set; }
+    RuntimeFieldResolver IElasticQueryVisitorContext.RuntimeFieldResolver { get; set; } = null!;
+    Func<string, Task<string>>? IElasticQueryVisitorContext.GeoLocationResolver { get; set; }
 
     GroupOperator IQueryVisitorContext.DefaultOperator { get; set; }
-    Func<Task<string>> IElasticQueryVisitorContext.DefaultTimeZone { get; set; }
+    Func<Task<string>>? IElasticQueryVisitorContext.DefaultTimeZone { get; set; }
     bool IElasticQueryVisitorContext.UseScoring { get; set; }
-    string[] IQueryVisitorContext.DefaultFields { get; set; }
-    string IQueryVisitorContext.QueryType { get; set; }
+    string[]? IQueryVisitorContext.DefaultFields { get; set; }
+    string? IQueryVisitorContext.QueryType { get; set; }
 
-    private DateRange GetDateRange()
+    private DateRange? GetDateRange()
     {
         foreach (var dateRange in Source.GetDateRanges())
         {
@@ -76,7 +76,7 @@ public class QueryBuilderContext<T> : IQueryBuilderContext, IElasticQueryVisitor
 
 public interface IQueryBuilderContext
 {
-    IQueryBuilderContext Parent { get; }
+    IQueryBuilderContext? Parent { get; }
     IRepositoryQuery Source { get; }
     ICommandOptions Options { get; }
     Query Query { get; set; }
@@ -102,13 +102,13 @@ public static class QueryBuilderContextExtensions
         elasticContext.DefaultTimeZone = () => Task.FromResult(timeZone);
     }
 
-    public static Task<string> GetTimeZoneAsync(this IQueryBuilderContext context)
+    public static async Task<string?> GetTimeZoneAsync(this IQueryBuilderContext context)
     {
         var elasticContext = context as IElasticQueryVisitorContext;
-        if (elasticContext?.DefaultTimeZone != null)
-            return elasticContext.DefaultTimeZone.Invoke();
+        if (elasticContext?.DefaultTimeZone is not null)
+            return await elasticContext.DefaultTimeZone.Invoke();
 
-        return Task.FromResult<string>(null);
+        return null;
     }
 }
 

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ParentQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ParentQueryBuilder.cs
@@ -91,7 +91,7 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
                     if (parentQuery.GetDocumentType() == typeof(object))
                         parentQuery.DocumentType(ctx.Options.ParentDocumentType());
 
-                    var parentContext = new QueryBuilderContext<object>(parentQuery, parentOptions, null);
+                    var parentContext = new QueryBuilderContext<object>(parentQuery, parentOptions);
 
                     await index.QueryBuilder.BuildAsync(parentContext);
 

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
@@ -38,8 +38,9 @@ namespace Foundatio.Repositories
             options.SearchAfterPaging();
             if (!String.IsNullOrEmpty(searchAfterToken))
             {
-                object[] values = FindHitExtensions.DecodeSortToken(searchAfterToken);
-                options.Values.Set(SearchAfterKey, values);
+                object[]? values = FindHitExtensions.DecodeSortToken(searchAfterToken);
+                if (values is not null)
+                    options.Values.Set(SearchAfterKey, values);
             }
             else
             {
@@ -69,8 +70,9 @@ namespace Foundatio.Repositories
             options.SearchAfterPaging();
             if (!String.IsNullOrEmpty(searchBeforeToken))
             {
-                object[] values = FindHitExtensions.DecodeSortToken(searchBeforeToken);
-                options.Values.Set(SearchBeforeKey, values);
+                object[]? values = FindHitExtensions.DecodeSortToken(searchBeforeToken);
+                if (values is not null)
+                    options.Values.Set(SearchBeforeKey, values);
             }
             else
             {

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
@@ -42,8 +42,9 @@ namespace Foundatio.Repositories
             options.SearchAfterPaging();
             if (!String.IsNullOrEmpty(searchAfterToken))
             {
-                object[] values = FindHitExtensions.DecodeSortToken(searchAfterToken, serializer);
-                options.Values.Set(SearchAfterKey, values);
+                object[]? values = FindHitExtensions.DecodeSortToken(searchAfterToken, serializer);
+                if (values is not null)
+                    options.Values.Set(SearchAfterKey, values);
             }
             else
             {
@@ -73,8 +74,9 @@ namespace Foundatio.Repositories
             options.SearchAfterPaging();
             if (!String.IsNullOrEmpty(searchBeforeToken))
             {
-                object[] values = FindHitExtensions.DecodeSortToken(searchBeforeToken, serializer);
-                options.Values.Set(SearchBeforeKey, values);
+                object[]? values = FindHitExtensions.DecodeSortToken(searchBeforeToken, serializer);
+                if (values is not null)
+                    options.Values.Set(SearchBeforeKey, values);
             }
             else
             {
@@ -133,7 +135,7 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
         public Task BuildAsync<T>(QueryBuilderContext<T> ctx) where T : class, new()
         {
             // Get sorts from context data (set by SortQueryBuilder or ExpressionQueryBuilder)
-            List<SortOptions> sortFields = null;
+            List<SortOptions>? sortFields = null;
             if (ctx.Data.TryGetValue(SortQueryBuilder.SortFieldsKey, out var sortsObj) && sortsObj is List<SortOptions> sorts)
             {
                 sortFields = sorts;
@@ -164,7 +166,7 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
                 // Reverse sort orders if searching before
                 if (ctx.Options.HasSearchBefore())
                 {
-                    sortFields = sortFields.Select(s => s.ReverseOrder()).ToList();
+                    sortFields = sortFields.Select(s => s.ReverseOrder()!).ToList();
                 }
             }
 

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SortQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SortQueryBuilder.cs
@@ -29,17 +29,17 @@ namespace Foundatio.Repositories
             return query.Sort(field, SortOrder.Asc);
         }
 
-        public static IRepositoryQuery<T> Sort<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath, SortOrder? order = null) where T : class
+        public static IRepositoryQuery<T> Sort<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath, SortOrder? order = null) where T : class
         {
             return query.AddCollectionOptionValue<IRepositoryQuery<T>, SortOptions>(SortsKey, new FieldSort { Field = objectPath, Order = order });
         }
 
-        public static IRepositoryQuery<T> SortDescending<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath) where T : class
+        public static IRepositoryQuery<T> SortDescending<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath) where T : class
         {
             return query.Sort(objectPath, SortOrder.Desc);
         }
 
-        public static IRepositoryQuery<T> SortAscending<T>(this IRepositoryQuery<T> query, Expression<Func<T, object>> objectPath) where T : class
+        public static IRepositoryQuery<T> SortAscending<T>(this IRepositoryQuery<T> query, Expression<Func<T, object?>> objectPath) where T : class
         {
             return query.Sort(objectPath, SortOrder.Asc);
         }

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/BulkResult.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/BulkResult.cs
@@ -50,11 +50,11 @@ internal sealed record BulkResult
         var validItems = response.Items.Where(i => i.IsValid && i.Id is not null).ToList();
         return new BulkResult
         {
-            SuccessfulIds = validItems.Select(i => i.Id!).ToHashSet(),
-            NoopIds = validItems.Where(i => String.Equals(i.Result, "noop", StringComparison.Ordinal)).Select(i => i.Id!).ToHashSet(),
-            ConflictIds = errors.Where(e => e.Status is 409 && e.Id is not null).Select(e => e.Id!).ToHashSet(),
-            RetryableIds = errors.Where(e => e.Status is 429 or 503 && e.Id is not null).Select(e => e.Id!).ToHashSet(),
-            FatalIds = errors.Where(e => e.Status is not 409 and not 429 and not 503 && e.Id is not null).Select(e => e.Id!).ToHashSet()
+            SuccessfulIds = validItems.Select(i => i.Id).OfType<string>().ToHashSet(),
+            NoopIds = validItems.Where(i => String.Equals(i.Result, "noop", StringComparison.Ordinal)).Select(i => i.Id).OfType<string>().ToHashSet(),
+            ConflictIds = errors.Where(e => e.Status is 409 && e.Id is not null).Select(e => e.Id).OfType<string>().ToHashSet(),
+            RetryableIds = errors.Where(e => e.Status is 429 or 503 && e.Id is not null).Select(e => e.Id).OfType<string>().ToHashSet(),
+            FatalIds = errors.Where(e => e.Status is not 409 and not 429 and not 503 && e.Id is not null).Select(e => e.Id).OfType<string>().ToHashSet()
         };
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/BulkResult.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/BulkResult.cs
@@ -20,8 +20,8 @@ internal sealed record BulkResult
 
     public long ModifiedCount => SuccessfulIds.Count - NoopIds.Count;
 
-    public string TransportError { get; init; }
-    public Exception TransportException { get; init; }
+    public string? TransportError { get; init; }
+    public Exception? TransportException { get; init; }
 
     public bool HasTransportError => TransportError is not null;
 

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/BulkResult.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/BulkResult.cs
@@ -21,8 +21,8 @@ internal sealed record BulkResult
 
     public long ModifiedCount => SuccessfulIds.Count - NoopIds.Count;
 
-    public string TransportError { get; init; }
-    public Exception TransportException { get; init; }
+    public string? TransportError { get; init; }
+    public Exception? TransportException { get; init; }
 
     public bool HasTransportError => TransportError is not null;
 
@@ -50,11 +50,11 @@ internal sealed record BulkResult
         var validItems = response.Items.Where(i => i.IsValid).ToList();
         return new BulkResult
         {
-            SuccessfulIds = validItems.Select(i => i.Id).ToHashSet(),
-            NoopIds = validItems.Where(i => String.Equals(i.Result, "noop", StringComparison.Ordinal)).Select(i => i.Id).ToHashSet(),
-            ConflictIds = errors.Where(e => e.Status is 409).Select(e => e.Id).ToHashSet(),
-            RetryableIds = errors.Where(e => e.Status is 429 or 503).Select(e => e.Id).ToHashSet(),
-            FatalIds = errors.Where(e => e.Status is not 409 and not 429 and not 503).Select(e => e.Id).ToHashSet()
+            SuccessfulIds = validItems.Select(i => i.Id!).ToHashSet(),
+            NoopIds = validItems.Where(i => String.Equals(i.Result, "noop", StringComparison.Ordinal)).Select(i => i.Id!).ToHashSet(),
+            ConflictIds = errors.Where(e => e.Status is 409).Select(e => e.Id!).ToHashSet(),
+            RetryableIds = errors.Where(e => e.Status is 429 or 503).Select(e => e.Id!).ToHashSet(),
+            FatalIds = errors.Where(e => e.Status is not 409 and not 429 and not 503).Select(e => e.Id!).ToHashSet()
         };
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/BulkResult.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/BulkResult.cs
@@ -47,14 +47,14 @@ internal sealed record BulkResult
         }
 
         var errors = response.ItemsWithErrors.ToList();
-        var validItems = response.Items.Where(i => i.IsValid).ToList();
+        var validItems = response.Items.Where(i => i.IsValid && i.Id is not null).ToList();
         return new BulkResult
         {
             SuccessfulIds = validItems.Select(i => i.Id!).ToHashSet(),
             NoopIds = validItems.Where(i => String.Equals(i.Result, "noop", StringComparison.Ordinal)).Select(i => i.Id!).ToHashSet(),
-            ConflictIds = errors.Where(e => e.Status is 409).Select(e => e.Id!).ToHashSet(),
-            RetryableIds = errors.Where(e => e.Status is 429 or 503).Select(e => e.Id!).ToHashSet(),
-            FatalIds = errors.Where(e => e.Status is not 409 and not 429 and not 503).Select(e => e.Id!).ToHashSet()
+            ConflictIds = errors.Where(e => e.Status is 409 && e.Id is not null).Select(e => e.Id!).ToHashSet(),
+            RetryableIds = errors.Where(e => e.Status is 429 or 503 && e.Id is not null).Select(e => e.Id!).ToHashSet(),
+            FatalIds = errors.Where(e => e.Status is not 409 and not 429 and not 503 && e.Id is not null).Select(e => e.Id!).ToHashSet()
         };
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticDocumentVersion.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticDocumentVersion.cs
@@ -20,7 +20,7 @@ public struct ElasticDocumentVersion : IEquatable<ElasticDocumentVersion>, IComp
 
     public override string ToString() => $"{PrimaryTerm}:{SequenceNumber}";
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (obj is ElasticDocumentVersion version)
             return Equals(version);
@@ -87,7 +87,7 @@ public struct ElasticDocumentVersion : IEquatable<ElasticDocumentVersion>, IComp
         return SequenceNumber.CompareTo(other.SequenceNumber);
     }
 
-    public int CompareTo(object obj)
+    public int CompareTo(object? obj)
     {
         if (ReferenceEquals(null, obj))
             return 1;

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -623,16 +623,6 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return response.Total > 0;
     }
 
-    public virtual Task<FindResults<T>> SearchAsync(ISystemFilter systemFilter, string? filter = null, string? criteria = null, string? sort = null, string? aggregations = null, ICommandOptions? options = null)
-    {
-        return FindAsAsync<T>(q => q.SystemFilter(systemFilter).FilterExpression(filter!).SearchExpression(criteria!).SortExpression(sort!).AggregationsExpression(aggregations!), o => options?.As<T>()!);
-    }
-
-    public virtual Task<CountResult> CountBySearchAsync(ISystemFilter systemFilter, string? filter = null, string? aggregations = null, ICommandOptions? options = null)
-    {
-        return CountAsync(q => q.SystemFilter(systemFilter).FilterExpression(filter!).AggregationsExpression(aggregations!), o => options?.As<T>()!);
-    }
-
     protected virtual IRepositoryQuery<T> NewQuery()
     {
         return new RepositoryQuery<T>();

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -76,8 +76,8 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     protected Func<T, string>? GetParentIdFunc { get; set; }
 
     protected Inferrer Infer => ElasticIndex.Configuration.Client.Infer;
-    protected string InferField(Expression<Func<T, object>> objectPath) => Infer.Field(objectPath);
-    protected string InferPropertyName(Expression<Func<T, object>> objectPath) => Infer.PropertyName(objectPath);
+    protected string InferField(Expression<Func<T, object?>> objectPath) => Infer.Field(objectPath);
+    protected string InferPropertyName(Expression<Func<T, object?>> objectPath) => Infer.PropertyName(objectPath);
     protected bool HasParent { get; set; } = false;
 
     protected Consistency DefaultConsistency { get; set; } = Consistency.Eventual;
@@ -690,13 +690,13 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     }
 
     /// <inheritdoc cref="AddDefaultExclude(string)"/>
-    protected void AddDefaultExclude(Expression<Func<T, object>> objectPath)
+    protected void AddDefaultExclude(Expression<Func<T, object?>> objectPath)
     {
         _defaultExcludes.Add(new Lazy<Field>(() => InferPropertyName(objectPath)));
     }
 
     /// <inheritdoc cref="AddDefaultExclude(string)"/>
-    protected void AddDefaultExclude(params Expression<Func<T, object>>[] objectPaths)
+    protected void AddDefaultExclude(params Expression<Func<T, object?>>[] objectPaths)
     {
         _defaultExcludes.AddRange(objectPaths.Select(o => new Lazy<Field>(() => InferPropertyName(o))));
     }
@@ -722,13 +722,13 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     }
 
     /// <inheritdoc cref="AddRequiredField(string)"/>
-    protected void AddRequiredField(Expression<Func<T, object>> objectPath)
+    protected void AddRequiredField(Expression<Func<T, object?>> objectPath)
     {
         _requiredFields.Add(new Lazy<Field>(() => InferPropertyName(objectPath)));
     }
 
     /// <inheritdoc cref="AddRequiredField(string)"/>
-    protected void AddRequiredField(params Expression<Func<T, object>>[] objectPaths)
+    protected void AddRequiredField(params Expression<Func<T, object?>>[] objectPaths)
     {
         _requiredFields.AddRange(objectPaths.Select(o => new Lazy<Field>(() => InferPropertyName(o))));
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
@@ -37,8 +38,8 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     private readonly List<Lazy<Field>> _defaultExcludes = new();
     private readonly List<Lazy<Field>> _requiredFields = new();
     protected IReadOnlyList<Lazy<Field>> RequiredFields => _requiredFields;
-    protected readonly Lazy<string> _idField;
-    protected readonly Lazy<string> _updatedUtcField;
+    protected readonly Lazy<string>? _idField;
+    protected readonly Lazy<string>? _updatedUtcField;
 
     protected readonly ILogger _logger;
     protected readonly Lazy<IElasticClient> _lazyClient;
@@ -46,7 +47,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     protected readonly IResiliencePolicyProvider _resiliencePolicyProvider;
     protected readonly IResiliencePolicy _resiliencePolicy;
 
-    private ScopedCacheClient _scopedCacheClient;
+    private ScopedCacheClient _scopedCacheClient = null!;
     private readonly CancellationTokenSource _disposedCancellationTokenSource = new();
     private int _disposed;
     protected CancellationToken DisposedCancellationToken => _disposedCancellationTokenSource.Token;
@@ -68,7 +69,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     }
 
     protected IIndex ElasticIndex { get; private set; }
-    protected Func<T, string> GetParentIdFunc { get; set; }
+    protected Func<T, string>? GetParentIdFunc { get; set; }
 
     protected Inferrer Infer => ElasticIndex.Configuration.Client.Infer;
     protected string InferField(Expression<Func<T, object>> objectPath) => Infer.Field(objectPath);
@@ -81,17 +82,17 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     protected int MaxPageLimit { get; set; } = 10000;
     protected Microsoft.Extensions.Logging.LogLevel DefaultQueryLogLevel { get; set; } = Microsoft.Extensions.Logging.LogLevel.Trace;
 
-    public Task<T> GetByIdAsync(Id id, CommandOptionsDescriptor<T> options)
+    public Task<T?> GetByIdAsync(Id id, CommandOptionsDescriptor<T>? options)
     {
-        return GetByIdAsync(id, options.Configure());
+        return GetByIdAsync(id, options?.Configure());
     }
 
-    public virtual async Task<T> GetByIdAsync(Id id, ICommandOptions options = null)
+    public virtual async Task<T?> GetByIdAsync(Id id, ICommandOptions? options = null)
     {
         if (String.IsNullOrEmpty(id.Value))
             return null;
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         await OnBeforeGetAsync(new Ids(id), options, typeof(T));
 
@@ -106,11 +107,12 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         {
             var value = await GetCachedFindHit(id, options.GetCacheKey()).AnyContext();
 
-            if (value?.Document != null)
+            var cachedDoc = value?.Document;
+            if (cachedDoc is not null)
             {
                 _logger.LogTrace("Cache hit: type={EntityType} key={Id}", EntityTypeName, id);
 
-                return ShouldReturnDocument(value.Document, options) ? value.Document : null;
+                return ShouldReturnDocument(cachedDoc, options) ? cachedDoc : null;
             }
         }
 
@@ -131,15 +133,16 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (IsCacheEnabled && options.ShouldUseCache())
             await AddDocumentsToCacheAsync(findHit ?? new FindHit<T>(id, null, 0), options, false).AnyContext();
 
-        return ShouldReturnDocument(findHit?.Document, options) ? findHit?.Document : null;
+        var doc = findHit?.Document;
+        return ShouldReturnDocument(doc, options) ? doc : null;
     }
 
-    public Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, CommandOptionsDescriptor<T> options)
+    public Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, CommandOptionsDescriptor<T>? options)
     {
-        return GetByIdsAsync(ids, options.Configure());
+        return GetByIdsAsync(ids, options?.Configure());
     }
 
-    public virtual async Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, ICommandOptions options = null)
+    public virtual async Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, ICommandOptions? options = null)
     {
         var idList = ids?.Distinct().Where(i => !String.IsNullOrEmpty(i)).ToList();
         if (idList == null || idList.Count == 0)
@@ -148,7 +151,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (!HasIdentity)
             throw new NotSupportedException("Model type must implement IIdentity.");
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         await OnBeforeGetAsync(new Ids(idList), options, typeof(T));
 
@@ -156,9 +159,9 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (IsCacheEnabled && options.ShouldReadCache())
             hits.AddRange(await GetCachedFindHit(idList, options.GetCacheKey()).AnyContext());
 
-        var itemsToFind = idList.Except(hits.Select(i => (Id)i.Id)).ToList();
+        var itemsToFind = idList.Except(hits.Select(i => (Id)i.Id!)).ToList();
         if (itemsToFind.Count == 0)
-            return hits.Where(h => h.Document != null && ShouldReturnDocument(h.Document, options)).Select(h => h.Document).ToList().AsReadOnly();
+            return hits.Where(h => ShouldReturnDocument(h.Document, options)).Select(h => h.Document!).ToList().AsReadOnly();
 
         var multiGet = new MultiGetDescriptor();
         foreach (var id in itemsToFind.Where(i => i.Routing != null || !HasParent))
@@ -189,7 +192,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         // fallback to doing a find
         if (itemsToFind.Count > 0 && (HasParent || ElasticIndex.HasMultipleIndexes))
         {
-            var response = await FindAsync(q => q.Id(itemsToFind.Select(id => id.Value)), o => o.PageLimit(1000)).AnyContext();
+            var response = await FindAsync(q => q.Id(itemsToFind.Select(id => id.Value)!), o => o.PageLimit(1000)).AnyContext();
             do
             {
                 if (response.Hits.Count > 0)
@@ -200,30 +203,32 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (IsCacheEnabled && options.ShouldUseCache())
             await AddDocumentsToCacheAsync(hits, options, false).AnyContext();
 
-        return hits.Where(h => h.Document != null && ShouldReturnDocument(h.Document, options)).Select(h => h.Document).ToList().AsReadOnly();
+        return hits.Where(h => ShouldReturnDocument(h.Document, options)).Select(h => h.Document!).ToList().AsReadOnly();
     }
 
-    public Task<FindResults<T>> GetAllAsync(CommandOptionsDescriptor<T> options)
+    public Task<FindResults<T>> GetAllAsync(CommandOptionsDescriptor<T>? options)
     {
-        return GetAllAsync(options.Configure());
+        return GetAllAsync(options?.Configure());
     }
 
-    public virtual Task<FindResults<T>> GetAllAsync(ICommandOptions options = null)
+    public virtual Task<FindResults<T>> GetAllAsync(ICommandOptions? options = null)
     {
         return FindAsync(NewQuery(), options);
     }
 
-    public Task<bool> ExistsAsync(Id id, CommandOptionsDescriptor<T> options)
+    public Task<bool> ExistsAsync(Id id, CommandOptionsDescriptor<T>? options)
     {
-        return ExistsAsync(id, options.Configure());
+        return ExistsAsync(id, options?.Configure());
     }
 
-    public virtual async Task<bool> ExistsAsync(Id id, ICommandOptions options = null)
+    public virtual async Task<bool> ExistsAsync(Id id, ICommandOptions? options = null)
     {
         if (String.IsNullOrEmpty(id.Value))
             return false;
 
         // documents that use soft deletes or have parents without a routing id need to use search for exists
+        options = ConfigureOptions(options?.As<T>());
+
         if (!SupportsSoftDeletes && (!HasParent || id.Routing != null))
         {
             var response = await _client.DocumentExistsAsync(new DocumentPath<T>(id.Value), d =>
@@ -245,12 +250,12 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return await ExistsAsync(q => q.Id(id), o => options.As<T>()).AnyContext();
     }
 
-    public Task<CountResult> CountAsync(CommandOptionsDescriptor<T> options)
+    public Task<CountResult> CountAsync(CommandOptionsDescriptor<T>? options)
     {
-        return CountAsync(options.Configure());
+        return CountAsync(options?.Configure());
     }
 
-    public virtual async Task<CountResult> CountAsync(ICommandOptions options = null)
+    public virtual async Task<CountResult> CountAsync(ICommandOptions? options = null)
     {
         var result = await CountAsync(NewQuery(), options).AnyContext();
         return result;
@@ -328,24 +333,24 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         await AfterQuery.InvokeAsync(this, new AfterQueryEventArgs<T>(query, options, this, result.GetType(), result)).AnyContext();
     }
 
-    public virtual Task<FindResults<T>> FindAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null)
+    public virtual Task<FindResults<T>> FindAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null)
     {
-        return FindAsync(query.Configure(), options.Configure());
+        return FindAsync(query.Configure(), options?.Configure());
     }
 
-    public Task<FindResults<T>> FindAsync(IRepositoryQuery query, ICommandOptions options = null)
+    public Task<FindResults<T>> FindAsync(IRepositoryQuery query, ICommandOptions? options = null)
     {
         return FindAsAsync<T>(query, options);
     }
 
-    public Task<FindResults<TResult>> FindAsAsync<TResult>(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null) where TResult : class, new()
+    public Task<FindResults<TResult>> FindAsAsync<TResult>(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null) where TResult : class, new()
     {
-        return FindAsAsync<TResult>(query.Configure(), options.Configure());
+        return FindAsAsync<TResult>(query.Configure(), options?.Configure());
     }
 
-    public virtual async Task<FindResults<TResult>> FindAsAsync<TResult>(IRepositoryQuery query, ICommandOptions options = null) where TResult : class, new()
+    public virtual async Task<FindResults<TResult>> FindAsAsync<TResult>(IRepositoryQuery query, ICommandOptions? options = null) where TResult : class, new()
     {
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         bool useSnapshotPaging = options.ShouldUseSnapshotPaging();
         // don't use caching with snapshot paging.
         bool allowCaching = IsCacheEnabled && useSnapshotPaging == false;
@@ -354,15 +359,15 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
 
         await RefreshForConsistency(query, options).AnyContext();
 
-        string cacheSuffix = options?.HasPageLimit() == true ? String.Concat(options.GetPage().ToString(), ":", options.GetLimit().ToString()) : null;
+        string? cacheSuffix = options.HasPageLimit() ? String.Concat(options.GetPage().ToString(), ":", options.GetLimit().ToString()) : null;
 
-        FindResults<TResult> result;
+        FindResults<TResult>? result;
         if (allowCaching)
         {
-            result = await GetCachedQueryResultAsync<FindResults<TResult>>(options, cacheSuffix: cacheSuffix).AnyContext();
+            result = await GetCachedQueryResultAsync<FindResults<TResult>>(options!, cacheSuffix: cacheSuffix).AnyContext();
             if (result != null)
             {
-                ((IFindResults<TResult>)result).GetNextPageFunc = async previousResults => await GetNextPageFunc(previousResults, query, options).AnyContext();
+                ((IFindResults<TResult>)result).GetNextPageFunc = async previousResults => await GetNextPageFunc(previousResults, query, options!).AnyContext();
                 return result;
             }
         }
@@ -427,7 +432,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (useSnapshotPaging && !result.HasMore)
         {
             // clear the scroll
-            string scrollId = result.GetScrollId();
+            string? scrollId = result.GetScrollId();
             if (!String.IsNullOrEmpty(scrollId))
             {
                 var response = await _client.ClearScrollAsync(s => s.ScrollId(result.GetScrollId())).AnyContext();
@@ -453,7 +458,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     {
         ArgumentNullException.ThrowIfNull(previousResults);
 
-        string scrollId = previousResults.GetScrollId();
+        string? scrollId = previousResults.GetScrollId();
         if (!String.IsNullOrEmpty(scrollId))
         {
             var scrollResponse = await _client.ScrollAsync<TResult>(options.GetSnapshotLifetime(), scrollId).AnyContext();
@@ -473,7 +478,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         }
 
         if (options.ShouldUseSearchAfterPaging())
-            options.SearchAfterToken(previousResults.GetSearchAfterToken());
+            options.SearchAfterToken(previousResults.GetSearchAfterToken()!);
 
         if (options == null)
             return new FindResults<TResult>();
@@ -482,20 +487,20 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return await FindAsAsync<TResult>(query, options).AnyContext();
     }
 
-    public Task<FindHit<T>> FindOneAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null)
+    public Task<FindHit<T>> FindOneAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null)
     {
-        return FindOneAsync(query.Configure(), options.Configure());
+        return FindOneAsync(query.Configure(), options?.Configure());
     }
 
-    public virtual async Task<FindHit<T>> FindOneAsync(IRepositoryQuery query, ICommandOptions options = null)
+    public virtual async Task<FindHit<T>> FindOneAsync(IRepositoryQuery query, ICommandOptions? options = null)
     {
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         if (IsCacheEnabled && (options.ShouldUseCache() || options.ShouldReadCache()) && !options.HasCacheKey())
             throw new ArgumentException("Cache key is required when enabling cache.", nameof(options));
 
         var result = IsCacheEnabled && options.ShouldReadCache() && options.HasCacheKey() ? await GetCachedFindHit(options).AnyContext() : null;
         if (result != null)
-            return result.FirstOrDefault();
+            return result.FirstOrDefault()!;
 
         await OnBeforeQueryAsync(query, options, typeof(T)).AnyContext();
 
@@ -519,19 +524,19 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (IsCacheEnabled && options.ShouldUseCache())
             await AddDocumentsToCacheAsync(result, options, options.GetConsistency(DefaultConsistency) == Consistency.Eventual).AnyContext();
 
-        return result.FirstOrDefault();
+        return result.FirstOrDefault()!;
     }
 
-    public Task<CountResult> CountAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null)
+    public Task<CountResult> CountAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null)
     {
-        return CountAsync(query.Configure(), options.Configure());
+        return CountAsync(query.Configure(), options?.Configure());
     }
 
-    public virtual async Task<CountResult> CountAsync(IRepositoryQuery query, ICommandOptions options = null)
+    public virtual async Task<CountResult> CountAsync(IRepositoryQuery query, ICommandOptions? options = null)
     {
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
-        CountResult result;
+        CountResult? result;
         if (IsCacheEnabled && options.ShouldReadCache())
         {
             result = await GetCachedQueryResultAsync<CountResult>(options, "count").AnyContext();
@@ -590,20 +595,20 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return result;
     }
 
-    public Task<bool> ExistsAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null)
+    public Task<bool> ExistsAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null)
     {
-        return ExistsAsync(query.Configure(), options.Configure());
+        return ExistsAsync(query.Configure(), options?.Configure());
     }
 
-    public virtual async Task<bool> ExistsAsync(IRepositoryQuery query, ICommandOptions options = null)
+    public virtual async Task<bool> ExistsAsync(IRepositoryQuery query, ICommandOptions? options = null)
     {
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         await OnBeforeQueryAsync(query, options, typeof(T)).AnyContext();
 
         await RefreshForConsistency(query, options).AnyContext();
 
         var searchDescriptor = (await CreateSearchDescriptorAsync(query, options).AnyContext()).Size(0);
-        searchDescriptor.DocValueFields(_idField.Value);
+        searchDescriptor.DocValueFields(_idField!.Value);
         var response = await _client.SearchAsync<T>(searchDescriptor).AnyContext();
         _logger.LogRequest(response, options.GetQueryLogLevel());
 
@@ -618,14 +623,14 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return response.Total > 0;
     }
 
-    public virtual Task<FindResults<T>> SearchAsync(ISystemFilter systemFilter, string filter = null, string criteria = null, string sort = null, string aggregations = null, ICommandOptions options = null)
+    public virtual Task<FindResults<T>> SearchAsync(ISystemFilter systemFilter, string? filter = null, string? criteria = null, string? sort = null, string? aggregations = null, ICommandOptions? options = null)
     {
-        return FindAsAsync<T>(q => q.SystemFilter(systemFilter).FilterExpression(filter).SearchExpression(criteria).SortExpression(sort).AggregationsExpression(aggregations), o => options.As<T>());
+        return FindAsAsync<T>(q => q.SystemFilter(systemFilter).FilterExpression(filter!).SearchExpression(criteria!).SortExpression(sort!).AggregationsExpression(aggregations!), o => options?.As<T>()!);
     }
 
-    public virtual Task<CountResult> CountBySearchAsync(ISystemFilter systemFilter, string filter = null, string aggregations = null, ICommandOptions options = null)
+    public virtual Task<CountResult> CountBySearchAsync(ISystemFilter systemFilter, string? filter = null, string? aggregations = null, ICommandOptions? options = null)
     {
-        return CountAsync(q => q.SystemFilter(systemFilter).FilterExpression(filter).AggregationsExpression(aggregations), o => options.As<T>());
+        return CountAsync(q => q.SystemFilter(systemFilter).FilterExpression(filter!).AggregationsExpression(aggregations!), o => options?.As<T>()!);
     }
 
     protected virtual IRepositoryQuery<T> NewQuery()
@@ -742,8 +747,8 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             foreach (var document in documents)
             {
                 keysToRemove.Add(((IIdentity)document.Value).Id);
-                if (((IIdentity)document.Original)?.Id != null)
-                    keysToRemove.Add(((IIdentity)document.Original).Id);
+                if (document.Original is { } original && ((IIdentity)original).Id is { } originalId)
+                    keysToRemove.Add(originalId);
             }
         }
 
@@ -758,7 +763,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return ConfigureSearchDescriptorAsync(null, query, options);
     }
 
-    protected virtual async Task<SearchDescriptor<T>> ConfigureSearchDescriptorAsync(SearchDescriptor<T> search, IRepositoryQuery query, ICommandOptions options)
+    protected virtual async Task<SearchDescriptor<T>> ConfigureSearchDescriptorAsync(SearchDescriptor<T>? search, IRepositoryQuery query, ICommandOptions options)
     {
         search ??= new SearchDescriptor<T>();
 
@@ -780,7 +785,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return search;
     }
 
-    protected virtual ICommandOptions<T> ConfigureOptions(ICommandOptions<T> options)
+    protected virtual ICommandOptions<T> ConfigureOptions(ICommandOptions<T>? options)
     {
         options ??= new CommandOptions<T>();
 
@@ -842,10 +847,11 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return GetResolvedIncludesAndExcludes(null, options);
     }
 
-    protected (Field[] Includes, Field[] Excludes) GetResolvedIncludesAndExcludes(IRepositoryQuery query, ICommandOptions options)
+    protected (Field[] Includes, Field[] Excludes) GetResolvedIncludesAndExcludes(IRepositoryQuery? query, ICommandOptions options)
     {
         var includes = new HashSet<Field>();
-        includes.AddRange(query.GetIncludes());
+        if (query is not null)
+            includes.AddRange(query.GetIncludes());
         includes.AddRange(options.GetIncludes());
 
         string optionIncludeMask = options.GetIncludeMask();
@@ -853,7 +859,8 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             includes.AddRange(FieldIncludeParser.ParseFieldPaths(optionIncludeMask).Select(f => (Field)f));
 
         var excludes = new HashSet<Field>();
-        excludes.AddRange(query.GetExcludes());
+        if (query is not null)
+            excludes.AddRange(query.GetExcludes());
         excludes.AddRange(options.GetExcludes());
 
         string optionExcludeMask = options.GetExcludeMask();
@@ -883,10 +890,10 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return (resolvedIncludes, resolvedExcludes);
     }
 
-    protected bool ShouldReturnDocument(T document, ICommandOptions options)
+    protected bool ShouldReturnDocument([NotNullWhen(true)] T? document, ICommandOptions options)
     {
-        if (document == null)
-            return true;
+        if (document is null)
+            return false;
 
         if (!SupportsSoftDeletes)
             return true;
@@ -909,7 +916,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         }
     }
 
-    protected async Task<TResult> GetCachedQueryResultAsync<TResult>(ICommandOptions options, string cachePrefix = null, string cacheSuffix = null)
+    protected async Task<TResult?> GetCachedQueryResultAsync<TResult>(ICommandOptions options, string? cachePrefix = null, string? cacheSuffix = null)
     {
         if (IsCacheEnabled && (options.ShouldUseCache() || options.ShouldReadCache()) && !options.HasCacheKey())
             throw new ArgumentException("Cache key is required when enabling cache.", nameof(options));
@@ -917,17 +924,18 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (!IsCacheEnabled || !options.ShouldReadCache() || !options.HasCacheKey())
             return default;
 
-        string cacheKey = cachePrefix != null ? cachePrefix + ":" + options.GetCacheKey() : options.GetCacheKey();
+        string cacheKey = cachePrefix is not null ? cachePrefix + ":" + options.GetCacheKey() : options.GetCacheKey()!;
         if (!String.IsNullOrEmpty(cacheSuffix))
             cacheKey += ":" + cacheSuffix;
 
-        var result = await Cache.GetAsync<TResult>(cacheKey, default).AnyContext();
-        _logger.LogTrace("Cache {HitOrMiss}: type={EntityType} key={CacheKey}", (result != null ? "hit" : "miss"), EntityTypeName, cacheKey);
+        var cacheValue = await Cache.GetAsync<TResult>(cacheKey).AnyContext();
+        var result = cacheValue.HasValue ? cacheValue.Value : default;
+        _logger.LogTrace("Cache {HitOrMiss}: type={EntityType} key={CacheKey}", (cacheValue.HasValue ? "hit" : "miss"), EntityTypeName, cacheKey);
 
         return result;
     }
 
-    protected async Task SetCachedQueryResultAsync<TResult>(ICommandOptions options, TResult result, string cachePrefix = null, string cacheSuffix = null)
+    protected async Task SetCachedQueryResultAsync<TResult>(ICommandOptions options, TResult result, string? cachePrefix = null, string? cacheSuffix = null)
     {
         if (!IsCacheEnabled || result == null || !options.ShouldUseCache())
             return;
@@ -935,7 +943,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (!options.HasCacheKey())
             throw new ArgumentException("Cache key is required when enabling cache.", nameof(options));
 
-        string cacheKey = cachePrefix != null ? cachePrefix + ":" + options.GetCacheKey() : options.GetCacheKey();
+        string cacheKey = cachePrefix is not null ? cachePrefix + ":" + options.GetCacheKey() : options.GetCacheKey()!;
         if (!String.IsNullOrEmpty(cacheSuffix))
             cacheKey += ":" + cacheSuffix;
 
@@ -943,9 +951,9 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         _logger.LogTrace("Set cache: type={EntityType} key={CacheKey}", EntityTypeName, cacheKey);
     }
 
-    protected async Task<ICollection<FindHit<T>>> GetCachedFindHit(ICommandOptions options)
+    protected async Task<ICollection<FindHit<T>>?> GetCachedFindHit(ICommandOptions options)
     {
-        string cacheKey = options.GetCacheKey();
+        string cacheKey = options.GetCacheKey()!;
         try
         {
             var cacheKeyHits = await Cache.GetAsync<ICollection<FindHit<T>>>(cacheKey).AnyContext();
@@ -964,7 +972,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         }
     }
 
-    protected async Task<FindHit<T>> GetCachedFindHit(Id id, string cacheKey = null)
+    protected async Task<FindHit<T>?> GetCachedFindHit(Id id, string? cacheKey = null)
     {
         try
         {
@@ -985,7 +993,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         }
     }
 
-    protected async Task<ICollection<FindHit<T>>> GetCachedFindHit(ICollection<Id> ids, string cacheKey = null)
+    protected async Task<ICollection<FindHit<T>>> GetCachedFindHit(ICollection<Id> ids, string? cacheKey = null)
     {
         var idList = ids.Select(id => id.Value).ToList();
         IEnumerable<FindHit<T>> result;
@@ -998,13 +1006,13 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
                 result = cacheHitsById
                     .Where(kvp => kvp.Value.HasValue && !kvp.Value.IsNull)
                     .SelectMany(kvp => kvp.Value.Value)
-                    .Where(v => v?.Document != null && idList.Contains(v.Id));
+                    .Where(v => v is not null && v.Document is not null && v.Id is not null && idList.Contains(v.Id));
             }
             else
             {
                 var cacheKeyHits = await Cache.GetAsync<ICollection<FindHit<T>>>(cacheKey).AnyContext();
                 result = cacheKeyHits.HasValue && !cacheKeyHits.IsNull
-                    ? cacheKeyHits.Value.Where(v => v?.Document != null && idList.Contains(v.Id))
+                    ? cacheKeyHits.Value.Where(v => v is not null && v.Document is not null && v.Id is not null && idList.Contains(v.Id))
                     : Enumerable.Empty<FindHit<T>>();
             }
 
@@ -1025,10 +1033,10 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
 
     protected FindHit<T> ToFindHit(T document)
     {
-        string version = HasVersion ? ((IVersioned)document)?.Version : null;
-        string routing = GetParentIdFunc?.Invoke(document);
+        string? version = HasVersion ? ((IVersioned)document)?.Version : null;
+        string? routing = GetParentIdFunc?.Invoke(document!);
         var idDocument = document as IIdentity;
-        return new FindHit<T>(idDocument?.Id, document, 0, version, routing);
+        return new FindHit<T>(idDocument?.Id, document!, 0, version, routing);
     }
 
     protected Task AddDocumentsToCacheAsync(T document, ICommandOptions options, bool isDirtyRead)
@@ -1050,7 +1058,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     {
         if (options.HasCacheKey())
         {
-            await Cache.SetAsync(options.GetCacheKey(), findHits, options.GetExpiresIn()).AnyContext();
+            await Cache.SetAsync(options.GetCacheKey()!, findHits, options.GetExpiresIn()).AnyContext();
 
             // NOTE: Custom cache keys store the complete filtered result, but ID-based caching is skipped when includes/excludes are present to avoid incomplete data.
             // This method also doesn't take into account any query includes or excludes but GetById(s) requests don't specify a query.
@@ -1064,7 +1072,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
 
         var findHitsById = findHits
             .Where(hit => hit?.Id != null)
-            .GroupBy(hit => hit.Id)
+            .GroupBy(hit => hit.Id!)
             .ToDictionary(g => g.Key, g => (ICollection<FindHit<T>>)g.ToList());
 
         if (findHitsById.Count == 0)
@@ -1117,21 +1125,21 @@ internal class SearchResponse<TDocument> : IResponse, IElasticsearchResponse whe
 
     public ServerError ServerError => throw new NotImplementedException();
 
-    AggregateDictionary Aggregations { get; }
+    AggregateDictionary Aggregations { get; } = null!;
     bool TimedOut { get; }
     bool TerminatedEarly { get; }
-    ISuggestDictionary<TDocument> Suggest { get; }
-    ShardStatistics Shards { get; }
-    string ScrollId { get; }
-    Profile Profile { get; }
+    ISuggestDictionary<TDocument> Suggest { get; } = null!;
+    ShardStatistics Shards { get; } = null!;
+    string ScrollId { get; } = null!;
+    Profile Profile { get; } = null!;
     long Took { get; }
-    string PointInTimeId { get; }
+    string PointInTimeId { get; } = null!;
     double MaxScore { get; }
-    IHitsMetadata<TDocument> HitsMetadata { get; }
-    IReadOnlyCollection<IHit<TDocument>> Hits { get; }
-    IReadOnlyCollection<FieldValues> Fields { get; }
-    IReadOnlyCollection<TDocument> Documents { get; }
-    ClusterStatistics Clusters { get; }
+    IHitsMetadata<TDocument> HitsMetadata { get; } = null!;
+    IReadOnlyCollection<IHit<TDocument>> Hits { get; } = null!;
+    IReadOnlyCollection<FieldValues> Fields { get; } = null!;
+    IReadOnlyCollection<TDocument> Documents { get; } = null!;
+    ClusterStatistics Clusters { get; } = null!;
     long NumberOfReducePhases { get; }
     long Total { get; }
 

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -642,16 +642,6 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return response.Total > 0;
     }
 
-    public virtual Task<FindResults<T>> SearchAsync(ISystemFilter systemFilter, string? filter = null, string? criteria = null, string? sort = null, string? aggregations = null, ICommandOptions? options = null)
-    {
-        return FindAsAsync<T>(q => q.SystemFilter(systemFilter).FilterExpression(filter!).SearchExpression(criteria!).SortExpression(sort!).AggregationsExpression(aggregations!), o => options?.As<T>()!);
-    }
-
-    public virtual Task<CountResult> CountBySearchAsync(ISystemFilter systemFilter, string? filter = null, string? aggregations = null, ICommandOptions? options = null)
-    {
-        return CountAsync(q => q.SystemFilter(systemFilter).FilterExpression(filter!).AggregationsExpression(aggregations!), o => options?.As<T>()!);
-    }
-
     protected virtual IRepositoryQuery<T> NewQuery()
     {
         return new RepositoryQuery<T>();

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
@@ -41,8 +42,8 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     private readonly List<Lazy<Field>> _defaultExcludes = new();
     private readonly List<Lazy<Field>> _requiredFields = new();
     protected IReadOnlyList<Lazy<Field>> RequiredFields => _requiredFields;
-    protected readonly Lazy<string> _idField;
-    protected readonly Lazy<string> _updatedUtcField;
+    protected readonly Lazy<string>? _idField;
+    protected readonly Lazy<string>? _updatedUtcField;
 
     protected readonly ILogger _logger;
     protected readonly Lazy<ElasticsearchClient> _lazyClient;
@@ -50,7 +51,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     protected readonly IResiliencePolicyProvider _resiliencePolicyProvider;
     protected readonly IResiliencePolicy _resiliencePolicy;
 
-    private ScopedCacheClient _scopedCacheClient;
+    private ScopedCacheClient _scopedCacheClient = null!;
     private readonly CancellationTokenSource _disposedCancellationTokenSource = new();
     private int _disposed;
     protected CancellationToken DisposedCancellationToken => _disposedCancellationTokenSource.Token;
@@ -72,7 +73,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     }
 
     protected IIndex ElasticIndex { get; private set; }
-    protected Func<T, string> GetParentIdFunc { get; set; }
+    protected Func<T, string>? GetParentIdFunc { get; set; }
 
     protected Inferrer Infer => ElasticIndex.Configuration.Client.Infer;
     protected string InferField(Expression<Func<T, object>> objectPath) => Infer.Field(objectPath);
@@ -85,17 +86,17 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     protected int MaxPageLimit { get; set; } = 10000;
     protected Microsoft.Extensions.Logging.LogLevel DefaultQueryLogLevel { get; set; } = Microsoft.Extensions.Logging.LogLevel.Trace;
 
-    public Task<T> GetByIdAsync(Id id, CommandOptionsDescriptor<T> options)
+    public Task<T?> GetByIdAsync(Id id, CommandOptionsDescriptor<T>? options)
     {
-        return GetByIdAsync(id, options.Configure());
+        return GetByIdAsync(id, options?.Configure());
     }
 
-    public virtual async Task<T> GetByIdAsync(Id id, ICommandOptions options = null)
+    public virtual async Task<T?> GetByIdAsync(Id id, ICommandOptions? options = null)
     {
         if (String.IsNullOrEmpty(id.Value))
             return null;
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         await OnBeforeGetAsync(new Ids(id), options, typeof(T)).AnyContext();
 
@@ -110,11 +111,12 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         {
             var value = await GetCachedFindHit(id, options.GetCacheKey()).AnyContext();
 
-            if (value?.Document != null)
+            var cachedDoc = value?.Document;
+            if (cachedDoc is not null)
             {
                 _logger.LogTrace("Cache hit: type={EntityType} key={Id}", EntityTypeName, id);
 
-                return ShouldReturnDocument(value.Document, options) ? value.Document : null;
+                return ShouldReturnDocument(cachedDoc, options) ? cachedDoc : null;
             }
         }
 
@@ -135,15 +137,16 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (IsCacheEnabled && options.ShouldUseCache())
             await AddDocumentsToCacheAsync(findHit ?? new FindHit<T>(id, null, 0), options, false).AnyContext();
 
-        return ShouldReturnDocument(findHit?.Document, options) ? findHit?.Document : null;
+        var doc = findHit?.Document;
+        return ShouldReturnDocument(doc, options) ? doc : null;
     }
 
-    public Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, CommandOptionsDescriptor<T> options)
+    public Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, CommandOptionsDescriptor<T>? options)
     {
-        return GetByIdsAsync(ids, options.Configure());
+        return GetByIdsAsync(ids, options?.Configure());
     }
 
-    public virtual async Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, ICommandOptions options = null)
+    public virtual async Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, ICommandOptions? options = null)
     {
         var idList = ids?.Distinct().Where(i => !String.IsNullOrEmpty(i)).ToList();
         if (idList == null || idList.Count == 0)
@@ -152,7 +155,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (!HasIdentity)
             throw new NotSupportedException("Model type must implement IIdentity.");
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         await OnBeforeGetAsync(new Ids(idList), options, typeof(T)).AnyContext();
 
@@ -160,9 +163,9 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (IsCacheEnabled && options.ShouldReadCache())
             hits.AddRange(await GetCachedFindHit(idList, options.GetCacheKey()).AnyContext());
 
-        var itemsToFind = idList.Except(hits.Select(i => (Id)i.Id)).ToList();
+        var itemsToFind = idList.Except(hits.Select(i => (Id)i.Id!)).ToList();
         if (itemsToFind.Count == 0)
-            return hits.Where(h => h.Document != null && ShouldReturnDocument(h.Document, options)).Select(h => h.Document).ToList().AsReadOnly();
+            return hits.Where(h => ShouldReturnDocument(h.Document, options)).Select(h => h.Document!).ToList().AsReadOnly();
 
         // Build MultiGetOperation objects for each ID
         var itemsForMultiGet = itemsToFind.Where(i => i.Routing != null || !HasParent).ToList();
@@ -190,14 +193,14 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             foreach (var findHit in multiGetResults.ToFindHits(_logger))
             {
                 hits.Add(findHit);
-                itemsToFind.Remove(new Id(findHit.Id, findHit.Routing));
+                itemsToFind.Remove(new Id(findHit.Id!, findHit.Routing));
             }
         }
 
         // fallback to doing a find
         if (itemsToFind.Count > 0 && (HasParent || ElasticIndex.HasMultipleIndexes))
         {
-            var response = await FindAsync(q => q.Id(itemsToFind.Select(id => id.Value)), o => o.PageLimit(1000)).AnyContext();
+            var response = await FindAsync(q => q.Id(itemsToFind.Select(id => id.Value)!), o => o.PageLimit(1000)).AnyContext();
             do
             {
                 if (response.Hits.Count > 0)
@@ -205,7 +208,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
                     foreach (var hit in response.Hits.Where(h => h.Document != null))
                     {
                         hits.Add(hit);
-                        itemsToFind.Remove(new Id(hit.Id, hit.Routing));
+                        itemsToFind.Remove(new Id(hit.Id!, hit.Routing));
                     }
                 }
             } while (await response.NextPageAsync().AnyContext());
@@ -220,30 +223,32 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             await AddDocumentsToCacheAsync(hits, options, false).AnyContext();
         }
 
-        return hits.Where(h => h.Document != null && ShouldReturnDocument(h.Document, options)).Select(h => h.Document).ToList().AsReadOnly();
+        return hits.Where(h => ShouldReturnDocument(h.Document, options)).Select(h => h.Document!).ToList().AsReadOnly();
     }
 
-    public Task<FindResults<T>> GetAllAsync(CommandOptionsDescriptor<T> options)
+    public Task<FindResults<T>> GetAllAsync(CommandOptionsDescriptor<T>? options)
     {
-        return GetAllAsync(options.Configure());
+        return GetAllAsync(options?.Configure());
     }
 
-    public virtual Task<FindResults<T>> GetAllAsync(ICommandOptions options = null)
+    public virtual Task<FindResults<T>> GetAllAsync(ICommandOptions? options = null)
     {
         return FindAsync(NewQuery(), options);
     }
 
-    public Task<bool> ExistsAsync(Id id, CommandOptionsDescriptor<T> options)
+    public Task<bool> ExistsAsync(Id id, CommandOptionsDescriptor<T>? options)
     {
-        return ExistsAsync(id, options.Configure());
+        return ExistsAsync(id, options?.Configure());
     }
 
-    public virtual async Task<bool> ExistsAsync(Id id, ICommandOptions options = null)
+    public virtual async Task<bool> ExistsAsync(Id id, ICommandOptions? options = null)
     {
         if (String.IsNullOrEmpty(id.Value))
             return false;
 
         // documents that use soft deletes or have parents without a routing id need to use search for exists
+        options = ConfigureOptions(options?.As<T>());
+
         if (!SupportsSoftDeletes && (!HasParent || id.Routing != null))
         {
             var request = new ExistsRequest(ElasticIndex.GetIndex(id), id.Value);
@@ -262,12 +267,12 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return await ExistsAsync(q => q.Id(id), o => options.As<T>()).AnyContext();
     }
 
-    public Task<CountResult> CountAsync(CommandOptionsDescriptor<T> options)
+    public Task<CountResult> CountAsync(CommandOptionsDescriptor<T>? options)
     {
-        return CountAsync(options.Configure());
+        return CountAsync(options?.Configure());
     }
 
-    public virtual async Task<CountResult> CountAsync(ICommandOptions options = null)
+    public virtual async Task<CountResult> CountAsync(ICommandOptions? options = null)
     {
         var result = await CountAsync(NewQuery(), options).AnyContext();
         return result;
@@ -345,24 +350,24 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         await AfterQuery.InvokeAsync(this, new AfterQueryEventArgs<T>(query, options, this, result.GetType(), result)).AnyContext();
     }
 
-    public virtual Task<FindResults<T>> FindAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null)
+    public virtual Task<FindResults<T>> FindAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null)
     {
-        return FindAsync(query.Configure(), options.Configure());
+        return FindAsync(query.Configure(), options?.Configure());
     }
 
-    public Task<FindResults<T>> FindAsync(IRepositoryQuery query, ICommandOptions options = null)
+    public Task<FindResults<T>> FindAsync(IRepositoryQuery query, ICommandOptions? options = null)
     {
         return FindAsAsync<T>(query, options);
     }
 
-    public Task<FindResults<TResult>> FindAsAsync<TResult>(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null) where TResult : class, new()
+    public Task<FindResults<TResult>> FindAsAsync<TResult>(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null) where TResult : class, new()
     {
-        return FindAsAsync<TResult>(query.Configure(), options.Configure());
+        return FindAsAsync<TResult>(query.Configure(), options?.Configure());
     }
 
-    public virtual async Task<FindResults<TResult>> FindAsAsync<TResult>(IRepositoryQuery query, ICommandOptions options = null) where TResult : class, new()
+    public virtual async Task<FindResults<TResult>> FindAsAsync<TResult>(IRepositoryQuery query, ICommandOptions? options = null) where TResult : class, new()
     {
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         bool useSnapshotPaging = options.ShouldUseSnapshotPaging();
         // don't use caching with snapshot paging.
         bool allowCaching = IsCacheEnabled && useSnapshotPaging == false;
@@ -371,15 +376,15 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
 
         await RefreshForConsistency(query, options).AnyContext();
 
-        string cacheSuffix = options?.HasPageLimit() == true ? String.Concat(options.GetPage().ToString(), ":", options.GetLimit().ToString()) : null;
+        string? cacheSuffix = options.HasPageLimit() ? String.Concat(options.GetPage().ToString(), ":", options.GetLimit().ToString()) : null;
 
-        FindResults<TResult> result;
+        FindResults<TResult>? result;
         if (allowCaching)
         {
-            result = await GetCachedQueryResultAsync<FindResults<TResult>>(options, cacheSuffix: cacheSuffix).AnyContext();
+            result = await GetCachedQueryResultAsync<FindResults<TResult>>(options!, cacheSuffix: cacheSuffix).AnyContext();
             if (result != null)
             {
-                ((IFindResults<TResult>)result).GetNextPageFunc = async previousResults => await GetNextPageFunc(previousResults, query, options).AnyContext();
+                ((IFindResults<TResult>)result).GetNextPageFunc = async previousResults => await GetNextPageFunc(previousResults, query, options!).AnyContext();
                 return result;
             }
         }
@@ -406,7 +411,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         }
         else if (options.HasSnapshotScrollId())
         {
-            var scrollRequest = new ScrollRequest(options.GetSnapshotScrollId()) { Scroll = options.GetSnapshotLifetime() };
+            var scrollRequest = new ScrollRequest(options.GetSnapshotScrollId()!) { Scroll = options.GetSnapshotLifetime() };
             var response = await _client.ScrollAsync<TResult>(scrollRequest).AnyContext();
             _logger.LogRequest(response, options.GetQueryLogLevel());
             result = response.ToFindResults(options, ElasticIndex.Configuration.Serializer, _logger);
@@ -445,7 +450,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (useSnapshotPaging && !result.HasMore)
         {
             // clear the scroll
-            string scrollId = result.GetScrollId();
+            string? scrollId = result.GetScrollId();
             if (!String.IsNullOrEmpty(scrollId))
             {
                 var response = await _client.ClearScrollAsync(s => s.ScrollId(scrollId)).AnyContext();
@@ -471,7 +476,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     {
         ArgumentNullException.ThrowIfNull(previousResults);
 
-        string scrollId = previousResults.GetScrollId();
+        string? scrollId = previousResults.GetScrollId();
         if (!String.IsNullOrEmpty(scrollId))
         {
             var scrollRequest = new ScrollRequest(scrollId) { Scroll = options.GetSnapshotLifetime() };
@@ -492,26 +497,26 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         }
 
         if (options.ShouldUseSearchAfterPaging())
-            options.SearchAfterToken(previousResults.GetSearchAfterToken(), ElasticIndex.Configuration.Serializer);
+            options.SearchAfterToken(previousResults.GetSearchAfterToken()!, ElasticIndex.Configuration.Serializer);
 
         options.PageNumber(!options.HasPageNumber() ? 2 : options.GetPage() + 1);
         return await FindAsAsync<TResult>(query, options).AnyContext();
     }
 
-    public Task<FindHit<T>> FindOneAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null)
+    public Task<FindHit<T>> FindOneAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null)
     {
-        return FindOneAsync(query.Configure(), options.Configure());
+        return FindOneAsync(query.Configure(), options?.Configure());
     }
 
-    public virtual async Task<FindHit<T>> FindOneAsync(IRepositoryQuery query, ICommandOptions options = null)
+    public virtual async Task<FindHit<T>> FindOneAsync(IRepositoryQuery query, ICommandOptions? options = null)
     {
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         if (IsCacheEnabled && (options.ShouldUseCache() || options.ShouldReadCache()) && !options.HasCacheKey())
             throw new ArgumentException("Cache key is required when enabling cache.", nameof(options));
 
         var result = IsCacheEnabled && options.ShouldReadCache() && options.HasCacheKey() ? await GetCachedFindHit(options).AnyContext() : null;
         if (result != null)
-            return result.FirstOrDefault();
+            return result.FirstOrDefault()!;
 
         await OnBeforeQueryAsync(query, options, typeof(T)).AnyContext();
 
@@ -535,19 +540,19 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (IsCacheEnabled && options.ShouldUseCache())
             await AddDocumentsToCacheAsync(result, options, options.GetConsistency(DefaultConsistency) == Consistency.Eventual).AnyContext();
 
-        return result.FirstOrDefault();
+        return result.FirstOrDefault()!;
     }
 
-    public Task<CountResult> CountAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null)
+    public Task<CountResult> CountAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null)
     {
-        return CountAsync(query.Configure(), options.Configure());
+        return CountAsync(query.Configure(), options?.Configure());
     }
 
-    public virtual async Task<CountResult> CountAsync(IRepositoryQuery query, ICommandOptions options = null)
+    public virtual async Task<CountResult> CountAsync(IRepositoryQuery query, ICommandOptions? options = null)
     {
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
-        CountResult result;
+        CountResult? result;
         if (IsCacheEnabled && options.ShouldReadCache())
         {
             result = await GetCachedQueryResultAsync<CountResult>(options, "count").AnyContext();
@@ -609,20 +614,20 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return result;
     }
 
-    public Task<bool> ExistsAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null)
+    public Task<bool> ExistsAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null)
     {
-        return ExistsAsync(query.Configure(), options.Configure());
+        return ExistsAsync(query.Configure(), options?.Configure());
     }
 
-    public virtual async Task<bool> ExistsAsync(IRepositoryQuery query, ICommandOptions options = null)
+    public virtual async Task<bool> ExistsAsync(IRepositoryQuery query, ICommandOptions? options = null)
     {
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         await OnBeforeQueryAsync(query, options, typeof(T)).AnyContext();
 
         await RefreshForConsistency(query, options).AnyContext();
 
         var searchDescriptor = (await CreateSearchDescriptorAsync(query, options).AnyContext()).Size(0);
-        searchDescriptor.DocvalueFields(new FieldAndFormat[] { new() { Field = _idField.Value } });
+        searchDescriptor.DocvalueFields(new FieldAndFormat[] { new() { Field = _idField!.Value! } });
         var response = await _client.SearchAsync<T>(searchDescriptor).AnyContext();
         _logger.LogRequest(response, options.GetQueryLogLevel());
 
@@ -637,14 +642,14 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return response.Total > 0;
     }
 
-    public virtual Task<FindResults<T>> SearchAsync(ISystemFilter systemFilter, string filter = null, string criteria = null, string sort = null, string aggregations = null, ICommandOptions options = null)
+    public virtual Task<FindResults<T>> SearchAsync(ISystemFilter systemFilter, string? filter = null, string? criteria = null, string? sort = null, string? aggregations = null, ICommandOptions? options = null)
     {
-        return FindAsAsync<T>(q => q.SystemFilter(systemFilter).FilterExpression(filter).SearchExpression(criteria).SortExpression(sort).AggregationsExpression(aggregations), o => options.As<T>());
+        return FindAsAsync<T>(q => q.SystemFilter(systemFilter).FilterExpression(filter!).SearchExpression(criteria!).SortExpression(sort!).AggregationsExpression(aggregations!), o => options?.As<T>()!);
     }
 
-    public virtual Task<CountResult> CountBySearchAsync(ISystemFilter systemFilter, string filter = null, string aggregations = null, ICommandOptions options = null)
+    public virtual Task<CountResult> CountBySearchAsync(ISystemFilter systemFilter, string? filter = null, string? aggregations = null, ICommandOptions? options = null)
     {
-        return CountAsync(q => q.SystemFilter(systemFilter).FilterExpression(filter).AggregationsExpression(aggregations), o => options.As<T>());
+        return CountAsync(q => q.SystemFilter(systemFilter).FilterExpression(filter!).AggregationsExpression(aggregations!), o => options?.As<T>()!);
     }
 
     protected virtual IRepositoryQuery<T> NewQuery()
@@ -761,8 +766,8 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             foreach (var document in documents)
             {
                 keysToRemove.Add(((IIdentity)document.Value).Id);
-                if (((IIdentity)document.Original)?.Id != null)
-                    keysToRemove.Add(((IIdentity)document.Original).Id);
+                if (document.Original is { } original && ((IIdentity)original).Id is { } originalId)
+                    keysToRemove.Add(originalId);
             }
         }
 
@@ -801,7 +806,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return search;
     }
 
-    protected virtual ICommandOptions<T> ConfigureOptions(ICommandOptions<T> options)
+    protected virtual ICommandOptions<T> ConfigureOptions(ICommandOptions<T>? options)
     {
         options ??= new CommandOptions<T>();
 
@@ -863,10 +868,11 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return GetResolvedIncludesAndExcludes(null, options);
     }
 
-    protected (Field[] Includes, Field[] Excludes) GetResolvedIncludesAndExcludes(IRepositoryQuery query, ICommandOptions options)
+    protected (Field[] Includes, Field[] Excludes) GetResolvedIncludesAndExcludes(IRepositoryQuery? query, ICommandOptions options)
     {
         var includes = new HashSet<Field>();
-        includes.AddRange(query.GetIncludes());
+        if (query is not null)
+            includes.AddRange(query.GetIncludes());
         includes.AddRange(options.GetIncludes());
 
         string optionIncludeMask = options.GetIncludeMask();
@@ -874,7 +880,8 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             includes.AddRange(FieldIncludeParser.ParseFieldPaths(optionIncludeMask).Select(f => (Field)f));
 
         var excludes = new HashSet<Field>();
-        excludes.AddRange(query.GetExcludes());
+        if (query is not null)
+            excludes.AddRange(query.GetExcludes());
         excludes.AddRange(options.GetExcludes());
 
         string optionExcludeMask = options.GetExcludeMask();
@@ -904,10 +911,10 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return (resolvedIncludes, resolvedExcludes);
     }
 
-    protected bool ShouldReturnDocument(T document, ICommandOptions options)
+    protected bool ShouldReturnDocument([NotNullWhen(true)] T? document, ICommandOptions options)
     {
-        if (document == null)
-            return true;
+        if (document is null)
+            return false;
 
         if (!SupportsSoftDeletes)
             return true;
@@ -930,7 +937,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         }
     }
 
-    protected async Task<TResult> GetCachedQueryResultAsync<TResult>(ICommandOptions options, string cachePrefix = null, string cacheSuffix = null)
+    protected async Task<TResult?> GetCachedQueryResultAsync<TResult>(ICommandOptions options, string? cachePrefix = null, string? cacheSuffix = null)
     {
         if (IsCacheEnabled && (options.ShouldUseCache() || options.ShouldReadCache()) && !options.HasCacheKey())
             throw new ArgumentException("Cache key is required when enabling cache.", nameof(options));
@@ -938,17 +945,18 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (!IsCacheEnabled || !options.ShouldReadCache() || !options.HasCacheKey())
             return default;
 
-        string cacheKey = cachePrefix != null ? $"{cachePrefix}:{options.GetCacheKey()}" : options.GetCacheKey();
+        string cacheKey = cachePrefix is not null ? $"{cachePrefix}:{options.GetCacheKey()}" : options.GetCacheKey()!;
         if (!String.IsNullOrEmpty(cacheSuffix))
             cacheKey = $"{cacheKey}:{cacheSuffix}";
 
-        var result = await Cache.GetAsync<TResult>(cacheKey, default).AnyContext();
-        _logger.LogTrace("Cache {HitOrMiss}: type={EntityType} key={CacheKey}", (result != null ? "hit" : "miss"), EntityTypeName, cacheKey);
+        var cacheValue = await Cache.GetAsync<TResult>(cacheKey).AnyContext();
+        var result = cacheValue.HasValue ? cacheValue.Value : default;
+        _logger.LogTrace("Cache {HitOrMiss}: type={EntityType} key={CacheKey}", (cacheValue.HasValue ? "hit" : "miss"), EntityTypeName, cacheKey);
 
         return result;
     }
 
-    protected async Task SetCachedQueryResultAsync<TResult>(ICommandOptions options, TResult result, string cachePrefix = null, string cacheSuffix = null)
+    protected async Task SetCachedQueryResultAsync<TResult>(ICommandOptions options, TResult result, string? cachePrefix = null, string? cacheSuffix = null)
     {
         if (!IsCacheEnabled || result == null || !options.ShouldUseCache())
             return;
@@ -956,7 +964,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (!options.HasCacheKey())
             throw new ArgumentException("Cache key is required when enabling cache.", nameof(options));
 
-        string cacheKey = cachePrefix != null ? $"{cachePrefix}:{options.GetCacheKey()}" : options.GetCacheKey();
+        string cacheKey = cachePrefix is not null ? $"{cachePrefix}:{options.GetCacheKey()}" : options.GetCacheKey()!;
         if (!String.IsNullOrEmpty(cacheSuffix))
             cacheKey = $"{cacheKey}:{cacheSuffix}";
 
@@ -964,9 +972,9 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         _logger.LogTrace("Set cache: type={EntityType} key={CacheKey}", EntityTypeName, cacheKey);
     }
 
-    protected async Task<ICollection<FindHit<T>>> GetCachedFindHit(ICommandOptions options)
+    protected async Task<ICollection<FindHit<T>>?> GetCachedFindHit(ICommandOptions options)
     {
-        string cacheKey = options.GetCacheKey();
+        string cacheKey = options.GetCacheKey()!;
         try
         {
             var cacheKeyHits = await Cache.GetAsync<ICollection<FindHit<T>>>(cacheKey).AnyContext();
@@ -985,7 +993,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         }
     }
 
-    protected async Task<FindHit<T>> GetCachedFindHit(Id id, string cacheKey = null)
+    protected async Task<FindHit<T>?> GetCachedFindHit(Id id, string? cacheKey = null)
     {
         try
         {
@@ -1006,7 +1014,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         }
     }
 
-    protected async Task<ICollection<FindHit<T>>> GetCachedFindHit(ICollection<Id> ids, string cacheKey = null)
+    protected async Task<ICollection<FindHit<T>>> GetCachedFindHit(ICollection<Id> ids, string? cacheKey = null)
     {
         var idList = ids.Select(id => id.Value).ToList();
         IEnumerable<FindHit<T>> result;
@@ -1019,13 +1027,13 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
                 result = cacheHitsById
                     .Where(kvp => kvp.Value.HasValue && !kvp.Value.IsNull)
                     .SelectMany(kvp => kvp.Value.Value)
-                    .Where(v => v?.Document != null && idList.Contains(v.Id));
+                    .Where(v => v is not null && v.Document is not null && v.Id is not null && idList.Contains(v.Id));
             }
             else
             {
                 var cacheKeyHits = await Cache.GetAsync<ICollection<FindHit<T>>>(cacheKey).AnyContext();
                 result = cacheKeyHits.HasValue && !cacheKeyHits.IsNull
-                    ? cacheKeyHits.Value.Where(v => v?.Document != null && idList.Contains(v.Id))
+                    ? cacheKeyHits.Value.Where(v => v is not null && v.Document is not null && v.Id is not null && idList.Contains(v.Id))
                     : Enumerable.Empty<FindHit<T>>();
             }
 
@@ -1046,10 +1054,10 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
 
     protected FindHit<T> ToFindHit(T document)
     {
-        string version = HasVersion ? ((IVersioned)document)?.Version : null;
-        string routing = GetParentIdFunc?.Invoke(document);
+        string? version = HasVersion ? ((IVersioned)document)?.Version : null;
+        string? routing = GetParentIdFunc?.Invoke(document!);
         var idDocument = document as IIdentity;
-        return new FindHit<T>(idDocument?.Id, document, 0, version, routing);
+        return new FindHit<T>(idDocument?.Id, document!, 0, version, routing);
     }
 
     protected Task AddDocumentsToCacheAsync(T document, ICommandOptions options, bool isDirtyRead)
@@ -1071,7 +1079,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     {
         if (options.HasCacheKey())
         {
-            await Cache.SetAsync(options.GetCacheKey(), findHits, options.GetExpiresIn()).AnyContext();
+            await Cache.SetAsync(options.GetCacheKey()!, findHits, options.GetExpiresIn()).AnyContext();
 
             // NOTE: Custom cache keys store the complete filtered result, but ID-based caching is skipped when includes/excludes are present to avoid incomplete data.
             // This method also doesn't take into account any query includes or excludes but GetById(s) requests don't specify a query.
@@ -1085,7 +1093,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
 
         var findHitsById = findHits
             .Where(hit => hit?.Id != null)
-            .GroupBy(hit => hit.Id)
+            .GroupBy(hit => hit.Id!)
             .ToDictionary(g => g.Key, g => (ICollection<FindHit<T>>)g.ToList());
 
         if (findHitsById.Count == 0)

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReindexer.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReindexer.cs
@@ -27,15 +27,15 @@ public class ElasticReindexer
     private const string ID_FIELD = "id";
     private const int MAX_STATUS_FAILS = 10;
 
-    public ElasticReindexer(IElasticClient client, ILogger logger = null) : this(client, TimeProvider.System, logger)
+    public ElasticReindexer(IElasticClient client, ILogger? logger = null) : this(client, TimeProvider.System, logger)
     {
     }
 
-    public ElasticReindexer(IElasticClient client, TimeProvider timeProvider, ILogger logger = null) : this(client, timeProvider ?? TimeProvider.System, new ResiliencePolicyProvider(), logger ?? NullLogger.Instance)
+    public ElasticReindexer(IElasticClient client, TimeProvider timeProvider, ILogger? logger = null) : this(client, timeProvider ?? TimeProvider.System, new ResiliencePolicyProvider(), logger ?? NullLogger.Instance)
     {
     }
 
-    public ElasticReindexer(IElasticClient client, TimeProvider timeProvider, IResiliencePolicyProvider resiliencePolicyProvider, ILogger logger = null)
+    public ElasticReindexer(IElasticClient client, TimeProvider timeProvider, IResiliencePolicyProvider resiliencePolicyProvider, ILogger? logger = null)
     {
         _client = client;
         _timeProvider = timeProvider ?? TimeProvider.System;
@@ -45,7 +45,7 @@ public class ElasticReindexer
         _resiliencePolicy = _resiliencePolicyProvider.GetPolicy<ElasticReindexer>(fallback => fallback.WithMaxAttempts(5).WithDelay(TimeSpan.FromSeconds(10)), _logger, _timeProvider);
     }
 
-    public async Task ReindexAsync(ReindexWorkItem workItem, Func<int, string, Task> progressCallbackAsync = null)
+    public async Task ReindexAsync(ReindexWorkItem workItem, Func<int, string?, Task>? progressCallbackAsync = null)
     {
         if (String.IsNullOrEmpty(workItem.OldIndex))
             throw new ArgumentNullException(nameof(workItem.OldIndex));
@@ -98,7 +98,7 @@ public class ElasticReindexer
         if (!refreshResponse.IsValid)
             _logger.LogWarning("Failed to refresh indices before second reindex pass: {Error}", refreshResponse.ServerError);
 
-        ReindexResult secondPassResult = null;
+        ReindexResult? secondPassResult = null;
         if (!String.IsNullOrEmpty(workItem.TimestampField))
         {
             secondPassResult = await InternalReindexAsync(workItem, progressCallbackAsync, 92, 96, startTime).AnyContext();
@@ -147,7 +147,7 @@ public class ElasticReindexer
         await progressCallbackAsync(100, null).AnyContext();
     }
 
-    private async Task<ReindexResult> InternalReindexAsync(ReindexWorkItem workItem, Func<int, string, Task> progressCallbackAsync, int startProgress = 0, int endProgress = 100, DateTime? startTime = null, CancellationToken cancellationToken = default)
+    private async Task<ReindexResult> InternalReindexAsync(ReindexWorkItem workItem, Func<int, string?, Task> progressCallbackAsync, int startProgress = 0, int endProgress = 100, DateTime? startTime = null, CancellationToken cancellationToken = default)
     {
         var query = await GetResumeQueryAsync(workItem.NewIndex, workItem.TimestampField, startTime).AnyContext();
 
@@ -178,7 +178,7 @@ public class ElasticReindexer
         long totalDocs = result.Total;
 
         bool taskSuccess = false;
-        TaskReindexResult lastReindexResponse = null;
+        TaskReindexResult? lastReindexResponse = null;
         int statusGetFails = 0;
         long lastProgress = 0;
         var sw = Stopwatch.StartNew();
@@ -290,7 +290,7 @@ public class ElasticReindexer
 
     private async Task HandleFailureAsync(ReindexWorkItem workItem, BulkIndexByScrollFailure failure)
     {
-        _logger.LogError("Error reindexing document {Index}/{Id}: [{Status}] {Message}", workItem.OldIndex, failure.Id, failure.Status, failure.Cause.Reason);
+        _logger.LogError("Error reindexing document {Index}/{Id}: [{Status}] {Message}", workItem.OldIndex, failure.Id, failure.Status, failure.Cause?.Reason);
         var gr = await _client.GetAsync<object>(request: new GetRequest(workItem.OldIndex, failure.Id)).AnyContext();
 
         if (!gr.IsValid)
@@ -333,7 +333,7 @@ public class ElasticReindexer
         return new List<string>();
     }
 
-    private async Task<QueryContainer> GetResumeQueryAsync(string newIndex, string timestampField, DateTime? startTime)
+    private async Task<QueryContainer> GetResumeQueryAsync(string newIndex, string? timestampField, DateTime? startTime)
     {
         var descriptor = new QueryContainerDescriptor<object>();
         if (startTime.HasValue)
@@ -346,7 +346,7 @@ public class ElasticReindexer
         return descriptor;
     }
 
-    private QueryContainer CreateRangeQuery(QueryContainerDescriptor<object> descriptor, string timestampField, DateTime? startTime)
+    private QueryContainer CreateRangeQuery(QueryContainerDescriptor<object> descriptor, string? timestampField, DateTime? startTime)
     {
         if (!startTime.HasValue)
             return descriptor;
@@ -397,52 +397,52 @@ public class ElasticReindexer
         return startProgress + (int)((100 * (double)completed / total) * (((double)endProgress - startProgress) / 100));
     }
 
-    private class ReindexResult
+    private record ReindexResult
     {
-        public long Total { get; set; }
-        public long Completed { get; set; }
-        public long Failures { get; set; }
-        public bool Succeeded { get; set; }
+        public long Total { get; init; }
+        public long Completed { get; init; }
+        public long Failures { get; init; }
+        public bool Succeeded { get; init; }
     }
 
-    private class TaskWithReindexResponse
+    private record TaskWithReindexResponse
     {
-        public TaskReindexResult Response { get; set; }
-        public TaskReindexError Error { get; set; }
+        public TaskReindexResult? Response { get; init; }
+        public TaskReindexError? Error { get; init; }
     }
 
-    private class TaskReindexError
+    private record TaskReindexError
     {
-        public string Type { get; set; }
-        public string Reason { get; set; }
-        public List<string> Script_Stack { get; set; }
+        public string? Type { get; init; }
+        public string? Reason { get; init; }
+        public List<string>? Script_Stack { get; init; }
 
-        public TaskCause Caused_By { get; set; }
+        public TaskCause? Caused_By { get; init; }
     }
 
-    private class TaskCause
+    private record TaskCause
     {
-        public string Type { get; set; }
-        public string Reason { get; set; }
+        public string? Type { get; init; }
+        public string? Reason { get; init; }
     }
 
-    private class TaskReindexResult
+    private record TaskReindexResult
     {
-        public long Total { get; set; }
-        public long Created { get; set; }
-        public long Updated { get; set; }
-        public long Noops { get; set; }
-        public long VersionConflicts { get; set; }
+        public long Total { get; init; }
+        public long Created { get; init; }
+        public long Updated { get; init; }
+        public long Noops { get; init; }
+        public long VersionConflicts { get; init; }
 
-        public IReadOnlyCollection<BulkIndexByScrollFailure> Failures { get; set; }
+        public IReadOnlyCollection<BulkIndexByScrollFailure>? Failures { get; init; }
     }
 
-    private class BulkIndexByScrollFailure
+    private record BulkIndexByScrollFailure
     {
-        public Error Cause { get; set; }
-        public string Id { get; set; }
-        public string Index { get; set; }
-        public int Status { get; set; }
-        public string Type { get; set; }
+        public Error? Cause { get; init; }
+        public string? Id { get; init; }
+        public string? Index { get; init; }
+        public int Status { get; init; }
+        public string? Type { get; init; }
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReindexer.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReindexer.cs
@@ -348,7 +348,14 @@ public class ElasticReindexer
     private async Task HandleFailureAsync(ReindexWorkItem workItem, BulkIndexByScrollFailure failure)
     {
         _logger.LogError("Error reindexing document {Index}/{Id}: [{Status}] {Message}", workItem.OldIndex, failure.Id, failure.Status, failure.Cause?.Reason);
-        var gr = await _client.GetAsync<object>(request: new GetRequest(workItem.OldIndex, failure.Id!)).AnyContext();
+
+        if (String.IsNullOrEmpty(failure.Id))
+        {
+            _logger.LogWarning("Skipping error document fetch: failure has no document Id");
+            return;
+        }
+
+        var gr = await _client.GetAsync<object>(request: new GetRequest(workItem.OldIndex, failure.Id)).AnyContext();
 
         if (!gr.IsValidResponse)
         {

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReindexer.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReindexer.cs
@@ -33,15 +33,15 @@ public class ElasticReindexer
     private const string ID_FIELD = "id";
     private const int MAX_STATUS_FAILS = 10;
 
-    public ElasticReindexer(ElasticsearchClient client, ITextSerializer serializer, ILogger logger = null) : this(client, serializer, TimeProvider.System, logger)
+    public ElasticReindexer(ElasticsearchClient client, ITextSerializer serializer, ILogger? logger = null) : this(client, serializer, TimeProvider.System, logger)
     {
     }
 
-    public ElasticReindexer(ElasticsearchClient client, ITextSerializer serializer, TimeProvider timeProvider, ILogger logger = null) : this(client, serializer, timeProvider ?? TimeProvider.System, new ResiliencePolicyProvider(), logger ?? NullLogger.Instance)
+    public ElasticReindexer(ElasticsearchClient client, ITextSerializer serializer, TimeProvider timeProvider, ILogger? logger = null) : this(client, serializer, timeProvider ?? TimeProvider.System, new ResiliencePolicyProvider(), logger ?? NullLogger.Instance)
     {
     }
 
-    public ElasticReindexer(ElasticsearchClient client, ITextSerializer serializer, TimeProvider timeProvider, IResiliencePolicyProvider resiliencePolicyProvider, ILogger logger = null)
+    public ElasticReindexer(ElasticsearchClient client, ITextSerializer serializer, TimeProvider timeProvider, IResiliencePolicyProvider resiliencePolicyProvider, ILogger? logger = null)
     {
         _client = client;
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
@@ -52,7 +52,7 @@ public class ElasticReindexer
         _resiliencePolicy = _resiliencePolicyProvider.GetPolicy<ElasticReindexer>(fallback => fallback.WithMaxAttempts(5).WithDelay(TimeSpan.FromSeconds(10)), _logger, _timeProvider);
     }
 
-    public async Task ReindexAsync(ReindexWorkItem workItem, Func<int, string, Task> progressCallbackAsync = null)
+    public async Task ReindexAsync(ReindexWorkItem workItem, Func<int, string?, Task>? progressCallbackAsync = null)
     {
         if (String.IsNullOrEmpty(workItem.OldIndex))
             throw new ArgumentNullException(nameof(workItem.OldIndex));
@@ -117,7 +117,7 @@ public class ElasticReindexer
         if (!refreshResponse.IsValidResponse)
             _logger.LogWarning("Failed to refresh indices before second reindex pass: {Error}", refreshResponse.ElasticsearchServerError);
 
-        ReindexResult secondPassResult = null;
+        ReindexResult? secondPassResult = null;
         if (!String.IsNullOrEmpty(workItem.TimestampField))
         {
             secondPassResult = await InternalReindexAsync(workItem, progressCallbackAsync, 92, 96, startTime).AnyContext();
@@ -166,7 +166,7 @@ public class ElasticReindexer
         await progressCallbackAsync(100, null).AnyContext();
     }
 
-    private async Task<ReindexResult> InternalReindexAsync(ReindexWorkItem workItem, Func<int, string, Task> progressCallbackAsync, int startProgress = 0, int endProgress = 100, DateTime? startTime = null, CancellationToken cancellationToken = default)
+    private async Task<ReindexResult> InternalReindexAsync(ReindexWorkItem workItem, Func<int, string?, Task> progressCallbackAsync, int startProgress = 0, int endProgress = 100, DateTime? startTime = null, CancellationToken cancellationToken = default)
     {
         var query = await GetResumeQueryAsync(workItem.NewIndex, workItem.TimestampField, startTime).AnyContext();
 
@@ -192,7 +192,7 @@ public class ElasticReindexer
             return response;
         }, cancellationToken).AnyContext();
 
-        if (result.Task == null)
+        if (result.Task is null)
         {
             _logger.LogError("Reindex failed to start - no task returned. Response valid: {IsValid}, Reason: {Reason}",
                 result.IsValidResponse, result.ElasticsearchServerError?.Error?.Reason ?? "Unknown");
@@ -205,7 +205,7 @@ public class ElasticReindexer
         long totalDocs = result.Total ?? 0;
 
         bool taskSuccess = false;
-        TaskReindexResult lastReindexResponse = null;
+        TaskReindexResult? lastReindexResponse = null;
         int statusGetFails = 0;
         long lastProgress = 0;
         var sw = Stopwatch.StartNew();
@@ -243,7 +243,7 @@ public class ElasticReindexer
 
             // Extract status values from the raw JSON. The Status property is object? and may be
             // deserialized as JsonElement or IDictionary<string, object> depending on serializer config.
-            TaskStatusValues taskStatus = null;
+            TaskStatusValues? taskStatus = null;
             if (status.Task.Status is JsonElement jsonElement)
             {
                 taskStatus = new TaskStatusValues
@@ -347,8 +347,8 @@ public class ElasticReindexer
 
     private async Task HandleFailureAsync(ReindexWorkItem workItem, BulkIndexByScrollFailure failure)
     {
-        _logger.LogError("Error reindexing document {Index}/{Id}: [{Status}] {Message}", workItem.OldIndex, failure.Id, failure.Status, failure.Cause.Reason);
-        var gr = await _client.GetAsync<object>(request: new GetRequest(workItem.OldIndex, failure.Id)).AnyContext();
+        _logger.LogError("Error reindexing document {Index}/{Id}: [{Status}] {Message}", workItem.OldIndex, failure.Id, failure.Status, failure.Cause?.Reason);
+        var gr = await _client.GetAsync<object>(request: new GetRequest(workItem.OldIndex, failure.Id!)).AnyContext();
 
         if (!gr.IsValidResponse)
         {
@@ -411,7 +411,7 @@ public class ElasticReindexer
         return [];
     }
 
-    private async Task<Query> GetResumeQueryAsync(string newIndex, string timestampField, DateTime? startTime)
+    private async Task<Query?> GetResumeQueryAsync(string newIndex, string? timestampField, DateTime? startTime)
     {
         var descriptor = new QueryDescriptor<object>();
         if (startTime.HasValue)
@@ -425,7 +425,7 @@ public class ElasticReindexer
         return null;
     }
 
-    private Query CreateRangeQuery(QueryDescriptor<object> descriptor, string timestampField, DateTime? startTime)
+    private Query? CreateRangeQuery(QueryDescriptor<object> descriptor, string? timestampField, DateTime? startTime)
     {
         if (!startTime.HasValue)
             return descriptor;
@@ -493,61 +493,61 @@ public class ElasticReindexer
         return startProgress + (int)((100 * (double)completed / total) * (((double)endProgress - startProgress) / 100));
     }
 
-    private class ReindexResult
+    private record ReindexResult
     {
-        public long Total { get; set; }
-        public long Completed { get; set; }
-        public long Failures { get; set; }
-        public bool Succeeded { get; set; }
+        public long Total { get; init; }
+        public long Completed { get; init; }
+        public long Failures { get; init; }
+        public bool Succeeded { get; init; }
     }
 
-    private class TaskWithReindexResponse
+    private record TaskWithReindexResponse
     {
-        public TaskReindexResult Response { get; set; }
-        public TaskReindexError Error { get; set; }
+        public TaskReindexResult? Response { get; init; }
+        public TaskReindexError? Error { get; init; }
     }
 
-    private class TaskReindexError
+    private record TaskReindexError
     {
-        public string Type { get; set; }
-        public string Reason { get; set; }
-        public List<string> Script_Stack { get; set; }
+        public string? Type { get; init; }
+        public string? Reason { get; init; }
+        public List<string>? Script_Stack { get; init; }
 
-        public TaskCause Caused_By { get; set; }
+        public TaskCause? Caused_By { get; init; }
     }
 
-    private class TaskCause
+    private record TaskCause
     {
-        public string Type { get; set; }
-        public string Reason { get; set; }
+        public string? Type { get; init; }
+        public string? Reason { get; init; }
     }
 
-    private class TaskReindexResult
+    private record TaskReindexResult
     {
-        public long Total { get; set; }
-        public long Created { get; set; }
-        public long Updated { get; set; }
-        public long Noops { get; set; }
-        public long VersionConflicts { get; set; }
+        public long Total { get; init; }
+        public long Created { get; init; }
+        public long Updated { get; init; }
+        public long Noops { get; init; }
+        public long VersionConflicts { get; init; }
 
-        public IReadOnlyCollection<BulkIndexByScrollFailure> Failures { get; set; }
+        public IReadOnlyCollection<BulkIndexByScrollFailure>? Failures { get; init; }
     }
 
-    private class TaskStatusValues
+    private record TaskStatusValues
     {
-        public long Total { get; set; }
-        public long Created { get; set; }
-        public long Updated { get; set; }
-        public long Noops { get; set; }
-        public long VersionConflicts { get; set; }
+        public long Total { get; init; }
+        public long Created { get; init; }
+        public long Updated { get; init; }
+        public long Noops { get; init; }
+        public long VersionConflicts { get; init; }
     }
 
-    private class BulkIndexByScrollFailure
+    private record BulkIndexByScrollFailure
     {
-        public Error Cause { get; set; }
-        public string Id { get; set; }
-        public string Index { get; set; }
-        public int Status { get; set; }
-        public string Type { get; set; }
+        public Error? Cause { get; init; }
+        public string? Id { get; init; }
+        public string? Index { get; init; }
+        public int Status { get; init; }
+        public string? Type { get; init; }
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -31,16 +31,21 @@ namespace Foundatio.Repositories.Elasticsearch;
 
 public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T>, ISearchableRepository<T> where T : class, IIdentity, new()
 {
-    protected readonly IMessagePublisher _messagePublisher;
+    protected readonly IMessagePublisher? _messagePublisher;
 
     protected ElasticRepositoryBase(IIndex index) : base(index)
     {
         _messagePublisher = index.Configuration.MessageBus;
         NotificationsEnabled = _messagePublisher != null;
 
-        AddRequiredField(_idField);
+        if (_idField is not null)
+            AddRequiredField(_idField);
+
         if (HasCreatedDate)
             AddRequiredField(e => ((IHaveCreatedDate)e).CreatedUtc);
+
+        if (HasDates && _updatedUtcField is not null)
+            AddRequiredField(_updatedUtcField);
 
         if (HasCustomFields)
         {
@@ -57,15 +62,15 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     /// Override to <c>true</c> for custom date field scenarios (e.g., nested metadata dates).
     /// </summary>
     protected virtual bool HasDateTracking => HasDates;
-    protected string DefaultPipeline { get; set; } = null;
+    protected string? DefaultPipeline { get; set; } = null;
     protected bool AutoCreateCustomFields { get; set; } = false;
 
     public Task<T> AddAsync(T document, CommandOptionsDescriptor<T> options)
     {
-        return AddAsync(document, options.Configure());
+        return AddAsync(document, options?.Configure());
     }
 
-    public async Task<T> AddAsync(T document, ICommandOptions options = null)
+    public async Task<T> AddAsync(T document, ICommandOptions? options = null)
     {
         if (document == null)
             throw new ArgumentNullException(nameof(document));
@@ -76,10 +81,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task AddAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options)
     {
-        return AddAsync(documents, options.Configure());
+        return AddAsync(documents, options?.Configure());
     }
 
-    public virtual async Task AddAsync(IEnumerable<T> documents, ICommandOptions options = null)
+    public virtual async Task AddAsync(IEnumerable<T> documents, ICommandOptions? options = null)
     {
         var docs = documents?.ToList();
         if (docs == null || docs.Any(d => d == null))
@@ -88,7 +93,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (docs.Count == 0)
             return;
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         await OnDocumentsAddingAsync(docs, options).AnyContext();
 
@@ -114,10 +119,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task<T> SaveAsync(T document, CommandOptionsDescriptor<T> options)
     {
-        return SaveAsync(document, options.Configure());
+        return SaveAsync(document, options?.Configure());
     }
 
-    public async Task<T> SaveAsync(T document, ICommandOptions options = null)
+    public async Task<T> SaveAsync(T document, ICommandOptions? options = null)
     {
         if (document == null)
             throw new ArgumentNullException(nameof(document));
@@ -128,10 +133,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task SaveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options)
     {
-        return SaveAsync(documents, options.Configure());
+        return SaveAsync(documents, options?.Configure());
     }
 
-    public virtual async Task SaveAsync(IEnumerable<T> documents, ICommandOptions options = null)
+    public virtual async Task SaveAsync(IEnumerable<T> documents, ICommandOptions? options = null)
     {
         var docs = documents?.ToList();
         if (docs == null || docs.Any(d => d == null))
@@ -144,7 +149,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (ids.Length < docs.Count)
             throw new ArgumentException("Id must be set when calling Save.");
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         var originalDocuments = await GetOriginalDocumentsAsync(ids, options).AnyContext();
         await OnDocumentsSavingAsync(docs, originalDocuments, options).AnyContext();
@@ -172,10 +177,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task<bool> PatchAsync(Id id, IPatchOperation operation, CommandOptionsDescriptor<T> options)
     {
-        return PatchAsync(id, operation, options.Configure());
+        return PatchAsync(id, operation, options?.Configure());
     }
 
-    public virtual async Task<bool> PatchAsync(Id id, IPatchOperation operation, ICommandOptions options = null)
+    public virtual async Task<bool> PatchAsync(Id id, IPatchOperation operation, ICommandOptions? options = null)
     {
         if (String.IsNullOrEmpty(id.Value))
             throw new ArgumentNullException(nameof(id));
@@ -190,7 +195,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
         await ElasticIndex.EnsureIndexAsync(id).AnyContext();
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         if (operation is ScriptPatch scriptPatchOp)
             operation = ApplyDateTracking(scriptPatchOp);
@@ -307,7 +312,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                             sourceObj[prop.Key] = prop.Value?.DeepClone();
                     }
 
-                    using var mergedStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(sourceNode.ToJsonString()));
+                    using var mergedStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(sourceNode!.ToJsonString()));
                     var mergedDocument = _client.ElasticsearchClientSettings.SourceSerializer.Deserialize<T>(mergedStream);
 
                     var indexRequest = new IndexRequest<T>(mergedDocument, ElasticIndex.GetIndex(id), id.Value)
@@ -398,12 +403,12 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 // Serialize to JSON string, apply patch, deserialize back
                 // Using System.Text.Json.Nodes.JsonNode since Elastic.Clients.Elasticsearch uses System.Text.Json exclusively
                 var json = _client.ElasticsearchClientSettings.SourceSerializer.SerializeToString(response.Source);
-                var target = JsonNode.Parse(json);
+                JsonNode target = JsonNode.Parse(json)!;
                 new JsonPatcher().Patch(ref target, jsonOperation.Patch);
 
                 ApplyDateTracking(target);
 
-                using var patchStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(target.ToJsonString()));
+                using var patchStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(target!.ToJsonString()));
                 var patchedDocument = _client.ElasticsearchClientSettings.SourceSerializer.Deserialize<T>(patchStream);
 
                 var indexRequest = new IndexRequest<T>(patchedDocument, ElasticIndex.GetIndex(id), id.Value)
@@ -443,7 +448,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     _logger.LogWarning("Unable to override resilience policy max attempts");
             }
 
-            T modifiedDocument = null;
+            T? modifiedDocument = null;
             await policy.ExecuteAsync(async ct =>
             {
                 modifiedDocument = null;
@@ -467,7 +472,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
                 bool actionModified = false;
                 foreach (var action in actionPatch.Actions)
-                    actionModified |= action?.Invoke(response.Source) ?? false;
+                    actionModified |= action?.Invoke(response.Source!) ?? false;
 
                 if (!actionModified)
                 {
@@ -476,10 +481,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 }
 
                 if (HasDateTracking)
-                    SetDocumentDates(response.Source, ElasticIndex.Configuration.TimeProvider);
+                    SetDocumentDates(response.Source!, ElasticIndex.Configuration.TimeProvider);
 
-                modifiedDocument = response.Source;
-                await IndexDocumentsAsync([response.Source], false, options).AnyContext();
+                modifiedDocument = response.Source!;
+                await IndexDocumentsAsync([response.Source!], false, options).AnyContext();
             }).AnyContext();
 
             if (modified && modifiedDocument is not null)
@@ -516,10 +521,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task<long> PatchAsync(Ids ids, IPatchOperation operation, CommandOptionsDescriptor<T> options)
     {
-        return PatchAsync(ids, operation, options.Configure());
+        return PatchAsync(ids, operation, options?.Configure());
     }
 
-    public virtual async Task<long> PatchAsync(Ids ids, IPatchOperation operation, ICommandOptions options = null)
+    public virtual async Task<long> PatchAsync(Ids ids, IPatchOperation operation, ICommandOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(ids);
         ArgumentNullException.ThrowIfNull(operation);
@@ -527,7 +532,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (ids is { Count: 0 })
             return 0;
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         if (ids.Count is 1)
             return await PatchAsync(ids[0], operation, options).AnyContext() ? 1 : 0;
@@ -621,10 +626,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task RemoveAsync(Id id, CommandOptionsDescriptor<T> options)
     {
-        return RemoveAsync(id, options.Configure());
+        return RemoveAsync(id, options?.Configure());
     }
 
-    public Task RemoveAsync(Id id, ICommandOptions options = null)
+    public Task RemoveAsync(Id id, ICommandOptions? options = null)
     {
         if (String.IsNullOrEmpty(id))
             throw new ArgumentNullException(nameof(id));
@@ -634,15 +639,15 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task RemoveAsync(Ids ids, CommandOptionsDescriptor<T> options)
     {
-        return RemoveAsync(ids, options.Configure());
+        return RemoveAsync(ids, options?.Configure());
     }
 
-    public async Task RemoveAsync(Ids ids, ICommandOptions options = null)
+    public async Task RemoveAsync(Ids ids, ICommandOptions? options = null)
     {
         if (ids == null)
             throw new ArgumentNullException(nameof(ids));
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         if (IsCacheEnabled)
             options = options.ReadCache();
 
@@ -657,10 +662,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task RemoveAsync(T document, CommandOptionsDescriptor<T> options)
     {
-        return RemoveAsync(document, options.Configure());
+        return RemoveAsync(document, options?.Configure());
     }
 
-    public virtual Task RemoveAsync(T document, ICommandOptions options = null)
+    public virtual Task RemoveAsync(T document, ICommandOptions? options = null)
     {
         if (document == null)
             throw new ArgumentNullException(nameof(document));
@@ -670,10 +675,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task RemoveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options)
     {
-        return RemoveAsync(documents, options.Configure());
+        return RemoveAsync(documents, options?.Configure());
     }
 
-    public virtual async Task RemoveAsync(IEnumerable<T> documents, ICommandOptions options = null)
+    public virtual async Task RemoveAsync(IEnumerable<T> documents, ICommandOptions? options = null)
     {
         var docs = documents?.ToList();
         if (docs == null || docs.Any(d => d == null))
@@ -692,7 +697,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             await ElasticIndex.EnsureIndexAsync(null).AnyContext();
         }
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         if (IsCacheEnabled && options.HasCacheKey())
             throw new ArgumentException("Cache key can't be set when calling RemoveAsync");
 
@@ -749,12 +754,12 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         await OnDocumentsRemovedAsync(docs, options).AnyContext();
     }
 
-    public Task<long> RemoveAllAsync(CommandOptionsDescriptor<T> options)
+    public Task<long> RemoveAllAsync(CommandOptionsDescriptor<T>? options)
     {
-        return RemoveAllAsync(options.Configure());
+        return RemoveAllAsync(options?.Configure());
     }
 
-    public virtual async Task<long> RemoveAllAsync(ICommandOptions options = null)
+    public virtual async Task<long> RemoveAllAsync(ICommandOptions? options = null)
     {
         long count = await RemoveAllAsync(NewQuery(), options).AnyContext();
 
@@ -764,9 +769,9 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return count;
     }
 
-    public Task<long> PatchAllAsync(RepositoryQueryDescriptor<T> query, IPatchOperation operation, CommandOptionsDescriptor<T> options = null)
+    public Task<long> PatchAllAsync(RepositoryQueryDescriptor<T> query, IPatchOperation operation, CommandOptionsDescriptor<T>? options = null)
     {
-        return PatchAllAsync(query.Configure(), operation, options.Configure());
+        return PatchAllAsync(query.Configure(), operation, options?.Configure());
     }
 
     /// <summary>
@@ -774,7 +779,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     /// update-by-query when caching is disabled; otherwise they fall back to batch processing.
     /// JsonPatch and ActionPatch always use batch processing with conflict retry.
     /// </summary>
-    public virtual async Task<long> PatchAllAsync(IRepositoryQuery query, IPatchOperation operation, ICommandOptions options = null)
+    public virtual async Task<long> PatchAllAsync(IRepositoryQuery query, IPatchOperation operation, ICommandOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(operation);
 
@@ -787,7 +792,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (!ElasticIndex.HasMultipleIndexes)
             await ElasticIndex.EnsureIndexAsync(null).AnyContext();
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         if (operation is ScriptPatch scriptPatchOp)
             operation = ApplyDateTracking(scriptPatchOp);
@@ -809,23 +814,23 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     {
                         // Using System.Text.Json.Nodes.JsonNode since Elastic.Clients.Elasticsearch uses System.Text.Json exclusively
                         var json = _client.ElasticsearchClientSettings.SourceSerializer.SerializeToString(h.Document);
-                        var target = JsonNode.Parse(json);
+                        JsonNode target = JsonNode.Parse(json)!;
                         patcher.Patch(ref target, jsonOperation.Patch);
-                        using var docStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(target.ToJsonString()));
+                        using var docStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(target!.ToJsonString()));
                         var doc = _client.ElasticsearchClientSettings.SourceSerializer.Deserialize<T>(docStream);
 
                         if (HasDateTracking)
                             SetDocumentDates(doc, ElasticIndex.Configuration.TimeProvider);
 
-                        processedDocs[h.Id] = doc;
+                        processedDocs[h.Id!] = doc!;
                         var elasticVersion = h.GetElasticVersion();
 
                         b.Index(doc, i =>
                         {
-                            i.Id(h.Id)
-                             .Routing(h.Routing)
-                             .Index(h.GetIndex())
-                             .Pipeline(DefaultPipeline);
+                            i.Id(h.Id!)
+                             .Routing(h.Routing!)
+                             .Index(h.GetIndex()!)
+                             .Pipeline(DefaultPipeline!);
 
                             if (HasVersion)
                             {
@@ -848,8 +853,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     retriedIds = retryResult.Ids;
                 }
 
-                var successfulIds = new HashSet<string>(bulkResult.Items?.Where(i => i.IsValid).Select(i => i.Id) ?? []);
-                var modifiedDocuments = successfulIds.Select(id => processedDocs.GetValueOrDefault(id)).Where(d => d is not null).ToList();
+                var successfulIds = new HashSet<string>(bulkResult.Items?.Where(i => i.IsValid).Select(i => i.Id!) ?? []);
+                var modifiedDocuments = successfulIds.Select(id => processedDocs.GetValueOrDefault(id)).Where(d => d is not null).Select(d => d!).ToList();
                 modifiedRecords += modifiedDocuments.Count;
 
                 if (modifiedDocuments.Count > 0 || retriedIds.Count > 0)
@@ -882,6 +887,9 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 var modifiedHits = new List<FindHit<T>>(results.Hits.Count);
                 foreach (var h in results.Hits)
                 {
+                    if (h.Document is null)
+                        continue;
+
                     bool actionModified = false;
                     foreach (var action in actionOperation.Actions)
                         actionModified |= action?.Invoke(h.Document) ?? false;
@@ -907,10 +915,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
                         b.Index(h.Document, i =>
                         {
-                            i.Id(h.Id)
-                                .Routing(h.Routing)
-                                .Index(h.GetIndex())
-                                .Pipeline(DefaultPipeline);
+                            i.Id(h.Id!)
+                                .Routing(h.Routing!)
+                                .Index(h.GetIndex()!)
+                                .Pipeline(DefaultPipeline!);
 
                             if (HasVersion)
                             {
@@ -933,18 +941,18 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     retriedIds = retryResult.Ids;
                 }
 
-                var successfulIds = new HashSet<string>(bulkResult.Items?.Where(i => i.IsValid).Select(i => i.Id) ?? []);
-                var modifiedDocuments = modifiedHits.Where(h => successfulIds.Contains(h.Id)).ToList();
+                var successfulIds = new HashSet<string>(bulkResult.Items?.Where(i => i.IsValid).Select(i => i.Id!) ?? []);
+                var modifiedDocuments = modifiedHits.Where(h => successfulIds.Contains(h.Id!)).ToList();
                 modifiedRecords += modifiedDocuments.Count;
 
                 if (modifiedDocuments.Count > 0 || retriedIds.Count > 0)
                 {
                     if (IsCacheEnabled)
-                        await InvalidateCacheAsync(modifiedDocuments.Select(h => h.Document)).AnyContext();
+                        await InvalidateCacheAsync(modifiedDocuments.Select(h => h.Document!)).AnyContext();
 
                     try
                     {
-                        var callbackIds = modifiedDocuments.Select(h => h.Id).Concat(retriedIds).ToList();
+                        var callbackIds = modifiedDocuments.Select(h => h.Id!).Concat(retriedIds).ToList();
                         options.GetUpdatedIdsCallback()?.Invoke(callbackIds);
                     }
                     catch (OperationCanceledException) { throw; }
@@ -985,7 +993,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     throw new DocumentException(response.GetErrorMessage("Error occurred while patching by query"), response.OriginalException());
                 }
 
-                var taskId = response.Task.ToString();
+                var taskId = response.Task!.ToString();
                 int attempts = 0;
                 do
                 {
@@ -1052,8 +1060,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             }
             else
             {
-                if (HasIdentity && !query.GetIncludes().Contains(_idField.Value))
-                    query.Include(_idField.Value);
+                if (HasIdentity && !query.GetIncludes().Contains(_idField!.Value))
+                    query.Include(_idField!.Value);
 
                 long modifiedInBatch = 0;
                 await BatchProcessAsync(query, async results =>
@@ -1078,16 +1086,16 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                                         sourceObj[prop.Key] = prop.Value?.DeepClone();
                                 }
 
-                                using var mergedStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(sourceNode.ToJsonString()));
+                                using var mergedStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(sourceNode!.ToJsonString()));
                                 var mergedDoc = _client.ElasticsearchClientSettings.SourceSerializer.Deserialize<T>(mergedStream);
                                 var elasticVersion = h.GetElasticVersion();
 
                                 b.Index(mergedDoc, i =>
                                 {
-                                    i.Id(h.Id)
-                                        .Routing(h.Routing)
-                                        .Index(h.GetIndex())
-                                        .Pipeline(DefaultPipeline);
+                                    i.Id(h.Id!)
+                                        .Routing(h.Routing!)
+                                        .Index(h.GetIndex()!)
+                                        .Pipeline(DefaultPipeline!);
 
                                     if (HasVersion)
                                     {
@@ -1098,17 +1106,17 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                             }
                             else if (operation is ScriptPatch sp)
                                 b.Update<T>(u => u
-                                    .Id(h.Id)
-                                    .Routing(h.Routing)
-                                    .Index(h.GetIndex())
+                                    .Id(h.Id!)
+                                    .Routing(h.Routing!)
+                                    .Index(h.GetIndex()!)
                                     .Script(s => s.Source(sp.Script).Params(sp.Params))
                                     .RetriesOnConflict(options.GetRetryCount()));
                             else if (operation is PartialPatch pp)
                                 // TODO: Null-valued properties are silently dropped by the ES client's SourceSerializer
                                 // (elastic/elasticsearch-net#8763). Consumers must use ScriptPatch or JsonPatch to set fields to null.
-                                b.Update<T, object>(u => u.Id(h.Id)
-                                    .Routing(h.Routing)
-                                    .Index(h.GetIndex())
+                                b.Update<T, object>(u => u.Id(h.Id!)
+                                    .Routing(h.Routing!)
+                                    .Index(h.GetIndex()!)
                                     .Doc(pp.Document)
                                     .RetriesOnConflict(options.GetRetryCount()));
                         }
@@ -1126,8 +1134,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
                     var result = BulkResult.From(bulkResult);
                     var updatedIds = results.Hits
-                        .Where(h => result.SuccessfulIds.Contains(h.Id) && !result.NoopIds.Contains(h.Id))
-                        .Select(h => h.Id).ToList();
+                        .Where(h => result.SuccessfulIds.Contains(h.Id!) && !result.NoopIds.Contains(h.Id!))
+                        .Select(h => h.Id!).ToList();
                     modifiedInBatch += updatedIds.Count;
 
                     if (IsCacheEnabled && updatedIds.Count > 0)
@@ -1170,14 +1178,14 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return affectedRecords;
     }
 
-    public Task<long> RemoveAllAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null)
+    public Task<long> RemoveAllAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null)
     {
-        return RemoveAllAsync(query.Configure(), options.Configure());
+        return RemoveAllAsync(query.Configure(), options?.Configure());
     }
 
-    public virtual async Task<long> RemoveAllAsync(IRepositoryQuery query, ICommandOptions options = null)
+    public virtual async Task<long> RemoveAllAsync(IRepositoryQuery query, ICommandOptions? options = null)
     {
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         bool hasRemoveListeners = DocumentsChanging.HasHandlers || DocumentsChanged.HasHandlers || DocumentsRemoving.HasHandlers || DocumentsRemoved.HasHandlers;
         if (hasRemoveListeners || (IsCacheEnabled && options.ShouldUseCache(true)))
         {
@@ -1228,22 +1236,22 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return response.Deleted ?? 0;
     }
 
-    public Task<long> BatchProcessAsync(RepositoryQueryDescriptor<T> query, Func<FindResults<T>, Task<bool>> processFunc, CommandOptionsDescriptor<T> options = null)
+    public Task<long> BatchProcessAsync(RepositoryQueryDescriptor<T> query, Func<FindResults<T>, Task<bool>> processFunc, CommandOptionsDescriptor<T>? options = null)
     {
-        return BatchProcessAsync(query.Configure(), processFunc, options.Configure());
+        return BatchProcessAsync(query.Configure(), processFunc, options?.Configure());
     }
 
-    public Task<long> BatchProcessAsync(IRepositoryQuery query, Func<FindResults<T>, Task<bool>> processFunc, ICommandOptions options = null)
+    public Task<long> BatchProcessAsync(IRepositoryQuery query, Func<FindResults<T>, Task<bool>> processFunc, ICommandOptions? options = null)
     {
         return BatchProcessAsAsync(query, processFunc, options);
     }
 
-    public Task<long> BatchProcessAsAsync<TResult>(RepositoryQueryDescriptor<T> query, Func<FindResults<TResult>, Task<bool>> processFunc, CommandOptionsDescriptor<T> options = null) where TResult : class, new()
+    public Task<long> BatchProcessAsAsync<TResult>(RepositoryQueryDescriptor<T> query, Func<FindResults<TResult>, Task<bool>> processFunc, CommandOptionsDescriptor<T>? options = null) where TResult : class, new()
     {
-        return BatchProcessAsAsync<TResult>(query.Configure(), processFunc, options.Configure());
+        return BatchProcessAsAsync<TResult>(query.Configure(), processFunc, options?.Configure());
     }
 
-    public virtual async Task<long> BatchProcessAsAsync<TResult>(IRepositoryQuery query, Func<FindResults<TResult>, Task<bool>> processFunc, ICommandOptions options = null)
+    public virtual async Task<long> BatchProcessAsAsync<TResult>(IRepositoryQuery query, Func<FindResults<TResult>, Task<bool>> processFunc, ICommandOptions? options = null)
         where TResult : class, new()
     {
         if (processFunc == null)
@@ -1252,7 +1260,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (!ElasticIndex.HasMultipleIndexes)
             await ElasticIndex.EnsureIndexAsync(null).AnyContext();
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         if (!options.ShouldUseSnapshotPaging())
             options.SearchAfterPaging();
         if (!options.HasPageLimit())
@@ -1324,7 +1332,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (String.IsNullOrEmpty(tenantKey))
             return;
 
-        var fieldMapping = await ElasticIndex.Configuration.CustomFieldDefinitionRepository.GetFieldMappingAsync(EntityTypeName, tenantKey).AnyContext();
+        var fieldMapping = await ElasticIndex.Configuration.CustomFieldDefinitionRepository!.GetFieldMappingAsync(EntityTypeName, tenantKey).AnyContext();
         var mapping = fieldMapping.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.GetIdxName(), StringComparer.OrdinalIgnoreCase);
 
         args.Options.QueryFieldResolver(mapping.ToHierarchicalFieldResolver("idx."));
@@ -1336,7 +1344,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
         foreach (var tenant in tenantGroups)
         {
-            var fieldDefinitions = await ElasticIndex.Configuration.CustomFieldDefinitionRepository.GetFieldMappingAsync(EntityTypeName, tenant.Key).AnyContext();
+            var fieldDefinitions = await ElasticIndex.Configuration.CustomFieldDefinitionRepository!.GetFieldMappingAsync(EntityTypeName, tenant.Key!).AnyContext();
 
             foreach (var doc in tenant)
             {
@@ -1368,11 +1376,11 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     }
 
                     var result = await fieldType.ProcessValueAsync(doc, customField.Value, fieldDefinition).AnyContext();
-                    SetDocumentCustomField(doc, customField.Key, result.Value);
-                    idx[fieldDefinition.GetIdxName()] = result.Idx ?? result.Value;
+                    SetDocumentCustomField(doc, customField.Key, result.Value!);
+                    idx[fieldDefinition.GetIdxName()] = (result.Idx ?? result.Value)!;
 
                     if (result.IsCustomFieldDefinitionModified)
-                        await ElasticIndex.Configuration.CustomFieldDefinitionRepository.SaveAsync(fieldDefinition).AnyContext();
+                        await ElasticIndex.Configuration.CustomFieldDefinitionRepository!.SaveAsync(fieldDefinition).AnyContext();
                 }
 
                 foreach (var alwaysProcessField in fieldDefinitions.Values.Where(f => f.ProcessMode == CustomFieldProcessMode.AlwaysProcess))
@@ -1383,19 +1391,19 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                         continue;
                     }
 
-                    var value = GetDocumentCustomField(doc, alwaysProcessField.Name);
-                    var result = await fieldType.ProcessValueAsync(doc, value, alwaysProcessField).AnyContext();
-                    SetDocumentCustomField(doc, alwaysProcessField.Name, result.Value);
-                    idx[alwaysProcessField.GetIdxName()] = result.Idx ?? result.Value;
+                    object? value = GetDocumentCustomField(doc, alwaysProcessField.Name);
+                    var result = await fieldType.ProcessValueAsync(doc, value!, alwaysProcessField).AnyContext();
+                    SetDocumentCustomField(doc, alwaysProcessField.Name, result.Value!);
+                    idx[alwaysProcessField.GetIdxName()] = (result.Idx ?? result.Value)!;
 
                     if (result.IsCustomFieldDefinitionModified)
-                        await ElasticIndex.Configuration.CustomFieldDefinitionRepository.SaveAsync(alwaysProcessField).AnyContext();
+                        await ElasticIndex.Configuration.CustomFieldDefinitionRepository!.SaveAsync(alwaysProcessField).AnyContext();
                 }
             }
         }
     }
 
-    protected virtual async Task<CustomFieldDefinition> HandleUnmappedCustomField(T document, string name, object value, IDictionary<string, CustomFieldDefinition> existingFields)
+    protected virtual async Task<CustomFieldDefinition?> HandleUnmappedCustomField(T document, string name, object value, IDictionary<string, CustomFieldDefinition> existingFields)
     {
         if (!AutoCreateCustomFields)
             return null;
@@ -1404,10 +1412,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (String.IsNullOrEmpty(tenantKey))
             return null;
 
-        return await ElasticIndex.Configuration.CustomFieldDefinitionRepository.AddFieldAsync(EntityTypeName, GetDocumentTenantKey(document), name, StringFieldType.IndexType).AnyContext();
+        return await ElasticIndex.Configuration.CustomFieldDefinitionRepository!.AddFieldAsync(EntityTypeName, GetDocumentTenantKey(document)!, name, StringFieldType.IndexType).AnyContext();
     }
 
-    protected string GetDocumentTenantKey(T document)
+    protected string? GetDocumentTenantKey(T document)
     {
         return document switch
         {
@@ -1417,7 +1425,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         };
     }
 
-    protected IDictionary<string, object> GetDocumentCustomFields(T document)
+    protected IDictionary<string, object>? GetDocumentCustomFields(T document)
     {
         return document switch
         {
@@ -1440,7 +1448,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         }
     }
 
-    protected object GetDocumentCustomField(T document, string name)
+    protected object? GetDocumentCustomField(T document, string name)
     {
         return document switch
         {
@@ -1450,7 +1458,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         };
     }
 
-    protected IDictionary<string, object> GetDocumentIdx(T document)
+    protected IDictionary<string, object>? GetDocumentIdx(T document)
     {
         return document switch
         {
@@ -1460,7 +1468,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         };
     }
 
-    protected virtual string GetTenantKey(IRepositoryQuery query)
+    protected virtual string? GetTenantKey(IRepositoryQuery query)
     {
         return null;
     }
@@ -1519,8 +1527,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         documents.EnsureIds(ElasticIndex.CreateDocumentId, ElasticIndex.Configuration.TimeProvider);
 
         var modifiedDocs = originalDocuments.FullOuterJoin(
-            documents, cf => cf.Id, cf => cf.Id,
-            (original, modified, id) => new { Id = id, Original = original, Modified = modified }).Select(m => new ModifiedDocument<T>(m.Modified, m.Original)).ToList();
+            documents, cf => cf!.Id!, cf => cf!.Id!,
+            (original, modified, id) => new { Id = id, Original = original, Modified = modified }).Select(m => new ModifiedDocument<T>(m.Modified!, m.Original!)).ToList();
 
         if (DocumentsSaving is { HasHandlers: true })
             await DocumentsSaving.InvokeAsync(this, new ModifiedDocumentsEventArgs<T>(modifiedDocs, this, options)).AnyContext();
@@ -1533,8 +1541,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     private async Task OnDocumentsSavedAsync(IReadOnlyCollection<T> documents, IReadOnlyCollection<T> originalDocuments, ICommandOptions options)
     {
         var modifiedDocs = originalDocuments.FullOuterJoin(
-            documents, cf => cf.Id, cf => cf.Id,
-            (original, modified, id) => new { Id = id, Original = original, Modified = modified }).Select(m => new ModifiedDocument<T>(m.Modified, m.Original)).ToList();
+            documents, cf => cf!.Id!, cf => cf!.Id!,
+            (original, modified, id) => new { Id = id, Original = original, Modified = modified }).Select(m => new ModifiedDocument<T>(m.Modified!, m.Original!)).ToList();
 
         if (SupportsSoftDeletes && IsCacheEnabled)
         {
@@ -1610,9 +1618,9 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         await DocumentsChanged.InvokeAsync(this, new DocumentsChangeEventArgs<T>(changeType, documents, this, options)).AnyContext();
     }
 
-    private async Task<IReadOnlyCollection<T>> GetOriginalDocumentsAsync(Ids ids, ICommandOptions options = null)
+    private async Task<IReadOnlyCollection<T>> GetOriginalDocumentsAsync(Ids ids, ICommandOptions options)
     {
-        if (!options.GetOriginalsEnabled(OriginalsEnabled) || ids.Count == 0)
+        if (!options.GetOriginalsEnabled(OriginalsEnabled) || ids.Count is 0)
             return EmptyList;
 
         var originals = options.GetOriginals<T>().ToList();
@@ -1754,7 +1762,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     if (!hit.IsValid)
                         continue;
 
-                    if (!documentsById.TryGetValue(hit.Id, out var document))
+                    if (!documentsById.TryGetValue(hit.Id!, out var document))
                         continue;
 
                     var versionDoc = (IVersioned)document;
@@ -1802,8 +1810,11 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             _logger.LogRequest(bulkResponse, options.GetQueryLogLevel());
             _logger.LogInformation("Bulk {PatchType} had {ConflictCount} version conflicts, re-fetching and retrying", patchType, result.ConflictIds.Count);
 
-            foreach (var hit in results.Hits.Where(h => result.ConflictIds.Contains(h.Id)))
+            foreach (var hit in results.Hits)
             {
+                if (hit.Id is null || !result.ConflictIds.Contains(hit.Id))
+                    continue;
+
                 if (await PatchAsync(new Id(hit.Id, hit.Routing), operation, options).AnyContext())
                     retriedIds.Add(hit.Id);
             }
@@ -1812,13 +1823,18 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return (retriedIds.Count, retriedIds);
     }
 
-    private static void ThrowForBulkErrors(BulkResult result, bool isCreateOperation = false, string operationLabel = null)
+    private static void ThrowForBulkErrors(BulkResult result, bool isCreateOperation = false, string? operationLabel = null)
     {
         if (result.IsSuccess)
             return;
 
         if (result.HasTransportError)
-            throw new DocumentException(result.TransportError, result.TransportException);
+        {
+            if (result.TransportException is not null)
+                throw new DocumentException(result.TransportError ?? "Unknown transport error", result.TransportException);
+
+            throw new DocumentException(result.TransportError ?? "Unknown transport error");
+        }
 
         string label = operationLabel ?? (isCreateOperation ? "adding" : "saving");
         int totalErrors = result.ConflictIds.Count + result.RetryableIds.Count + result.FatalIds.Count;
@@ -1923,7 +1939,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
         var delay = NotificationDeliveryDelay;
         if (documents.Count == 0)
-            return PublishChangeTypeMessageAsync(changeType, null, delay);
+            return PublishChangeTypeMessageAsync(changeType, (T?)null, delay);
 
         var tasks = new List<Task>(documents.Count);
         if (BatchNotifications && documents.Count > 1)
@@ -1969,17 +1985,17 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return Task.WhenAll(tasks);
     }
 
-    protected virtual Task PublishChangeTypeMessageAsync(ChangeType changeType, T document, TimeSpan? delay)
+    protected virtual Task PublishChangeTypeMessageAsync(ChangeType changeType, T? document, TimeSpan? delay)
     {
         return PublishChangeTypeMessageAsync(changeType, document, null, delay);
     }
 
-    protected virtual Task PublishChangeTypeMessageAsync(ChangeType changeType, T document, IDictionary<string, object> data = null, TimeSpan? delay = null)
+    protected virtual Task PublishChangeTypeMessageAsync(ChangeType changeType, T? document, IDictionary<string, object>? data = null, TimeSpan? delay = null)
     {
         return PublishChangeTypeMessageAsync(changeType, document?.Id, data, delay);
     }
 
-    protected virtual Task PublishChangeTypeMessageAsync(ChangeType changeType, string id, IDictionary<string, object> data = null, TimeSpan? delay = null)
+    protected virtual Task PublishChangeTypeMessageAsync(ChangeType changeType, string? id, IDictionary<string, object>? data = null, TimeSpan? delay = null)
     {
         if (!NotificationsEnabled)
             return Task.CompletedTask;
@@ -2022,7 +2038,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     protected virtual string GetUpdatedUtcFieldPath()
     {
         if (HasDates)
-            return _updatedUtcField.Value;
+            return _updatedUtcField!.Value;
 
         throw new RepositoryException(
             $"{GetType().Name} has HasDateTracking=true but does not implement IHaveDates. Override GetUpdatedUtcFieldPath() to return the Elasticsearch field path for your updated timestamp.");
@@ -2156,7 +2172,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return sb.ToString();
     }
 
-    private static JsonNode GetNestedJsonNode(JsonNode node, string dotPath)
+    private static JsonNode? GetNestedJsonNode(JsonNode? node, string dotPath)
     {
         var remaining = dotPath.AsSpan();
 
@@ -2217,12 +2233,12 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         var dict = new Dictionary<string, object>(obj.Count);
 
         foreach (var property in obj)
-            dict[property.Key] = ToValue(property.Value);
+            dict[property.Key] = ToValue(property.Value)!;
 
         return dict;
     }
 
-    private static object ToValue(JsonNode node)
+    private static object? ToValue(JsonNode? node)
     {
         return node switch
         {

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -28,16 +28,21 @@ namespace Foundatio.Repositories.Elasticsearch;
 
 public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T>, ISearchableRepository<T> where T : class, IIdentity, new()
 {
-    protected readonly IMessagePublisher _messagePublisher;
+    protected readonly IMessagePublisher? _messagePublisher;
 
     protected ElasticRepositoryBase(IIndex index) : base(index)
     {
         _messagePublisher = index.Configuration.MessageBus;
         NotificationsEnabled = _messagePublisher != null;
 
-        AddRequiredField(_idField);
+        if (_idField is not null)
+            AddRequiredField(_idField);
+
         if (HasCreatedDate)
             AddRequiredField(e => ((IHaveCreatedDate)e).CreatedUtc);
+
+        if (HasDates && _updatedUtcField is not null)
+            AddRequiredField(_updatedUtcField);
 
         if (HasCustomFields)
         {
@@ -54,15 +59,15 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     /// Override to <c>true</c> for custom date field scenarios (e.g., nested metadata dates).
     /// </summary>
     protected virtual bool HasDateTracking => HasDates;
-    protected string DefaultPipeline { get; set; } = null;
+    protected string? DefaultPipeline { get; set; } = null;
     protected bool AutoCreateCustomFields { get; set; } = false;
 
     public Task<T> AddAsync(T document, CommandOptionsDescriptor<T> options)
     {
-        return AddAsync(document, options.Configure());
+        return AddAsync(document, options?.Configure());
     }
 
-    public async Task<T> AddAsync(T document, ICommandOptions options = null)
+    public async Task<T> AddAsync(T document, ICommandOptions? options = null)
     {
         if (document == null)
             throw new ArgumentNullException(nameof(document));
@@ -73,10 +78,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task AddAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options)
     {
-        return AddAsync(documents, options.Configure());
+        return AddAsync(documents, options?.Configure());
     }
 
-    public virtual async Task AddAsync(IEnumerable<T> documents, ICommandOptions options = null)
+    public virtual async Task AddAsync(IEnumerable<T> documents, ICommandOptions? options = null)
     {
         var docs = documents?.ToList();
         if (docs == null || docs.Any(d => d == null))
@@ -85,7 +90,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (docs.Count == 0)
             return;
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         await OnDocumentsAddingAsync(docs, options).AnyContext();
 
@@ -111,10 +116,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task<T> SaveAsync(T document, CommandOptionsDescriptor<T> options)
     {
-        return SaveAsync(document, options.Configure());
+        return SaveAsync(document, options?.Configure());
     }
 
-    public async Task<T> SaveAsync(T document, ICommandOptions options = null)
+    public async Task<T> SaveAsync(T document, ICommandOptions? options = null)
     {
         if (document == null)
             throw new ArgumentNullException(nameof(document));
@@ -125,10 +130,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task SaveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options)
     {
-        return SaveAsync(documents, options.Configure());
+        return SaveAsync(documents, options?.Configure());
     }
 
-    public virtual async Task SaveAsync(IEnumerable<T> documents, ICommandOptions options = null)
+    public virtual async Task SaveAsync(IEnumerable<T> documents, ICommandOptions? options = null)
     {
         var docs = documents?.ToList();
         if (docs == null || docs.Any(d => d == null))
@@ -141,7 +146,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (ids.Length < docs.Count)
             throw new ArgumentException("Id must be set when calling Save.");
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         var originalDocuments = await GetOriginalDocumentsAsync(ids, options).AnyContext();
         await OnDocumentsSavingAsync(docs, originalDocuments, options).AnyContext();
@@ -169,10 +174,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task<bool> PatchAsync(Id id, IPatchOperation operation, CommandOptionsDescriptor<T> options)
     {
-        return PatchAsync(id, operation, options.Configure());
+        return PatchAsync(id, operation, options?.Configure());
     }
 
-    public virtual async Task<bool> PatchAsync(Id id, IPatchOperation operation, ICommandOptions options = null)
+    public virtual async Task<bool> PatchAsync(Id id, IPatchOperation operation, ICommandOptions? options = null)
     {
         if (String.IsNullOrEmpty(id.Value))
             throw new ArgumentNullException(nameof(id));
@@ -187,7 +192,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
         await ElasticIndex.EnsureIndexAsync(id).AnyContext();
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         if (operation is ScriptPatch scriptPatchOp)
             operation = ApplyDateTracking(scriptPatchOp);
@@ -335,7 +340,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     _logger.LogWarning("Unable to override resilience policy max attempts");
             }
 
-            T modifiedDocument = null;
+            T? modifiedDocument = null;
             await policy.ExecuteAsync(async ct =>
             {
                 modifiedDocument = null;
@@ -410,10 +415,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task<long> PatchAsync(Ids ids, IPatchOperation operation, CommandOptionsDescriptor<T> options)
     {
-        return PatchAsync(ids, operation, options.Configure());
+        return PatchAsync(ids, operation, options?.Configure());
     }
 
-    public virtual async Task<long> PatchAsync(Ids ids, IPatchOperation operation, ICommandOptions options = null)
+    public virtual async Task<long> PatchAsync(Ids ids, IPatchOperation operation, ICommandOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(ids);
         ArgumentNullException.ThrowIfNull(operation);
@@ -421,7 +426,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (ids is { Count: 0 })
             return 0;
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         if (ids.Count is 1)
             return await PatchAsync(ids[0], operation, options).AnyContext() ? 1 : 0;
@@ -510,10 +515,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task RemoveAsync(Id id, CommandOptionsDescriptor<T> options)
     {
-        return RemoveAsync(id, options.Configure());
+        return RemoveAsync(id, options?.Configure());
     }
 
-    public Task RemoveAsync(Id id, ICommandOptions options = null)
+    public Task RemoveAsync(Id id, ICommandOptions? options = null)
     {
         if (String.IsNullOrEmpty(id))
             throw new ArgumentNullException(nameof(id));
@@ -523,15 +528,15 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task RemoveAsync(Ids ids, CommandOptionsDescriptor<T> options)
     {
-        return RemoveAsync(ids, options.Configure());
+        return RemoveAsync(ids, options?.Configure());
     }
 
-    public async Task RemoveAsync(Ids ids, ICommandOptions options = null)
+    public async Task RemoveAsync(Ids ids, ICommandOptions? options = null)
     {
         if (ids == null)
             throw new ArgumentNullException(nameof(ids));
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         if (IsCacheEnabled)
             options = options.ReadCache();
 
@@ -546,10 +551,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task RemoveAsync(T document, CommandOptionsDescriptor<T> options)
     {
-        return RemoveAsync(document, options.Configure());
+        return RemoveAsync(document, options?.Configure());
     }
 
-    public virtual Task RemoveAsync(T document, ICommandOptions options = null)
+    public virtual Task RemoveAsync(T document, ICommandOptions? options = null)
     {
         if (document == null)
             throw new ArgumentNullException(nameof(document));
@@ -559,10 +564,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     public Task RemoveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options)
     {
-        return RemoveAsync(documents, options.Configure());
+        return RemoveAsync(documents, options?.Configure());
     }
 
-    public virtual async Task RemoveAsync(IEnumerable<T> documents, ICommandOptions options = null)
+    public virtual async Task RemoveAsync(IEnumerable<T> documents, ICommandOptions? options = null)
     {
         var docs = documents?.ToList();
         if (docs == null || docs.Any(d => d == null))
@@ -581,7 +586,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             await ElasticIndex.EnsureIndexAsync(null).AnyContext();
         }
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         if (IsCacheEnabled && options.HasCacheKey())
             throw new ArgumentException("Cache key can't be set when calling RemoveAsync");
 
@@ -642,12 +647,12 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         await OnDocumentsRemovedAsync(docs, options).AnyContext();
     }
 
-    public Task<long> RemoveAllAsync(CommandOptionsDescriptor<T> options)
+    public Task<long> RemoveAllAsync(CommandOptionsDescriptor<T>? options)
     {
-        return RemoveAllAsync(options.Configure());
+        return RemoveAllAsync(options?.Configure());
     }
 
-    public virtual async Task<long> RemoveAllAsync(ICommandOptions options = null)
+    public virtual async Task<long> RemoveAllAsync(ICommandOptions? options = null)
     {
         long count = await RemoveAllAsync(NewQuery(), options);
 
@@ -657,9 +662,9 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return count;
     }
 
-    public Task<long> PatchAllAsync(RepositoryQueryDescriptor<T> query, IPatchOperation operation, CommandOptionsDescriptor<T> options = null)
+    public Task<long> PatchAllAsync(RepositoryQueryDescriptor<T> query, IPatchOperation operation, CommandOptionsDescriptor<T>? options = null)
     {
-        return PatchAllAsync(query.Configure(), operation, options.Configure());
+        return PatchAllAsync(query.Configure(), operation, options?.Configure());
     }
 
     /// <summary>
@@ -667,7 +672,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     /// update-by-query when caching is disabled; otherwise they fall back to batch processing.
     /// JsonPatch and ActionPatch always use batch processing with conflict retry.
     /// </summary>
-    public virtual async Task<long> PatchAllAsync(IRepositoryQuery query, IPatchOperation operation, ICommandOptions options = null)
+    public virtual async Task<long> PatchAllAsync(IRepositoryQuery query, IPatchOperation operation, ICommandOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(operation);
 
@@ -680,7 +685,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (!ElasticIndex.HasMultipleIndexes)
             await ElasticIndex.EnsureIndexAsync(null).AnyContext();
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
 
         if (operation is ScriptPatch scriptPatchOp)
             operation = ApplyDateTracking(scriptPatchOp);
@@ -708,7 +713,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                         if (HasDateTracking)
                             SetDocumentDates(doc, ElasticIndex.Configuration.TimeProvider);
 
-                        processedDocs[h.Id] = doc;
+                        processedDocs[h.Id!] = doc!;
                         var elasticVersion = h.GetElasticVersion();
 
                         b.Index<T>(i =>
@@ -745,7 +750,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 }
 
                 var successfulIds = new HashSet<string>(bulkResult.Items?.Where(i => i.IsValid).Select(i => i.Id) ?? []);
-                var modifiedDocuments = successfulIds.Select(id => processedDocs.GetValueOrDefault(id)).Where(d => d is not null).ToList();
+                var modifiedDocuments = successfulIds.Select(id => processedDocs.GetValueOrDefault(id)).Where(d => d is not null).Select(d => d!).ToList();
                 modifiedRecords += modifiedDocuments.Count;
 
                 if (modifiedDocuments.Count > 0 || retriedIds.Count > 0)
@@ -778,6 +783,9 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 var modifiedHits = new List<FindHit<T>>(results.Hits.Count);
                 foreach (var h in results.Hits)
                 {
+                    if (h.Document is null)
+                        continue;
+
                     bool actionModified = false;
                     foreach (var action in actionOperation.Actions)
                         actionModified |= action?.Invoke(h.Document) ?? false;
@@ -803,7 +811,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
                         b.Index<T>(i =>
                         {
-                            i.Document(h.Document)
+                            i.Document(h.Document!)
                                 .Id(h.Id)
                                 .Routing(h.Routing)
                                 .Index(h.GetIndex())
@@ -835,17 +843,17 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 }
 
                 var successfulIds = new HashSet<string>(bulkResult.Items?.Where(i => i.IsValid).Select(i => i.Id) ?? []);
-                var modifiedDocuments = modifiedHits.Where(h => successfulIds.Contains(h.Id)).ToList();
+                var modifiedDocuments = modifiedHits.Where(h => successfulIds.Contains(h.Id!)).ToList();
                 modifiedRecords += modifiedDocuments.Count;
 
                 if (modifiedDocuments.Count > 0 || retriedIds.Count > 0)
                 {
                     if (IsCacheEnabled)
-                        await InvalidateCacheAsync(modifiedDocuments.Select(h => h.Document)).AnyContext();
+                        await InvalidateCacheAsync(modifiedDocuments.Select(h => h.Document!)).AnyContext();
 
                     try
                     {
-                        var callbackIds = modifiedDocuments.Select(h => h.Id).Concat(retriedIds).ToList();
+                        var callbackIds = modifiedDocuments.Select(h => h.Id!).Concat(retriedIds).ToList();
                         options.GetUpdatedIdsCallback()?.Invoke(callbackIds);
                     }
                     catch (OperationCanceledException) { throw; }
@@ -930,8 +938,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             }
             else
             {
-                if (HasIdentity && !query.GetIncludes().Contains(_idField.Value))
-                    query.Include(_idField.Value);
+                if (HasIdentity && !query.GetIncludes().Contains(_idField!.Value))
+                    query.Include(_idField!.Value);
 
                 long modifiedInBatch = 0;
                 await BatchProcessAsync(query, async results =>
@@ -973,8 +981,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
                     var result = BulkResult.From(bulkResult);
                     var updatedIds = results.Hits
-                        .Where(h => result.SuccessfulIds.Contains(h.Id) && !result.NoopIds.Contains(h.Id))
-                        .Select(h => h.Id).ToList();
+                        .Where(h => result.SuccessfulIds.Contains(h.Id!) && !result.NoopIds.Contains(h.Id!))
+                        .Select(h => h.Id!).ToList();
                     modifiedInBatch += updatedIds.Count;
 
                     if (IsCacheEnabled && updatedIds.Count > 0)
@@ -1017,14 +1025,14 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return affectedRecords;
     }
 
-    public Task<long> RemoveAllAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null)
+    public Task<long> RemoveAllAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null)
     {
-        return RemoveAllAsync(query.Configure(), options.Configure());
+        return RemoveAllAsync(query.Configure(), options?.Configure());
     }
 
-    public virtual async Task<long> RemoveAllAsync(IRepositoryQuery query, ICommandOptions options = null)
+    public virtual async Task<long> RemoveAllAsync(IRepositoryQuery query, ICommandOptions? options = null)
     {
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         bool hasRemoveListeners = DocumentsChanging.HasHandlers || DocumentsChanged.HasHandlers || DocumentsRemoving.HasHandlers || DocumentsRemoved.HasHandlers;
         if (hasRemoveListeners || (IsCacheEnabled && options.ShouldUseCache(true)))
         {
@@ -1075,22 +1083,22 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return response.Deleted;
     }
 
-    public Task<long> BatchProcessAsync(RepositoryQueryDescriptor<T> query, Func<FindResults<T>, Task<bool>> processFunc, CommandOptionsDescriptor<T> options = null)
+    public Task<long> BatchProcessAsync(RepositoryQueryDescriptor<T> query, Func<FindResults<T>, Task<bool>> processFunc, CommandOptionsDescriptor<T>? options = null)
     {
-        return BatchProcessAsync(query.Configure(), processFunc, options.Configure());
+        return BatchProcessAsync(query.Configure(), processFunc, options?.Configure());
     }
 
-    public Task<long> BatchProcessAsync(IRepositoryQuery query, Func<FindResults<T>, Task<bool>> processFunc, ICommandOptions options = null)
+    public Task<long> BatchProcessAsync(IRepositoryQuery query, Func<FindResults<T>, Task<bool>> processFunc, ICommandOptions? options = null)
     {
         return BatchProcessAsAsync(query, processFunc, options);
     }
 
-    public Task<long> BatchProcessAsAsync<TResult>(RepositoryQueryDescriptor<T> query, Func<FindResults<TResult>, Task<bool>> processFunc, CommandOptionsDescriptor<T> options = null) where TResult : class, new()
+    public Task<long> BatchProcessAsAsync<TResult>(RepositoryQueryDescriptor<T> query, Func<FindResults<TResult>, Task<bool>> processFunc, CommandOptionsDescriptor<T>? options = null) where TResult : class, new()
     {
-        return BatchProcessAsAsync<TResult>(query.Configure(), processFunc, options.Configure());
+        return BatchProcessAsAsync<TResult>(query.Configure(), processFunc, options?.Configure());
     }
 
-    public virtual async Task<long> BatchProcessAsAsync<TResult>(IRepositoryQuery query, Func<FindResults<TResult>, Task<bool>> processFunc, ICommandOptions options = null)
+    public virtual async Task<long> BatchProcessAsAsync<TResult>(IRepositoryQuery query, Func<FindResults<TResult>, Task<bool>> processFunc, ICommandOptions? options = null)
         where TResult : class, new()
     {
         if (processFunc == null)
@@ -1099,7 +1107,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (!ElasticIndex.HasMultipleIndexes)
             await ElasticIndex.EnsureIndexAsync(null).AnyContext();
 
-        options = ConfigureOptions(options.As<T>());
+        options = ConfigureOptions(options?.As<T>());
         if (!options.ShouldUseSnapshotPaging())
             options.SearchAfterPaging();
         if (!options.HasPageLimit())
@@ -1171,7 +1179,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (String.IsNullOrEmpty(tenantKey))
             return;
 
-        var fieldMapping = await ElasticIndex.Configuration.CustomFieldDefinitionRepository.GetFieldMappingAsync(EntityTypeName, tenantKey);
+        var fieldMapping = await ElasticIndex.Configuration.CustomFieldDefinitionRepository!.GetFieldMappingAsync(EntityTypeName, tenantKey);
         var mapping = fieldMapping.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.GetIdxName(), StringComparer.OrdinalIgnoreCase);
 
         args.Options.QueryFieldResolver(mapping.ToHierarchicalFieldResolver("idx."));
@@ -1183,7 +1191,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
         foreach (var tenant in tenantGroups)
         {
-            var fieldDefinitions = await ElasticIndex.Configuration.CustomFieldDefinitionRepository.GetFieldMappingAsync(EntityTypeName, tenant.Key);
+            var fieldDefinitions = await ElasticIndex.Configuration.CustomFieldDefinitionRepository!.GetFieldMappingAsync(EntityTypeName, tenant.Key!);
 
             foreach (var doc in tenant)
             {
@@ -1215,11 +1223,11 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     }
 
                     var result = await fieldType.ProcessValueAsync(doc, customField.Value, fieldDefinition);
-                    SetDocumentCustomField(doc, customField.Key, result.Value);
-                    idx[fieldDefinition.GetIdxName()] = result.Idx ?? result.Value;
+                    SetDocumentCustomField(doc, customField.Key, result.Value!);
+                    idx[fieldDefinition.GetIdxName()] = (result.Idx ?? result.Value)!;
 
                     if (result.IsCustomFieldDefinitionModified)
-                        await ElasticIndex.Configuration.CustomFieldDefinitionRepository.SaveAsync(fieldDefinition).AnyContext();
+                        await ElasticIndex.Configuration.CustomFieldDefinitionRepository!.SaveAsync(fieldDefinition).AnyContext();
                 }
 
                 foreach (var alwaysProcessField in fieldDefinitions.Values.Where(f => f.ProcessMode == CustomFieldProcessMode.AlwaysProcess))
@@ -1230,19 +1238,19 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                         continue;
                     }
 
-                    object value = GetDocumentCustomField(doc, alwaysProcessField.Name);
-                    var result = await fieldType.ProcessValueAsync(doc, value, alwaysProcessField);
-                    SetDocumentCustomField(doc, alwaysProcessField.Name, result.Value);
-                    idx[alwaysProcessField.GetIdxName()] = result.Idx ?? result.Value;
+                    object? value = GetDocumentCustomField(doc, alwaysProcessField.Name);
+                    var result = await fieldType.ProcessValueAsync(doc, value!, alwaysProcessField);
+                    SetDocumentCustomField(doc, alwaysProcessField.Name, result.Value!);
+                    idx[alwaysProcessField.GetIdxName()] = (result.Idx ?? result.Value)!;
 
                     if (result.IsCustomFieldDefinitionModified)
-                        await ElasticIndex.Configuration.CustomFieldDefinitionRepository.SaveAsync(alwaysProcessField).AnyContext();
+                        await ElasticIndex.Configuration.CustomFieldDefinitionRepository!.SaveAsync(alwaysProcessField).AnyContext();
                 }
             }
         }
     }
 
-    protected virtual async Task<CustomFieldDefinition> HandleUnmappedCustomField(T document, string name, object value, IDictionary<string, CustomFieldDefinition> existingFields)
+    protected virtual async Task<CustomFieldDefinition?> HandleUnmappedCustomField(T document, string name, object value, IDictionary<string, CustomFieldDefinition> existingFields)
     {
         if (!AutoCreateCustomFields)
             return null;
@@ -1251,10 +1259,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (String.IsNullOrEmpty(tenantKey))
             return null;
 
-        return await ElasticIndex.Configuration.CustomFieldDefinitionRepository.AddFieldAsync(EntityTypeName, GetDocumentTenantKey(document), name, StringFieldType.IndexType);
+        return await ElasticIndex.Configuration.CustomFieldDefinitionRepository!.AddFieldAsync(EntityTypeName, GetDocumentTenantKey(document)!, name, StringFieldType.IndexType);
     }
 
-    protected string GetDocumentTenantKey(T document)
+    protected string? GetDocumentTenantKey(T document)
     {
         return document switch
         {
@@ -1264,7 +1272,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         };
     }
 
-    protected IDictionary<string, object> GetDocumentCustomFields(T document)
+    protected IDictionary<string, object>? GetDocumentCustomFields(T document)
     {
         return document switch
         {
@@ -1287,7 +1295,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         }
     }
 
-    protected object GetDocumentCustomField(T document, string name)
+    protected object? GetDocumentCustomField(T document, string name)
     {
         return document switch
         {
@@ -1297,7 +1305,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         };
     }
 
-    protected IDictionary<string, object> GetDocumentIdx(T document)
+    protected IDictionary<string, object>? GetDocumentIdx(T document)
     {
         return document switch
         {
@@ -1307,7 +1315,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         };
     }
 
-    protected virtual string GetTenantKey(IRepositoryQuery query)
+    protected virtual string? GetTenantKey(IRepositoryQuery query)
     {
         return null;
     }
@@ -1366,8 +1374,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         documents.EnsureIds(ElasticIndex.CreateDocumentId, ElasticIndex.Configuration.TimeProvider);
 
         var modifiedDocs = originalDocuments.FullOuterJoin(
-            documents, cf => cf.Id, cf => cf.Id,
-            (original, modified, id) => new { Id = id, Original = original, Modified = modified }).Select(m => new ModifiedDocument<T>(m.Modified, m.Original)).ToList();
+            documents, cf => cf!.Id!, cf => cf!.Id!,
+            (original, modified, id) => new { Id = id, Original = original, Modified = modified }).Select(m => new ModifiedDocument<T>(m.Modified!, m.Original!)).ToList();
 
         if (DocumentsSaving is { HasHandlers: true })
             await DocumentsSaving.InvokeAsync(this, new ModifiedDocumentsEventArgs<T>(modifiedDocs, this, options)).AnyContext();
@@ -1380,8 +1388,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     private async Task OnDocumentsSavedAsync(IReadOnlyCollection<T> documents, IReadOnlyCollection<T> originalDocuments, ICommandOptions options)
     {
         var modifiedDocs = originalDocuments.FullOuterJoin(
-            documents, cf => cf.Id, cf => cf.Id,
-            (original, modified, id) => new { Id = id, Original = original, Modified = modified }).Select(m => new ModifiedDocument<T>(m.Modified, m.Original)).ToList();
+            documents, cf => cf!.Id!, cf => cf!.Id!,
+            (original, modified, id) => new { Id = id, Original = original, Modified = modified }).Select(m => new ModifiedDocument<T>(m.Modified!, m.Original!)).ToList();
 
         if (SupportsSoftDeletes && IsCacheEnabled)
         {
@@ -1457,9 +1465,9 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         await DocumentsChanged.InvokeAsync(this, new DocumentsChangeEventArgs<T>(changeType, documents, this, options)).AnyContext();
     }
 
-    private async Task<IReadOnlyCollection<T>> GetOriginalDocumentsAsync(Ids ids, ICommandOptions options = null)
+    private async Task<IReadOnlyCollection<T>> GetOriginalDocumentsAsync(Ids ids, ICommandOptions options)
     {
-        if (!options.GetOriginalsEnabled(OriginalsEnabled) || ids.Count == 0)
+        if (!options.GetOriginalsEnabled(OriginalsEnabled) || ids.Count is 0)
             return EmptyList;
 
         var originals = options.GetOriginals<T>().ToList();
@@ -1648,8 +1656,11 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             _logger.LogRequest(bulkResponse, options.GetQueryLogLevel());
             _logger.LogInformation("Bulk {PatchType} had {ConflictCount} version conflicts, re-fetching and retrying", patchType, result.ConflictIds.Count);
 
-            foreach (var hit in results.Hits.Where(h => result.ConflictIds.Contains(h.Id)))
+            foreach (var hit in results.Hits)
             {
+                if (hit.Id is null || !result.ConflictIds.Contains(hit.Id))
+                    continue;
+
                 if (await PatchAsync(new Id(hit.Id, hit.Routing), operation, options).AnyContext())
                     retriedIds.Add(hit.Id);
             }
@@ -1658,13 +1669,18 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return (retriedIds.Count, retriedIds);
     }
 
-    private static void ThrowForBulkErrors(BulkResult result, bool isCreateOperation = false, string operationLabel = null)
+    private static void ThrowForBulkErrors(BulkResult result, bool isCreateOperation = false, string? operationLabel = null)
     {
         if (result.IsSuccess)
             return;
 
         if (result.HasTransportError)
-            throw new DocumentException(result.TransportError, result.TransportException);
+        {
+            if (result.TransportException is not null)
+                throw new DocumentException(result.TransportError ?? "Unknown transport error", result.TransportException);
+
+            throw new DocumentException(result.TransportError ?? "Unknown transport error");
+        }
 
         string label = operationLabel ?? (isCreateOperation ? "adding" : "saving");
         int totalErrors = result.ConflictIds.Count + result.RetryableIds.Count + result.FatalIds.Count;
@@ -1769,7 +1785,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
         var delay = NotificationDeliveryDelay;
         if (documents.Count == 0)
-            return PublishChangeTypeMessageAsync(changeType, null, delay);
+            return PublishChangeTypeMessageAsync(changeType, (T?)null, delay);
 
         var tasks = new List<Task>(documents.Count);
         if (BatchNotifications && documents.Count > 1)
@@ -1815,17 +1831,17 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return Task.WhenAll(tasks);
     }
 
-    protected virtual Task PublishChangeTypeMessageAsync(ChangeType changeType, T document, TimeSpan? delay)
+    protected virtual Task PublishChangeTypeMessageAsync(ChangeType changeType, T? document, TimeSpan? delay)
     {
         return PublishChangeTypeMessageAsync(changeType, document, null, delay);
     }
 
-    protected virtual Task PublishChangeTypeMessageAsync(ChangeType changeType, T document, IDictionary<string, object> data = null, TimeSpan? delay = null)
+    protected virtual Task PublishChangeTypeMessageAsync(ChangeType changeType, T? document, IDictionary<string, object>? data = null, TimeSpan? delay = null)
     {
         return PublishChangeTypeMessageAsync(changeType, document?.Id, data, delay);
     }
 
-    protected virtual Task PublishChangeTypeMessageAsync(ChangeType changeType, string id, IDictionary<string, object> data = null, TimeSpan? delay = null)
+    protected virtual Task PublishChangeTypeMessageAsync(ChangeType changeType, string? id, IDictionary<string, object>? data = null, TimeSpan? delay = null)
     {
         if (!NotificationsEnabled)
             return Task.CompletedTask;
@@ -1868,7 +1884,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     protected virtual string GetUpdatedUtcFieldPath()
     {
         if (HasDates)
-            return _updatedUtcField.Value;
+            return _updatedUtcField!.Value;
 
         throw new RepositoryException(
             $"{GetType().Name} has HasDateTracking=true but does not implement IHaveDates. Override GetUpdatedUtcFieldPath() to return the Elasticsearch field path for your updated timestamp.");
@@ -2002,7 +2018,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return sb.ToString();
     }
 
-    private static JToken GetNestedJToken(JToken token, string dotPath)
+    private static JToken? GetNestedJToken(JToken token, string dotPath)
     {
         var remaining = dotPath.AsSpan();
 
@@ -2014,7 +2030,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             if (token is not JObject obj)
                 return null;
 
-            token = obj[segment.ToString()];
+            token = obj[segment.ToString()]!;
             if (token is null)
                 return null;
 
@@ -2063,12 +2079,12 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         var dict = new Dictionary<string, object>(obj.Count);
 
         foreach (var property in obj.Properties())
-            dict[property.Name] = ToValue(property.Value);
+            dict[property.Name] = ToValue(property.Value)!;
 
         return dict;
     }
 
-    private static object ToValue(JToken token)
+    private static object? ToValue(JToken token)
     {
         return token switch
         {

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -1317,14 +1317,14 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     /// <inheritdoc cref="AddPropertyRequiredForRemove(string)"/>
     [Obsolete("Use AddRequiredField instead. This method will be removed in a future major version.")]
-    protected void AddPropertyRequiredForRemove(Expression<Func<T, object>> objectPath)
+    protected void AddPropertyRequiredForRemove(Expression<Func<T, object?>> objectPath)
     {
         AddRequiredField(objectPath);
     }
 
     /// <inheritdoc cref="AddPropertyRequiredForRemove(string)"/>
     [Obsolete("Use AddRequiredField instead. This method will be removed in a future major version.")]
-    protected void AddPropertyRequiredForRemove(params Expression<Func<T, object>>[] objectPaths)
+    protected void AddPropertyRequiredForRemove(params Expression<Func<T, object?>>[] objectPaths)
     {
         AddRequiredField(objectPaths);
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -470,9 +470,12 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 if (response.Source is IVersioned versionedDoc && response.PrimaryTerm.HasValue)
                     versionedDoc.Version = response.GetElasticVersion();
 
+                if (response.Source is not { } source)
+                    throw new DocumentException($"Document {ElasticIndex.GetIndex(id)}/{id.Value} returned no source");
+
                 bool actionModified = false;
                 foreach (var action in actionPatch.Actions)
-                    actionModified |= action?.Invoke(response.Source!) ?? false;
+                    actionModified |= action?.Invoke(source) ?? false;
 
                 if (!actionModified)
                 {
@@ -481,10 +484,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 }
 
                 if (HasDateTracking)
-                    SetDocumentDates(response.Source!, ElasticIndex.Configuration.TimeProvider);
+                    SetDocumentDates(source, ElasticIndex.Configuration.TimeProvider);
 
-                modifiedDocument = response.Source!;
-                await IndexDocumentsAsync([response.Source!], false, options).AnyContext();
+                modifiedDocument = source;
+                await IndexDocumentsAsync([source], false, options).AnyContext();
             }).AnyContext();
 
             if (modified && modifiedDocument is not null)

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -1415,7 +1415,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         if (String.IsNullOrEmpty(tenantKey))
             return null;
 
-        return await ElasticIndex.Configuration.CustomFieldDefinitionRepository!.AddFieldAsync(EntityTypeName, GetDocumentTenantKey(document)!, name, StringFieldType.IndexType).AnyContext();
+        return await ElasticIndex.Configuration.CustomFieldDefinitionRepository!.AddFieldAsync(EntityTypeName, tenantKey, name, StringFieldType.IndexType).AnyContext();
     }
 
     protected string? GetDocumentTenantKey(T document)

--- a/src/Foundatio.Repositories.Elasticsearch/Utility/FieldIncludeParser.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Utility/FieldIncludeParser.cs
@@ -28,7 +28,7 @@ public ref struct FieldIncludeParser
     private int _position;
     private readonly FieldIncludeParseResult _result = new();
     private readonly Stack<FieldInclude> _includeStack = new();
-    private FieldInclude _current = null;
+    private FieldInclude? _current = null;
     private int _openParenCount = 0;
 
     public FieldIncludeParser(in ReadOnlySpan<char> source)
@@ -163,12 +163,12 @@ public class FieldIncludeParseResult
 {
     public IList<FieldInclude> Fields { get; set; } = new List<FieldInclude>();
     public bool IsValid { get; set; } = true;
-    public string ValidationMessage { get; set; }
+    public string? ValidationMessage { get; set; }
 
     public override string ToString()
     {
         if (!IsValid)
-            return ValidationMessage;
+            return ValidationMessage!;
 
         if (Fields.Count == 0)
             return String.Empty;

--- a/src/Foundatio.Repositories.Elasticsearch/Utility/FieldValueHelper.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Utility/FieldValueHelper.cs
@@ -25,7 +25,7 @@ public static class FieldValueHelper
             decimal m => FieldValue.Double((double)m),
             DateTime dt => FieldValue.String(dt.ToString("o")),
             DateTimeOffset dto => FieldValue.String(dto.ToString("o")),
-            _ => FieldValue.String(value.ToString())
+            _ => FieldValue.String(value.ToString()!)
         };
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Utility/FieldValueHelper.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Utility/FieldValueHelper.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Elasticsearch.Utility;
 
 public static class FieldValueHelper
 {
-    public static FieldValue ToFieldValue(object value)
+    public static FieldValue ToFieldValue(object? value)
     {
         return value switch
         {

--- a/src/Foundatio.Repositories.Elasticsearch/Utility/FieldValueHelper.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Utility/FieldValueHelper.cs
@@ -25,7 +25,7 @@ public static class FieldValueHelper
             decimal m => FieldValue.Double((double)m),
             DateTime dt => FieldValue.String(dt.ToString("o")),
             DateTimeOffset dto => FieldValue.String(dto.ToString("o")),
-            _ => FieldValue.String(value.ToString() ?? String.Empty)
+            _ => FieldValue.String(value.ToString() ?? throw new InvalidOperationException($"ToString() returned null for type {value.GetType().Name}"))
         };
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Utility/FieldValueHelper.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Utility/FieldValueHelper.cs
@@ -25,7 +25,7 @@ public static class FieldValueHelper
             decimal m => FieldValue.Double((double)m),
             DateTime dt => FieldValue.String(dt.ToString("o")),
             DateTimeOffset dto => FieldValue.String(dto.ToString("o")),
-            _ => FieldValue.String(value.ToString()!)
+            _ => FieldValue.String(value.ToString() ?? String.Empty)
         };
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Utility/FieldValueHelper.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Utility/FieldValueHelper.cs
@@ -25,7 +25,7 @@ public static class FieldValueHelper
             decimal m => FieldValue.Double((double)m),
             DateTime dt => FieldValue.String(dt.ToString("o")),
             DateTimeOffset dto => FieldValue.String(dto.ToString("o")),
-            _ => FieldValue.String(value.ToString() ?? throw new InvalidOperationException($"ToString() returned null for type {value.GetType().Name}"))
+            _ => FieldValue.String(value.ToString()!)
         };
     }
 }

--- a/src/Foundatio.Repositories/Exceptions/AsyncQueryNotFoundException.cs
+++ b/src/Foundatio.Repositories/Exceptions/AsyncQueryNotFoundException.cs
@@ -10,5 +10,5 @@ public class AsyncQueryNotFoundException : RepositoryException
         Id = id;
     }
 
-    public string Id { get; private set; }
+    public string? Id { get; private set; }
 }

--- a/src/Foundatio.Repositories/Exceptions/DocumentException.cs
+++ b/src/Foundatio.Repositories/Exceptions/DocumentException.cs
@@ -7,5 +7,5 @@ public class DocumentException : RepositoryException
 {
     public DocumentException() : base() { }
     public DocumentException(string message) : base(message) { }
-    public DocumentException(string message, Exception innerException) : base(message, innerException) { }
+    public DocumentException(string message, Exception? innerException) : base(message, innerException) { }
 }

--- a/src/Foundatio.Repositories/Exceptions/DocumentNotFoundException.cs
+++ b/src/Foundatio.Repositories/Exceptions/DocumentNotFoundException.cs
@@ -10,5 +10,5 @@ public class DocumentNotFoundException : DocumentException
         Id = id;
     }
 
-    public string Id { get; private set; }
+    public string? Id { get; private set; }
 }

--- a/src/Foundatio.Repositories/Exceptions/DuplicateDocumentException.cs
+++ b/src/Foundatio.Repositories/Exceptions/DuplicateDocumentException.cs
@@ -7,5 +7,5 @@ public class DuplicateDocumentException : DocumentException
 {
     public DuplicateDocumentException() : base() { }
     public DuplicateDocumentException(string message) : base(message) { }
-    public DuplicateDocumentException(string message, Exception innerException) : base(message, innerException) { }
+    public DuplicateDocumentException(string message, Exception? innerException) : base(message, innerException) { }
 }

--- a/src/Foundatio.Repositories/Exceptions/QueryValidationException.cs
+++ b/src/Foundatio.Repositories/Exceptions/QueryValidationException.cs
@@ -24,15 +24,15 @@ public class QueryValidationException : RepositoryException
 
     public QueryValidationException(string message) : base(message) { }
 
-    public QueryValidationException(string message, string field, string op = null) : base(message)
+    public QueryValidationException(string message, string field, string? op = null) : base(message)
     {
         Field = field;
         Operator = op;
     }
 
     /// <summary>The resolved Elasticsearch field name that caused the validation failure.</summary>
-    public string Field { get; }
+    public string? Field { get; }
 
     /// <summary>The comparison operator that was used (e.g., "Equals", "Contains", "GreaterThan"), if applicable.</summary>
-    public string Operator { get; }
+    public string? Operator { get; }
 }

--- a/src/Foundatio.Repositories/Exceptions/RepositoryException.cs
+++ b/src/Foundatio.Repositories/Exceptions/RepositoryException.cs
@@ -7,5 +7,5 @@ public class RepositoryException : Exception
 {
     public RepositoryException() : base() { }
     public RepositoryException(string message) : base(message) { }
-    public RepositoryException(string message, Exception innerException) : base(message, innerException) { }
+    public RepositoryException(string message, Exception? innerException) : base(message, innerException) { }
 }

--- a/src/Foundatio.Repositories/Exceptions/VersionConflictDocumentException.cs
+++ b/src/Foundatio.Repositories/Exceptions/VersionConflictDocumentException.cs
@@ -7,5 +7,5 @@ public class VersionConflictDocumentException : DocumentException
 {
     public VersionConflictDocumentException() : base() { }
     public VersionConflictDocumentException(string message) : base(message) { }
-    public VersionConflictDocumentException(string message, Exception innerException) : base(message, innerException) { }
+    public VersionConflictDocumentException(string message, Exception? innerException) : base(message, innerException) { }
 }

--- a/src/Foundatio.Repositories/Extensions/AggregationsExtensions.cs
+++ b/src/Foundatio.Repositories/Extensions/AggregationsExtensions.cs
@@ -6,21 +6,21 @@ namespace Foundatio.Repositories.Models;
 
 public static class AggregationsExtensions
 {
-    public static PercentileItem GetPercentile(this PercentilesAggregate agg, double percentile) => agg.Items.FirstOrDefault(i => i.Percentile == percentile);
-    public static ValueAggregate Min(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate>(key);
-    public static ValueAggregate<T> Min<T>(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate<T>>(key);
+    public static PercentileItem? GetPercentile(this PercentilesAggregate agg, double percentile) => agg.Items?.FirstOrDefault(i => i.Percentile == percentile);
+    public static ValueAggregate? Min(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate>(key);
+    public static ValueAggregate<T>? Min<T>(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate<T>>(key);
 
-    public static ValueAggregate Max(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate>(key);
-    public static ValueAggregate<T> Max<T>(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate<T>>(key);
-    public static TopHitsAggregate TopHits(this IReadOnlyDictionary<string, IAggregate> aggs) => aggs.TryGet<TopHitsAggregate>("tophits");
+    public static ValueAggregate? Max(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate>(key);
+    public static ValueAggregate<T>? Max<T>(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate<T>>(key);
+    public static TopHitsAggregate? TopHits(this IReadOnlyDictionary<string, IAggregate> aggs) => aggs.TryGet<TopHitsAggregate>("tophits");
 
-    public static ValueAggregate Sum(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate>(key);
+    public static ValueAggregate? Sum(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate>(key);
 
-    public static ValueAggregate Cardinality(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate>(key);
+    public static ValueAggregate? Cardinality(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate>(key);
 
-    public static ValueAggregate Average(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate>(key);
+    public static ValueAggregate? Average(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ValueAggregate>(key);
 
-    public static ObjectValueAggregate Metric(this IReadOnlyDictionary<string, IAggregate> aggs, string key)
+    public static ObjectValueAggregate? Metric(this IReadOnlyDictionary<string, IAggregate> aggs, string key)
     {
         var valueMetric = aggs.TryGet<ValueAggregate>(key);
 
@@ -29,15 +29,15 @@ public static class AggregationsExtensions
             : aggs.TryGet<ObjectValueAggregate>(key);
     }
 
-    public static StatsAggregate Stats(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<StatsAggregate>(key);
+    public static StatsAggregate? Stats(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<StatsAggregate>(key);
 
-    public static ExtendedStatsAggregate ExtendedStats(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ExtendedStatsAggregate>(key);
+    public static ExtendedStatsAggregate? ExtendedStats(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<ExtendedStatsAggregate>(key);
 
-    public static PercentilesAggregate Percentiles(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<PercentilesAggregate>(key);
+    public static PercentilesAggregate? Percentiles(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<PercentilesAggregate>(key);
 
-    public static SingleBucketAggregate Missing(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<SingleBucketAggregate>(key);
+    public static SingleBucketAggregate? Missing(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.TryGet<SingleBucketAggregate>(key);
 
-    public static TermsAggregate<TKey> Terms<TKey>(this IReadOnlyDictionary<string, IAggregate> aggs, string key)
+    public static TermsAggregate<TKey>? Terms<TKey>(this IReadOnlyDictionary<string, IAggregate> aggs, string key)
     {
         var bucket = aggs.TryGet<BucketAggregate>(key);
         return bucket == null
@@ -49,19 +49,19 @@ public static class AggregationsExtensions
             };
     }
 
-    public static TermsAggregate<string> Terms(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.Terms<string>(key);
+    public static TermsAggregate<string>? Terms(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.Terms<string>(key);
 
-    public static MultiBucketAggregate<KeyedBucket<string>> GeoHash(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.GetMultiKeyedBucketAggregate<string>(key);
+    public static MultiBucketAggregate<KeyedBucket<string>>? GeoHash(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.GetMultiKeyedBucketAggregate<string>(key);
 
-    public static MultiBucketAggregate<DateHistogramBucket> DateHistogram(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.GetMultiBucketAggregate<DateHistogramBucket>(key);
+    public static MultiBucketAggregate<DateHistogramBucket>? DateHistogram(this IReadOnlyDictionary<string, IAggregate> aggs, string key) => aggs.GetMultiBucketAggregate<DateHistogramBucket>(key);
 
-    private static TAggregate TryGet<TAggregate>(this IReadOnlyDictionary<string, IAggregate> aggs, string key)
+    private static TAggregate? TryGet<TAggregate>(this IReadOnlyDictionary<string, IAggregate> aggs, string key)
         where TAggregate : class, IAggregate
     {
         return aggs.TryGetValue(key, out var agg) ? agg as TAggregate : null;
     }
 
-    private static MultiBucketAggregate<TBucket> GetMultiBucketAggregate<TBucket>(this IReadOnlyDictionary<string, IAggregate> aggs, string key)
+    private static MultiBucketAggregate<TBucket>? GetMultiBucketAggregate<TBucket>(this IReadOnlyDictionary<string, IAggregate> aggs, string key)
         where TBucket : IBucket
     {
         var bucket = aggs.TryGet<BucketAggregate>(key);
@@ -73,7 +73,7 @@ public static class AggregationsExtensions
         };
     }
 
-    private static MultiBucketAggregate<KeyedBucket<TKey>> GetMultiKeyedBucketAggregate<TKey>(this IReadOnlyDictionary<string, IAggregate> aggs, string key)
+    private static MultiBucketAggregate<KeyedBucket<TKey>>? GetMultiKeyedBucketAggregate<TKey>(this IReadOnlyDictionary<string, IAggregate> aggs, string key)
     {
         var bucket = aggs.TryGet<BucketAggregate>(key);
         if (bucket == null) return null;
@@ -88,11 +88,11 @@ public static class AggregationsExtensions
     {
         foreach (var item in items)
         {
-            object key = null;
-            string keyAsString = null;
-            IReadOnlyDictionary<string, IAggregate> aggregations = null;
+            object? key = null;
+            string? keyAsString = null;
+            IReadOnlyDictionary<string, IAggregate>? aggregations = null;
             long? total = null;
-            IReadOnlyDictionary<string, object> data = null;
+            IReadOnlyDictionary<string, object>? data = null;
 
             switch (item)
             {
@@ -144,9 +144,9 @@ public static class AggregationsExtensions
 
             yield return new KeyedBucket<TKey>
             {
-                Key = (TKey)Convert.ChangeType(key, typeof(TKey)),
+                Key = (TKey)(Convert.ChangeType(key, typeof(TKey)) ?? throw new InvalidOperationException($"Failed to convert key '{key}' to {typeof(TKey).Name}")),
                 KeyAsString = keyAsString,
-                Aggregations = aggregations,
+                Aggregations = aggregations ?? EmptyReadOnly<string, IAggregate>.Dictionary,
                 Total = total,
                 Data = data
             };

--- a/src/Foundatio.Repositories/Extensions/DictionaryExtensions.cs
+++ b/src/Foundatio.Repositories/Extensions/DictionaryExtensions.cs
@@ -95,10 +95,7 @@ public static class DictionaryExtensions
 
     public static IReadOnlyDictionary<string, object>? ToReadOnlyData<T>(this IEnumerable<KeyValuePair<string, object>>? dictionary) where T : IAggregate
     {
-        if (dictionary is null)
-            return null;
-
-        var data = dictionary.ToData<T>();
+        var data = (dictionary ?? []).ToData<T>();
         return data is not null ? new ReadOnlyDictionary<string, object>(data) : null;
     }
 

--- a/src/Foundatio.Repositories/Extensions/DictionaryExtensions.cs
+++ b/src/Foundatio.Repositories/Extensions/DictionaryExtensions.cs
@@ -8,14 +8,17 @@ namespace Foundatio.Repositories.Extensions;
 
 public static class DictionaryExtensions
 {
-    public static string GetString(this IEnumerable<KeyValuePair<string, object>> data, string name)
+    public static string? GetString(this IEnumerable<KeyValuePair<string, object>> data, string name)
     {
-        return data.GetString(name, String.Empty);
+        return data.GetString(name, null);
     }
 
-    public static string GetString(this IEnumerable<KeyValuePair<string, object>> data, string name, string @default)
+    public static string? GetString(this IEnumerable<KeyValuePair<string, object>> data, string name, string? @default)
     {
-        object value = null;
+        if (data is null)
+            return @default;
+
+        object? value;
         if (data is IDictionary<string, object> dictionary)
         {
             if (!dictionary.TryGetValue(name, out value))
@@ -46,7 +49,7 @@ public static class DictionaryExtensions
 
     public static bool GetBoolean(this IEnumerable<KeyValuePair<string, object>> data, string name, bool @default)
     {
-        object value = null;
+        object? value = null;
         if (data is IDictionary<string, object> dictionary)
         {
             if (!dictionary.TryGetValue(name, out value))
@@ -67,34 +70,39 @@ public static class DictionaryExtensions
         if (value is bool b)
             return b;
 
-        if (Boolean.TryParse(value.ToString(), out var result))
+        string? valueString = value.ToString();
+        if (valueString is not null && Boolean.TryParse(valueString, out bool result))
             return result;
 
         return @default;
     }
 
-    public static IDictionary<string, object> ToData<T>(this IEnumerable<KeyValuePair<string, object>> dictionary) where T : IAggregate
+    public static IDictionary<string, object>? ToData<T>(this IEnumerable<KeyValuePair<string, object>> dictionary) where T : IAggregate
     {
         var dict = dictionary?
             .Where(kvp => kvp.Key != "@field_type" && kvp.Key != "@timezone")
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-        string type = GetAggregateType(typeof(T));
+        string? type = GetAggregateType(typeof(T));
         if (dict == null && type != null)
             dict = new Dictionary<string, object>();
 
         if (type != null)
-            dict["@type"] = type;
+            dict!["@type"] = type;
 
         return dict?.Count > 0 ? dict : null;
     }
 
-    public static IReadOnlyDictionary<string, object> ToReadOnlyData<T>(this IEnumerable<KeyValuePair<string, object>> dictionary) where T : IAggregate
+    public static IReadOnlyDictionary<string, object>? ToReadOnlyData<T>(this IEnumerable<KeyValuePair<string, object>>? dictionary) where T : IAggregate
     {
-        return new ReadOnlyDictionary<string, object>(dictionary.ToData<T>());
+        if (dictionary is null)
+            return null;
+
+        var data = dictionary.ToData<T>();
+        return data is not null ? new ReadOnlyDictionary<string, object>(data) : null;
     }
 
-    private static string GetAggregateType(Type type)
+    private static string? GetAggregateType(Type type)
     {
         if (type == typeof(BucketAggregate))
             return "bucket";

--- a/src/Foundatio.Repositories/Extensions/DictionaryExtensions.cs
+++ b/src/Foundatio.Repositories/Extensions/DictionaryExtensions.cs
@@ -8,14 +8,17 @@ namespace Foundatio.Repositories.Extensions;
 
 public static class DictionaryExtensions
 {
-    public static string GetString(this IEnumerable<KeyValuePair<string, object>> data, string name)
+    public static string? GetString(this IEnumerable<KeyValuePair<string, object>> data, string name)
     {
-        return data.GetString(name, String.Empty);
+        return data.GetString(name, null);
     }
 
-    public static string GetString(this IEnumerable<KeyValuePair<string, object>> data, string name, string @default)
+    public static string? GetString(this IEnumerable<KeyValuePair<string, object>> data, string name, string? @default)
     {
-        object value = null;
+        if (data is null)
+            return @default;
+
+        object? value;
         if (data is IDictionary<string, object> dictionary)
         {
             if (!dictionary.TryGetValue(name, out value))
@@ -46,7 +49,7 @@ public static class DictionaryExtensions
 
     public static bool GetBoolean(this IEnumerable<KeyValuePair<string, object>> data, string name, bool @default)
     {
-        object value = null;
+        object? value = null;
         if (data is IDictionary<string, object> dictionary)
         {
             if (!dictionary.TryGetValue(name, out value))
@@ -67,34 +70,36 @@ public static class DictionaryExtensions
         if (value is bool b)
             return b;
 
-        if (Boolean.TryParse(value.ToString(), out var result))
+        string? valueString = value.ToString();
+        if (valueString is not null && Boolean.TryParse(valueString, out bool result))
             return result;
 
         return @default;
     }
 
-    public static IDictionary<string, object> ToData<T>(this IEnumerable<KeyValuePair<string, object>> dictionary) where T : IAggregate
+    public static IDictionary<string, object>? ToData<T>(this IEnumerable<KeyValuePair<string, object>> dictionary) where T : IAggregate
     {
         var dict = dictionary?
             .Where(kvp => kvp.Key != "@field_type" && kvp.Key != "@timezone")
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-        string type = GetAggregateType(typeof(T));
+        string? type = GetAggregateType(typeof(T));
         if (dict == null && type != null)
             dict = new Dictionary<string, object>();
 
         if (type != null)
-            dict["@type"] = type;
+            dict!["@type"] = type;
 
         return dict?.Count > 0 ? dict : null;
     }
 
-    public static IReadOnlyDictionary<string, object> ToReadOnlyData<T>(this IEnumerable<KeyValuePair<string, object>> dictionary) where T : IAggregate
+    public static IReadOnlyDictionary<string, object>? ToReadOnlyData<T>(this IEnumerable<KeyValuePair<string, object>> dictionary) where T : IAggregate
     {
-        return new ReadOnlyDictionary<string, object>(dictionary.ToData<T>());
+        var data = dictionary.ToData<T>();
+        return data is not null ? new ReadOnlyDictionary<string, object>(data) : null;
     }
 
-    private static string GetAggregateType(Type type)
+    private static string? GetAggregateType(Type type)
     {
         if (type == typeof(BucketAggregate))
             return "bucket";

--- a/src/Foundatio.Repositories/Extensions/EnumerableExtensions.cs
+++ b/src/Foundatio.Repositories/Extensions/EnumerableExtensions.cs
@@ -9,7 +9,7 @@ namespace Foundatio.Repositories.Extensions;
 
 public static class EnumerableExtensions
 {
-    public static void EnsureIds<T>(this IEnumerable<T> values, Func<T, string> generateIdFunc = null, TimeProvider timeProvider = null) where T : class, IIdentity
+    public static void EnsureIds<T>(this IEnumerable<T> values, Func<T, string>? generateIdFunc = null, TimeProvider? timeProvider = null) where T : class, IIdentity
     {
         if (values == null)
             return;
@@ -25,7 +25,7 @@ public static class EnumerableExtensions
         }
     }
 
-    public static void SetDates(this IHaveDates value, TimeProvider timeProvider = null)
+    public static void SetDates(this IHaveDates value, TimeProvider? timeProvider = null)
     {
         if (value is null)
             return;
@@ -39,7 +39,7 @@ public static class EnumerableExtensions
         value.UpdatedUtc = utcNow;
     }
 
-    public static void SetDates<T>(this IEnumerable<T> values, TimeProvider timeProvider = null) where T : class, IHaveDates
+    public static void SetDates<T>(this IEnumerable<T> values, TimeProvider? timeProvider = null) where T : class, IHaveDates
     {
         if (values is null)
             return;
@@ -48,7 +48,7 @@ public static class EnumerableExtensions
             value.SetDates(timeProvider);
     }
 
-    public static void SetCreatedDates<T>(this IEnumerable<T> values, TimeProvider timeProvider = null) where T : class, IHaveCreatedDate
+    public static void SetCreatedDates<T>(this IEnumerable<T> values, TimeProvider? timeProvider = null) where T : class, IHaveCreatedDate
     {
         if (values == null)
             return;
@@ -74,9 +74,9 @@ public static class EnumerableExtensions
         Func<TA, TK> selectKeyA,
         Func<TB, TK> selectKeyB,
         Func<IEnumerable<TA>, IEnumerable<TB>, TK, TR> projection,
-        IEqualityComparer<TK> cmp = null)
+        IEqualityComparer<TK>? cmp = null)
     {
-        cmp = cmp ?? EqualityComparer<TK>.Default;
+        cmp ??= EqualityComparer<TK>.Default;
         var alookup = a.ToLookup(selectKeyA, cmp);
         var blookup = b.ToLookup(selectKeyB, cmp);
 
@@ -97,11 +97,11 @@ public static class EnumerableExtensions
         Func<TA, TK> selectKeyA,
         Func<TB, TK> selectKeyB,
         Func<TA, TB, TK, TR> projection,
-        TA defaultA = default,
-        TB defaultB = default,
-        IEqualityComparer<TK> cmp = null)
+        TA defaultA = default!,
+        TB defaultB = default!,
+        IEqualityComparer<TK>? cmp = null)
     {
-        cmp = cmp ?? EqualityComparer<TK>.Default;
+        cmp ??= EqualityComparer<TK>.Default;
         var alookup = a.ToLookup(selectKeyA, cmp);
         var blookup = (b ?? new List<TB>()).ToLookup(selectKeyB, cmp);
 
@@ -123,7 +123,7 @@ public static class EnumerableExtensions
     public static IReadOnlyCollection<T> UnionOriginalAndModified<T>(this IReadOnlyCollection<ModifiedDocument<T>> documents) where T : class, new()
     {
         return documents.Select(d => d.Value)
-            .Union(documents.Select(d => d.Original).Where(d => d is not null))
+            .Union(documents.Select(d => d.Original).Where(d => d is not null).Select(d => d!))
             .ToList();
     }
 

--- a/src/Foundatio.Repositories/Extensions/FindResultsExtensions.cs
+++ b/src/Foundatio.Repositories/Extensions/FindResultsExtensions.cs
@@ -4,9 +4,9 @@ namespace Foundatio.Repositories.Extensions;
 
 public static class FindResultsExtensions
 {
-    public static string GetAsyncQueryId(this IHaveData results)
+    public static string? GetAsyncQueryId(this IHaveData results)
     {
-        return results.Data.GetString(AsyncQueryDataKeys.AsyncQueryId, null);
+        return results.Data.GetString(AsyncQueryDataKeys.AsyncQueryId);
     }
 
     /// <summary>

--- a/src/Foundatio.Repositories/Foundatio.Repositories.csproj
+++ b/src/Foundatio.Repositories/Foundatio.Repositories.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.13" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="$(FoundatioProjectsDir)Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
 
-    <PackageReference Include="Foundatio.JsonNet" Version="13.0.0-beta3.13" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.JsonNet" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="$(FoundatioProjectsDir)Foundatio\src\Foundatio.JsonNet\Foundatio.JsonNet.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Repositories/Foundatio.Repositories.csproj
+++ b/src/Foundatio.Repositories/Foundatio.Repositories.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.45" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="$(FoundatioProjectsDir)Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
 
-    <PackageReference Include="Foundatio.JsonNet" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.JsonNet" Version="13.0.0-beta3.45" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="$(FoundatioProjectsDir)Foundatio\src\Foundatio.JsonNet\Foundatio.JsonNet.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Repositories/IReadOnlyRepository.cs
+++ b/src/Foundatio.Repositories/IReadOnlyRepository.cs
@@ -21,10 +21,10 @@ public interface IReadOnlyRepository<T> where T : class, new()
     /// </summary>
     /// <param name="id">The document identifier.</param>
     /// <param name="options">Options to control caching, soft delete filtering, and other behaviors.</param>
-    Task<T> GetByIdAsync(Id id, CommandOptionsDescriptor<T> options);
+    Task<T?> GetByIdAsync(Id id, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="GetByIdAsync(Id, CommandOptionsDescriptor{T})"/>
-    Task<T> GetByIdAsync(Id id, ICommandOptions options = null);
+    Task<T?> GetByIdAsync(Id id, ICommandOptions? options = null);
 
     /// <summary>
     /// Retrieves multiple documents by their unique identifiers.
@@ -34,7 +34,7 @@ public interface IReadOnlyRepository<T> where T : class, new()
     Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="GetByIdsAsync(Ids, CommandOptionsDescriptor{T})"/>
-    Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, ICommandOptions options = null);
+    Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, ICommandOptions? options = null);
 
     /// <summary>
     /// Retrieves all documents in the repository.
@@ -43,7 +43,7 @@ public interface IReadOnlyRepository<T> where T : class, new()
     Task<FindResults<T>> GetAllAsync(CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="GetAllAsync(CommandOptionsDescriptor{T})"/>
-    Task<FindResults<T>> GetAllAsync(ICommandOptions options = null);
+    Task<FindResults<T>> GetAllAsync(ICommandOptions? options = null);
 
     /// <summary>
     /// Checks whether a document with the specified identifier exists.
@@ -53,7 +53,7 @@ public interface IReadOnlyRepository<T> where T : class, new()
     Task<bool> ExistsAsync(Id id, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="ExistsAsync(Id, CommandOptionsDescriptor{T})"/>
-    Task<bool> ExistsAsync(Id id, ICommandOptions options = null);
+    Task<bool> ExistsAsync(Id id, ICommandOptions? options = null);
 
     /// <summary>
     /// Gets the total count of documents in the repository.
@@ -62,7 +62,7 @@ public interface IReadOnlyRepository<T> where T : class, new()
     Task<CountResult> CountAsync(CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="CountAsync(CommandOptionsDescriptor{T})"/>
-    Task<CountResult> CountAsync(ICommandOptions options = null);
+    Task<CountResult> CountAsync(ICommandOptions? options = null);
 
     /// <summary>
     /// Invalidates cached data for the specified document.

--- a/src/Foundatio.Repositories/IRepository.cs
+++ b/src/Foundatio.Repositories/IRepository.cs
@@ -30,7 +30,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     Task<T> AddAsync(T document, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="AddAsync(T, CommandOptionsDescriptor{T})"/>
-    Task<T> AddAsync(T document, ICommandOptions options = null);
+    Task<T> AddAsync(T document, ICommandOptions? options = null);
 
     /// <summary>
     /// Adds multiple documents to the repository.
@@ -42,7 +42,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     Task AddAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="AddAsync(IEnumerable{T}, CommandOptionsDescriptor{T})"/>
-    Task AddAsync(IEnumerable<T> documents, ICommandOptions options = null);
+    Task AddAsync(IEnumerable<T> documents, ICommandOptions? options = null);
 
     /// <summary>
     /// Saves changes to an existing document, or adds it if it doesn't exist.
@@ -55,7 +55,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     Task<T> SaveAsync(T document, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="SaveAsync(T, CommandOptionsDescriptor{T})"/>
-    Task<T> SaveAsync(T document, ICommandOptions options = null);
+    Task<T> SaveAsync(T document, ICommandOptions? options = null);
 
     /// <summary>
     /// Saves changes to multiple existing documents.
@@ -67,7 +67,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     Task SaveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="SaveAsync(IEnumerable{T}, CommandOptionsDescriptor{T})"/>
-    Task SaveAsync(IEnumerable<T> documents, ICommandOptions options = null);
+    Task SaveAsync(IEnumerable<T> documents, ICommandOptions? options = null);
 
     /// <summary>
     /// Applies a patch operation to a document.
@@ -95,7 +95,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     Task<bool> PatchAsync(Id id, IPatchOperation operation, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="PatchAsync(Id, IPatchOperation, CommandOptionsDescriptor{T})"/>
-    Task<bool> PatchAsync(Id id, IPatchOperation operation, ICommandOptions options = null);
+    Task<bool> PatchAsync(Id id, IPatchOperation operation, ICommandOptions? options = null);
 
     /// <summary>
     /// Applies a patch operation to multiple documents.
@@ -112,7 +112,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     Task<long> PatchAsync(Ids ids, IPatchOperation operation, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="PatchAsync(Ids, IPatchOperation, CommandOptionsDescriptor{T})"/>
-    Task<long> PatchAsync(Ids ids, IPatchOperation operation, ICommandOptions options = null);
+    Task<long> PatchAsync(Ids ids, IPatchOperation operation, ICommandOptions? options = null);
 
     /// <summary>
     /// Permanently removes a document from the repository (hard delete).
@@ -122,7 +122,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     Task RemoveAsync(Id id, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="RemoveAsync(Id, CommandOptionsDescriptor{T})"/>
-    Task RemoveAsync(Id id, ICommandOptions options = null);
+    Task RemoveAsync(Id id, ICommandOptions? options = null);
 
     /// <summary>
     /// Permanently removes multiple documents from the repository (hard delete).
@@ -132,7 +132,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     Task RemoveAsync(Ids ids, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="RemoveAsync(Ids, CommandOptionsDescriptor{T})"/>
-    Task RemoveAsync(Ids ids, ICommandOptions options = null);
+    Task RemoveAsync(Ids ids, ICommandOptions? options = null);
 
     /// <summary>
     /// Permanently removes a document from the repository (hard delete).
@@ -142,7 +142,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     Task RemoveAsync(T document, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="RemoveAsync(T, CommandOptionsDescriptor{T})"/>
-    Task RemoveAsync(T document, ICommandOptions options = null);
+    Task RemoveAsync(T document, ICommandOptions? options = null);
 
     /// <summary>
     /// Permanently removes multiple documents from the repository (hard delete).
@@ -152,7 +152,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     Task RemoveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="RemoveAsync(IEnumerable{T}, CommandOptionsDescriptor{T})"/>
-    Task RemoveAsync(IEnumerable<T> documents, ICommandOptions options = null);
+    Task RemoveAsync(IEnumerable<T> documents, ICommandOptions? options = null);
 
     /// <summary>
     /// Permanently removes all documents from the repository (hard delete).
@@ -162,7 +162,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     Task<long> RemoveAllAsync(CommandOptionsDescriptor<T> options);
 
     /// <inheritdoc cref="RemoveAllAsync(CommandOptionsDescriptor{T})"/>
-    Task<long> RemoveAllAsync(ICommandOptions options = null);
+    Task<long> RemoveAllAsync(ICommandOptions? options = null);
 
     /// <summary>
     /// Event raised before documents are added to the repository.

--- a/src/Foundatio.Repositories/ISearchableReadOnlyRepository.cs
+++ b/src/Foundatio.Repositories/ISearchableReadOnlyRepository.cs
@@ -26,10 +26,10 @@ public interface ISearchableReadOnlyRepository<T> : IReadOnlyRepository<T> where
     /// </summary>
     /// <param name="query">An object containing filter criteria used to enforce tenancy or other system-level filters.</param>
     /// <param name="options">Options to control paging, caching, soft delete filtering, and other behaviors.</param>
-    Task<FindResults<T>> FindAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null);
+    Task<FindResults<T>> FindAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null);
 
     /// <inheritdoc cref="FindAsync(RepositoryQueryDescriptor{T}, CommandOptionsDescriptor{T})"/>
-    Task<FindResults<T>> FindAsync(IRepositoryQuery query, ICommandOptions options = null);
+    Task<FindResults<T>> FindAsync(IRepositoryQuery query, ICommandOptions? options = null);
 
     /// <summary>
     /// Finds documents matching the specified query and maps results to a different type.
@@ -37,40 +37,40 @@ public interface ISearchableReadOnlyRepository<T> : IReadOnlyRepository<T> where
     /// <typeparam name="TResult">The type to map results to.</typeparam>
     /// <param name="query">An object containing filter criteria used to enforce tenancy or other system-level filters.</param>
     /// <param name="options">Options to control paging, caching, soft delete filtering, and other behaviors.</param>
-    Task<FindResults<TResult>> FindAsAsync<TResult>(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null) where TResult : class, new();
+    Task<FindResults<TResult>> FindAsAsync<TResult>(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null) where TResult : class, new();
 
     /// <inheritdoc cref="FindAsAsync{TResult}(RepositoryQueryDescriptor{T}, CommandOptionsDescriptor{T})"/>
-    Task<FindResults<TResult>> FindAsAsync<TResult>(IRepositoryQuery query, ICommandOptions options = null) where TResult : class, new();
+    Task<FindResults<TResult>> FindAsAsync<TResult>(IRepositoryQuery query, ICommandOptions? options = null) where TResult : class, new();
 
     /// <summary>
     /// Finds a single document matching the specified query.
     /// </summary>
     /// <param name="query">An object containing filter criteria used to enforce tenancy or other system-level filters.</param>
     /// <param name="options">Options to control caching, soft delete filtering, and other behaviors.</param>
-    Task<FindHit<T>> FindOneAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null);
+    Task<FindHit<T>> FindOneAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null);
 
     /// <inheritdoc cref="FindOneAsync(RepositoryQueryDescriptor{T}, CommandOptionsDescriptor{T})"/>
-    Task<FindHit<T>> FindOneAsync(IRepositoryQuery query, ICommandOptions options = null);
+    Task<FindHit<T>> FindOneAsync(IRepositoryQuery query, ICommandOptions? options = null);
 
     /// <summary>
     /// Gets a document count and optional aggregation data for documents matching the query.
     /// </summary>
     /// <param name="query">An object containing filter criteria used to enforce tenancy or other system-level filters.</param>
     /// <param name="options">Options to control caching, soft delete filtering, and other behaviors.</param>
-    Task<CountResult> CountAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null);
+    Task<CountResult> CountAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null);
 
     /// <inheritdoc cref="CountAsync(RepositoryQueryDescriptor{T}, CommandOptionsDescriptor{T})"/>
-    Task<CountResult> CountAsync(IRepositoryQuery query, ICommandOptions options = null);
+    Task<CountResult> CountAsync(IRepositoryQuery query, ICommandOptions? options = null);
 
     /// <summary>
     /// Checks whether any document exists that matches the specified query.
     /// </summary>
     /// <param name="query">An object containing filter criteria used to enforce tenancy or other system-level filters.</param>
     /// <param name="options">Options to control caching, soft delete filtering, and other behaviors.</param>
-    Task<bool> ExistsAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null);
+    Task<bool> ExistsAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null);
 
     /// <inheritdoc cref="ExistsAsync(RepositoryQueryDescriptor{T}, CommandOptionsDescriptor{T})"/>
-    Task<bool> ExistsAsync(IRepositoryQuery query, ICommandOptions options = null);
+    Task<bool> ExistsAsync(IRepositoryQuery query, ICommandOptions? options = null);
 
     /// <summary>
     /// Finds documents using search criteria.
@@ -82,7 +82,7 @@ public interface ISearchableReadOnlyRepository<T> : IReadOnlyRepository<T> where
     /// <param name="aggregations">Aggregation expression used to return aggregated data within any given filters.</param>
     /// <param name="options">Options to control paging, caching, soft delete filtering, and other behaviors.</param>
     [Obsolete("Use FindAsync")]
-    Task<FindResults<T>> SearchAsync(ISystemFilter systemFilter, string filter = null, string criteria = null, string sort = null, string aggregations = null, ICommandOptions options = null);
+    Task<FindResults<T>> SearchAsync(ISystemFilter systemFilter, string? filter = null, string? criteria = null, string? sort = null, string? aggregations = null, ICommandOptions? options = null);
 
     /// <summary>
     /// Gets a document count and optional aggregation data using search criteria.
@@ -92,5 +92,5 @@ public interface ISearchableReadOnlyRepository<T> : IReadOnlyRepository<T> where
     /// <param name="aggregations">Aggregation expression used to return aggregated data within any given filters.</param>
     /// <param name="options">Options to control caching, soft delete filtering, and other behaviors.</param>
     [Obsolete("Use CountAsync")]
-    Task<CountResult> CountBySearchAsync(ISystemFilter systemFilter, string filter = null, string aggregations = null, ICommandOptions options = null);
+    Task<CountResult> CountBySearchAsync(ISystemFilter systemFilter, string? filter = null, string? aggregations = null, ICommandOptions? options = null);
 }

--- a/src/Foundatio.Repositories/ISearchableReadOnlyRepository.cs
+++ b/src/Foundatio.Repositories/ISearchableReadOnlyRepository.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Foundatio.Repositories.Models;
 
@@ -71,26 +70,4 @@ public interface ISearchableReadOnlyRepository<T> : IReadOnlyRepository<T> where
 
     /// <inheritdoc cref="ExistsAsync(RepositoryQueryDescriptor{T}, CommandOptionsDescriptor{T})"/>
     Task<bool> ExistsAsync(IRepositoryQuery query, ICommandOptions? options = null);
-
-    /// <summary>
-    /// Finds documents using search criteria.
-    /// </summary>
-    /// <param name="systemFilter">An object containing filter criteria used to enforce tenancy or other system-level filters.</param>
-    /// <param name="filter">Used to filter the documents (defaults to AND and does not score).</param>
-    /// <param name="criteria">Search criteria to find documents and score the results within any given filters (defaults to OR).</param>
-    /// <param name="sort">How to sort the results. Must be null if you want the results ordered by score.</param>
-    /// <param name="aggregations">Aggregation expression used to return aggregated data within any given filters.</param>
-    /// <param name="options">Options to control paging, caching, soft delete filtering, and other behaviors.</param>
-    [Obsolete("Use FindAsync")]
-    Task<FindResults<T>> SearchAsync(ISystemFilter systemFilter, string? filter = null, string? criteria = null, string? sort = null, string? aggregations = null, ICommandOptions? options = null);
-
-    /// <summary>
-    /// Gets a document count and optional aggregation data using search criteria.
-    /// </summary>
-    /// <param name="systemFilter">An object containing filter criteria used to enforce tenancy or other system-level filters.</param>
-    /// <param name="filter">Used to filter the documents (defaults to AND and does not score).</param>
-    /// <param name="aggregations">Aggregation expression used to return aggregated data within any given filters.</param>
-    /// <param name="options">Options to control caching, soft delete filtering, and other behaviors.</param>
-    [Obsolete("Use CountAsync")]
-    Task<CountResult> CountBySearchAsync(ISystemFilter systemFilter, string? filter = null, string? aggregations = null, ICommandOptions? options = null);
 }

--- a/src/Foundatio.Repositories/ISearchableRepository.cs
+++ b/src/Foundatio.Repositories/ISearchableRepository.cs
@@ -29,10 +29,10 @@ public interface ISearchableRepository<T> : IRepository<T>, ISearchableReadOnlyR
     /// document-based cache invalidation per batch. <see cref="ScriptPatch"/> and <see cref="PartialPatch"/>
     /// use ID-based invalidation only (the modified document is not available client-side).</para>
     /// </remarks>
-    Task<long> PatchAllAsync(RepositoryQueryDescriptor<T> query, IPatchOperation operation, CommandOptionsDescriptor<T> options = null);
+    Task<long> PatchAllAsync(RepositoryQueryDescriptor<T> query, IPatchOperation operation, CommandOptionsDescriptor<T>? options = null);
 
     /// <inheritdoc cref="PatchAllAsync(RepositoryQueryDescriptor{T}, IPatchOperation, CommandOptionsDescriptor{T})"/>
-    Task<long> PatchAllAsync(IRepositoryQuery query, IPatchOperation operation, ICommandOptions options = null);
+    Task<long> PatchAllAsync(IRepositoryQuery query, IPatchOperation operation, ICommandOptions? options = null);
 
     /// <summary>
     /// Permanently removes all documents matching the query (hard delete).
@@ -40,10 +40,10 @@ public interface ISearchableRepository<T> : IRepository<T>, ISearchableReadOnlyR
     /// <param name="query">An object containing filter criteria used to enforce tenancy or other system-level filters.</param>
     /// <param name="options">Options to control caching, notifications, and other behaviors.</param>
     /// <returns>The number of documents removed.</returns>
-    Task<long> RemoveAllAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T> options = null);
+    Task<long> RemoveAllAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null);
 
     /// <inheritdoc cref="RemoveAllAsync(RepositoryQueryDescriptor{T}, CommandOptionsDescriptor{T})"/>
-    Task<long> RemoveAllAsync(IRepositoryQuery query, ICommandOptions options = null);
+    Task<long> RemoveAllAsync(IRepositoryQuery query, ICommandOptions? options = null);
 
     /// <summary>
     /// Processes all documents matching the query in batches.
@@ -52,10 +52,10 @@ public interface ISearchableRepository<T> : IRepository<T>, ISearchableReadOnlyR
     /// <param name="processFunc">A function that processes each batch and returns <c>true</c> to continue or <c>false</c> to stop.</param>
     /// <param name="options">Options to control paging, caching, and other behaviors.</param>
     /// <returns>The total number of documents processed.</returns>
-    Task<long> BatchProcessAsync(RepositoryQueryDescriptor<T> query, Func<FindResults<T>, Task<bool>> processFunc, CommandOptionsDescriptor<T> options = null);
+    Task<long> BatchProcessAsync(RepositoryQueryDescriptor<T> query, Func<FindResults<T>, Task<bool>> processFunc, CommandOptionsDescriptor<T>? options = null);
 
     /// <inheritdoc cref="BatchProcessAsync(RepositoryQueryDescriptor{T}, Func{FindResults{T}, Task{bool}}, CommandOptionsDescriptor{T})"/>
-    Task<long> BatchProcessAsync(IRepositoryQuery query, Func<FindResults<T>, Task<bool>> processFunc, ICommandOptions options = null);
+    Task<long> BatchProcessAsync(IRepositoryQuery query, Func<FindResults<T>, Task<bool>> processFunc, ICommandOptions? options = null);
 
     /// <summary>
     /// Processes all documents matching the query in batches, mapping results to a different type.
@@ -65,8 +65,8 @@ public interface ISearchableRepository<T> : IRepository<T>, ISearchableReadOnlyR
     /// <param name="processFunc">A function that processes each batch and returns <c>true</c> to continue or <c>false</c> to stop.</param>
     /// <param name="options">Options to control paging, caching, and other behaviors.</param>
     /// <returns>The total number of documents processed.</returns>
-    Task<long> BatchProcessAsAsync<TResult>(RepositoryQueryDescriptor<T> query, Func<FindResults<TResult>, Task<bool>> processFunc, CommandOptionsDescriptor<T> options = null) where TResult : class, new();
+    Task<long> BatchProcessAsAsync<TResult>(RepositoryQueryDescriptor<T> query, Func<FindResults<TResult>, Task<bool>> processFunc, CommandOptionsDescriptor<T>? options = null) where TResult : class, new();
 
     /// <inheritdoc cref="BatchProcessAsAsync{TResult}(RepositoryQueryDescriptor{T}, Func{FindResults{TResult}, Task{bool}}, CommandOptionsDescriptor{T})"/>
-    Task<long> BatchProcessAsAsync<TResult>(IRepositoryQuery query, Func<FindResults<TResult>, Task<bool>> processFunc, ICommandOptions options = null) where TResult : class, new();
+    Task<long> BatchProcessAsAsync<TResult>(IRepositoryQuery query, Func<FindResults<TResult>, Task<bool>> processFunc, ICommandOptions? options = null) where TResult : class, new();
 }

--- a/src/Foundatio.Repositories/Id.cs
+++ b/src/Foundatio.Repositories/Id.cs
@@ -9,14 +9,14 @@ public record struct Id
 {
     public static readonly Id Null = new();
 
-    public Id(string id, string routing = null)
+    public Id(string id, string? routing = null)
     {
         Value = id;
         Routing = routing;
     }
 
     public string Value { get; }
-    public string Routing { get; }
+    public string? Routing { get; }
 
     public static implicit operator Id(string id) => new(id);
     public static implicit operator string(Id id) => id.ToString();
@@ -37,11 +37,11 @@ public class Ids : List<Id>
 
     public Ids() { }
 
-    public Ids(IEnumerable<string> ids) : base(ids != null ? ids.Select(i => (Id)i) : new Id[] { }) { }
+    public Ids(IEnumerable<string>? ids) : base(ids is not null ? ids.Select(i => (Id)i) : new Id[] { }) { }
 
     public Ids(IEnumerable<Id> ids) : base(ids) { }
 
-    public Ids(params string[] ids) : base(ids != null ? ids.Select(i => (Id)i) : new Id[] { }) { }
+    public Ids(params string[]? ids) : base(ids is not null ? ids.Select(i => (Id)i) : new Id[] { }) { }
 
     public Ids(params Id[] ids) : base(ids) { }
 

--- a/src/Foundatio.Repositories/JsonPatch/AbstractPatcher.cs
+++ b/src/Foundatio.Repositories/JsonPatch/AbstractPatcher.cs
@@ -1,4 +1,4 @@
-namespace Foundatio.Repositories.Utility;
+﻿namespace Foundatio.Repositories.Utility;
 
 public abstract class AbstractPatcher<TDoc> where TDoc : class
 {
@@ -33,6 +33,7 @@ public abstract class AbstractPatcher<TDoc> where TDoc : class
                 Test(test, target);
                 break;
         }
+
         return target;
     }
 

--- a/src/Foundatio.Repositories/JsonPatch/AbstractPatcher.cs
+++ b/src/Foundatio.Repositories/JsonPatch/AbstractPatcher.cs
@@ -12,18 +12,28 @@ public abstract class AbstractPatcher<TDoc> where TDoc : class
 
     public virtual TDoc ApplyOperation(Operation operation, TDoc target)
     {
-        if (operation is AddOperation)
-            Add((AddOperation)operation, target);
-        else if (operation is CopyOperation)
-            Copy((CopyOperation)operation, target);
-        else if (operation is MoveOperation)
-            Move((MoveOperation)operation, target);
-        else if (operation is RemoveOperation)
-            Remove((RemoveOperation)operation, target);
-        else if (operation is ReplaceOperation)
-            target = Replace((ReplaceOperation)operation, target) ?? target;
-        else if (operation is TestOperation)
-            Test((TestOperation)operation, target);
+        switch (operation)
+        {
+            case AddOperation add:
+                Add(add, target);
+                break;
+            case CopyOperation copy:
+                Copy(copy, target);
+                break;
+            case MoveOperation move:
+                Move(move, target);
+                break;
+            case RemoveOperation remove:
+                Remove(remove, target);
+                break;
+            case ReplaceOperation replace:
+                target = Replace(replace, target) ?? target;
+                break;
+            case TestOperation test:
+                Test(test, target);
+                break;
+        }
+
         return target;
     }
 

--- a/src/Foundatio.Repositories/JsonPatch/AddOperation.cs
+++ b/src/Foundatio.Repositories/JsonPatch/AddOperation.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Utility;
 
 public class AddOperation : Operation
 {
-    public JsonNode Value { get; set; }
+    public JsonNode? Value { get; set; }
 
     public override void Write(Utf8JsonWriter writer)
     {

--- a/src/Foundatio.Repositories/JsonPatch/AddOperation.cs
+++ b/src/Foundatio.Repositories/JsonPatch/AddOperation.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Utility;
 
 public class AddOperation : Operation
 {
-    public JToken Value { get; set; }
+    public JToken? Value { get; set; }
 
     public override void Write(JsonWriter writer)
     {

--- a/src/Foundatio.Repositories/JsonPatch/CopyOperation.cs
+++ b/src/Foundatio.Repositories/JsonPatch/CopyOperation.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Utility;
 
 public class CopyOperation : Operation
 {
-    public string FromPath { get; set; }
+    public string? FromPath { get; set; }
 
     public override void Write(Utf8JsonWriter writer)
     {

--- a/src/Foundatio.Repositories/JsonPatch/CopyOperation.cs
+++ b/src/Foundatio.Repositories/JsonPatch/CopyOperation.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Utility;
 
 public class CopyOperation : Operation
 {
-    public string FromPath { get; set; }
+    public string? FromPath { get; set; }
 
     public override void Write(JsonWriter writer)
     {

--- a/src/Foundatio.Repositories/JsonPatch/JsonDiffer.cs
+++ b/src/Foundatio.Repositories/JsonPatch/JsonDiffer.cs
@@ -22,7 +22,7 @@ public class JsonDiffer
         return value.Replace("~", "~0").Replace("/", "~1");
     }
 
-    private static Operation Build(string op, string path, string key, JsonNode value)
+    private static Operation Build(string op, string path, string key, JsonNode? value)
     {
         string fullPath = String.IsNullOrEmpty(key) ? path : Extend(path, key);
         var jOperation = new JsonObject
@@ -36,7 +36,7 @@ public class JsonDiffer
         return Operation.Build(jOperation);
     }
 
-    internal static Operation Add(string path, string key, JsonNode value)
+    internal static Operation Add(string path, string key, JsonNode? value)
     {
         return Build("add", path, key, value);
     }
@@ -46,39 +46,39 @@ public class JsonDiffer
         return Build("remove", path, key, null);
     }
 
-    internal static Operation Replace(string path, string key, JsonNode value)
+    internal static Operation Replace(string path, string key, JsonNode? value)
     {
         return Build("replace", path, key, value);
     }
 
-    internal static IEnumerable<Operation> CalculatePatch(JsonNode left, JsonNode right, bool useIdToDetermineEquality,
+    internal static IEnumerable<Operation> CalculatePatch(JsonNode? left, JsonNode? right, bool useIdToDetermineEquality,
         string path = "")
     {
         if (GetNodeType(left) != GetNodeType(right))
         {
-            yield return JsonDiffer.Replace(path, "", right);
+            yield return JsonDiffer.Replace(path, String.Empty, right);
             yield break;
         }
 
         if (left is JsonArray)
         {
-            Operation prev = null;
+            Operation? prev = null;
             foreach (var operation in ProcessArray(left, right, path, useIdToDetermineEquality))
             {
-                if (prev is RemoveOperation prevRemove && operation is AddOperation add && add.Path == prevRemove.Path)
+                if (prev is RemoveOperation prevRemove && operation is AddOperation add && add.Path is not null && add.Path == prevRemove.Path)
                 {
-                    yield return Replace(add.Path, "", add.Value);
+                    yield return Replace(add.Path, String.Empty, add.Value);
                     prev = null;
                 }
                 else
                 {
-                    if (prev != null)
+                    if (prev is not null)
                         yield return prev;
                     prev = operation;
                 }
             }
 
-            if (prev != null)
+            if (prev is not null)
                 yield return prev;
         }
         else if (left is JsonObject leftObj && right is JsonObject rightObj)
@@ -114,11 +114,11 @@ public class JsonDiffer
             if (JsonNodeToString(left) == JsonNodeToString(right))
                 yield break;
             else
-                yield return JsonDiffer.Replace(path, "", right);
+                yield return JsonDiffer.Replace(path, String.Empty, right);
         }
     }
 
-    private static string GetNodeType(JsonNode node)
+    private static string GetNodeType(JsonNode? node)
     {
         return node switch
         {
@@ -130,12 +130,12 @@ public class JsonDiffer
         };
     }
 
-    private static string JsonNodeToString(JsonNode node)
+    private static string JsonNodeToString(JsonNode? node)
     {
         return node?.ToJsonString() ?? "null";
     }
 
-    private static IEnumerable<Operation> ProcessArray(JsonNode left, JsonNode right, string path,
+    private static IEnumerable<Operation> ProcessArray(JsonNode? left, JsonNode? right, string path,
         bool useIdPropertyToDetermineEquality)
     {
         var comparer = new CustomCheckEqualityComparer(useIdPropertyToDetermineEquality);
@@ -202,13 +202,13 @@ public class JsonDiffer
         }
     }
 
-    public PatchDocument Diff(JsonNode @from, JsonNode to, bool useIdPropertyToDetermineEquality)
+    public PatchDocument Diff(JsonNode? @from, JsonNode? to, bool useIdPropertyToDetermineEquality)
     {
         return new PatchDocument(CalculatePatch(@from, to, useIdPropertyToDetermineEquality).ToArray());
     }
 }
 
-internal class CustomCheckEqualityComparer : IEqualityComparer<JsonNode>
+internal class CustomCheckEqualityComparer : IEqualityComparer<JsonNode?>
 {
     private readonly bool _enableIdCheck;
 
@@ -217,14 +217,14 @@ internal class CustomCheckEqualityComparer : IEqualityComparer<JsonNode>
         _enableIdCheck = enableIdCheck;
     }
 
-    public bool Equals(JsonNode x, JsonNode y)
+    public bool Equals(JsonNode? x, JsonNode? y)
     {
         if (!_enableIdCheck || x is not JsonObject xObj || y is not JsonObject yObj)
             return JsonNode.DeepEquals(x, y);
 
-        string xId = xObj["id"]?.GetValue<string>();
-        string yId = yObj["id"]?.GetValue<string>();
-        if (xId != null && xId == yId)
+        string? xId = xObj["id"]?.GetValue<string>();
+        string? yId = yObj["id"]?.GetValue<string>();
+        if (xId is not null && xId == yId)
         {
             return true;
         }
@@ -232,7 +232,7 @@ internal class CustomCheckEqualityComparer : IEqualityComparer<JsonNode>
         return JsonNode.DeepEquals(x, y);
     }
 
-    public int GetHashCode(JsonNode obj)
+    public int GetHashCode(JsonNode? obj)
     {
         if (obj is null)
             return 0;
@@ -240,21 +240,21 @@ internal class CustomCheckEqualityComparer : IEqualityComparer<JsonNode>
         if (!_enableIdCheck || obj is not JsonObject xObj)
             return obj.ToJsonString().GetHashCode();
 
-        string xId = xObj["id"]?.GetValue<string>();
-        if (xId != null)
+        string? xId = xObj["id"]?.GetValue<string>();
+        if (xId is not null)
             return xId.GetHashCode() + obj.ToJsonString().GetHashCode();
 
         return obj.ToJsonString().GetHashCode();
     }
 
-    public static bool HaveEqualIds(JsonNode x, JsonNode y)
+    public static bool HaveEqualIds(JsonNode? x, JsonNode? y)
     {
         if (x is not JsonObject xObj || y is not JsonObject yObj)
             return false;
 
-        string xId = xObj["id"]?.GetValue<string>();
-        string yId = yObj["id"]?.GetValue<string>();
+        string? xId = xObj["id"]?.GetValue<string>();
+        string? yId = yObj["id"]?.GetValue<string>();
 
-        return xId != null && xId == yId;
+        return xId is not null && xId == yId;
     }
 }

--- a/src/Foundatio.Repositories/JsonPatch/JsonDiffer.cs
+++ b/src/Foundatio.Repositories/JsonPatch/JsonDiffer.cs
@@ -65,7 +65,7 @@ public class JsonDiffer
             Operation? prev = null;
             foreach (var operation in ProcessArray(left, right, path, useIdToDetermineEquality))
             {
-                if (prev is RemoveOperation prevRemove && operation is AddOperation add && add.Path is not null && add.Path == prevRemove.Path)
+                if (prev is RemoveOperation prevRemove && operation is AddOperation add && add.Path is not null && String.Equals(add.Path, prevRemove.Path, StringComparison.Ordinal))
                 {
                     yield return Replace(add.Path, String.Empty, add.Value);
                     prev = null;

--- a/src/Foundatio.Repositories/JsonPatch/JsonDiffer.cs
+++ b/src/Foundatio.Repositories/JsonPatch/JsonDiffer.cs
@@ -14,14 +14,15 @@ public class JsonDiffer
         return path + "/" + extension;
     }
 
-    private static Operation Build(string op, string path, string key, JToken value)
+    private static Operation Build(string op, string path, string key, JToken? value)
     {
-        if (String.IsNullOrEmpty(key))
-            return Operation.Parse("{ 'op' : '" + op + "' , path: '" + path + "', value: " +
-                                (value == null ? "null" : value.ToString(Formatting.None)) + "}");
+        string fullPath = String.IsNullOrEmpty(key) ? path : Extend(path, key);
 
-        return Operation.Parse("{ op : '" + op + "' , path : '" + Extend(path, key) + "' , value : " +
-                            (value == null ? "null" : value.ToString(Formatting.None)) + "}");
+        if (String.Equals(op, "remove", StringComparison.Ordinal))
+            return Operation.Parse("{ 'op' : '" + op + "' , 'path': '" + fullPath + "'}");
+
+        return Operation.Parse("{ 'op' : '" + op + "' , 'path' : '" + fullPath + "' , 'value' : " +
+                            (value is null ? "null" : value.ToString(Formatting.None)) + "}");
     }
 
     internal static Operation Add(string path, string key, JToken value)
@@ -34,7 +35,7 @@ public class JsonDiffer
         return Build("remove", path, key, null);
     }
 
-    internal static Operation Replace(string path, string key, JToken value)
+    internal static Operation Replace(string path, string key, JToken? value)
     {
         return Build("replace", path, key, value);
     }
@@ -44,29 +45,29 @@ public class JsonDiffer
     {
         if (left.Type != right.Type)
         {
-            yield return JsonDiffer.Replace(path, "", right);
+            yield return JsonDiffer.Replace(path, String.Empty, right);
             yield break;
         }
 
         if (left.Type == JTokenType.Array)
         {
-            Operation prev = null;
+            Operation? prev = null;
             foreach (var operation in ProcessArray(left, right, path, useIdToDetermineEquality))
             {
-                if (prev is RemoveOperation prevRemove && operation is AddOperation add && add.Path == prevRemove.Path)
+                if (prev is RemoveOperation prevRemove && operation is AddOperation add && add.Path is not null && add.Path == prevRemove.Path)
                 {
-                    yield return Replace(add.Path, "", add.Value);
+                    yield return Replace(add.Path, String.Empty, add.Value);
                     prev = null;
                 }
                 else
                 {
-                    if (prev != null)
+                    if (prev is not null)
                         yield return prev;
                     prev = operation;
                 }
             }
 
-            if (prev != null)
+            if (prev is not null)
                 yield return prev;
         }
         else if (left.Type == JTokenType.Object)
@@ -85,7 +86,7 @@ public class JsonDiffer
             }
 
             var matchedKeys = lprops.Select(x => x.Key).Intersect(rprops.Select(y => y.Key));
-            var zipped = matchedKeys.Select(k => new { key = k, left = left[k], right = right[k] });
+            var zipped = matchedKeys.Select(k => new { key = k, left = left[k]!, right = right[k]! });
 
             foreach (var match in zipped)
             {
@@ -102,7 +103,7 @@ public class JsonDiffer
             if (left.ToString() == right.ToString())
                 yield break;
             else
-                yield return JsonDiffer.Replace(path, "", right);
+                yield return JsonDiffer.Replace(path, String.Empty, right);
         }
     }
 
@@ -207,17 +208,17 @@ internal class CustomCheckEqualityComparer : IEqualityComparer<JToken>
         _inner = inner;
     }
 
-    public bool Equals(JToken x, JToken y)
+    public bool Equals(JToken? x, JToken? y)
     {
-        if (!_enableIdCheck || x.Type != JTokenType.Object || y.Type != JTokenType.Object)
+        if (!_enableIdCheck || x is null || y is null || x.Type != JTokenType.Object || y.Type != JTokenType.Object)
             return _inner.Equals(x, y);
 
         var xIdToken = x["id"];
         var yIdToken = y["id"];
 
-        string xId = xIdToken?.Value<string>();
-        string yId = yIdToken?.Value<string>();
-        if (xId != null && xId == yId)
+        string? xId = xIdToken?.Value<string>();
+        string? yId = yIdToken?.Value<string>();
+        if (xId is not null && xId == yId)
         {
             return true;
         }
@@ -231,8 +232,8 @@ internal class CustomCheckEqualityComparer : IEqualityComparer<JToken>
             return _inner.GetHashCode(obj);
 
         var xIdToken = obj["id"];
-        string xId = xIdToken != null && xIdToken.HasValues ? xIdToken.Value<string>() : null;
-        if (xId != null)
+        string? xId = xIdToken is not null && xIdToken.HasValues ? xIdToken.Value<string>() : null;
+        if (xId is not null)
             return xId.GetHashCode() + _inner.GetHashCode(obj);
 
         return _inner.GetHashCode(obj);
@@ -246,9 +247,9 @@ internal class CustomCheckEqualityComparer : IEqualityComparer<JToken>
         var xIdToken = x["id"];
         var yIdToken = y["id"];
 
-        string xId = xIdToken?.Value<string>();
-        string yId = yIdToken?.Value<string>();
+        string? xId = xIdToken?.Value<string>();
+        string? yId = yIdToken?.Value<string>();
 
-        return xId != null && xId == yId;
+        return xId is not null && xId == yId;
     }
 }

--- a/src/Foundatio.Repositories/JsonPatch/JsonPatcher.cs
+++ b/src/Foundatio.Repositories/JsonPatch/JsonPatcher.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
@@ -16,6 +16,9 @@ public class JsonPatcher : AbstractPatcher<JsonNode>
 {
     protected override JsonNode Replace(ReplaceOperation operation, JsonNode target)
     {
+        if (operation.Path is null)
+            throw new ArgumentException("Replace operation requires a 'path' property.");
+
         var tokens = target.SelectPatchTokens(operation.Path).ToList();
         if (tokens.Count == 0)
         {
@@ -37,7 +40,7 @@ public class JsonPatcher : AbstractPatcher<JsonNode>
             if (parent is JsonObject parentObj)
             {
                 var propName = parentObj.FirstOrDefault(p => ReferenceEquals(p.Value, token)).Key;
-                if (propName != null)
+                if (propName is not null)
                     parentObj[propName] = operation.Value?.DeepClone();
             }
             else if (parent is JsonArray parentArr)
@@ -48,7 +51,7 @@ public class JsonPatcher : AbstractPatcher<JsonNode>
             }
             else // root object
             {
-                return operation.Value?.DeepClone();
+                return operation.Value?.DeepClone()!;
             }
         }
 
@@ -57,25 +60,28 @@ public class JsonPatcher : AbstractPatcher<JsonNode>
 
     protected override void Add(AddOperation operation, JsonNode target)
     {
+        if (operation.Path is null)
+            throw new ArgumentException("Add operation requires a 'path' property.");
+
         string[] parts = operation.Path.Split('/');
         string parentPath = String.Join("/", parts.Select((p, i) => i < parts.Length - 1 ? p : String.Empty).Where(p => p.Length > 0));
-        string propertyName = JsonNodeExtensions.UnescapeJsonPointer(parts.LastOrDefault() ?? String.Empty);
+        string? propertyName = parts.LastOrDefault();
 
         if (propertyName == "-")
         {
             var array = target.SelectOrCreatePatchArrayToken(parentPath) as JsonArray;
             array?.Add(operation.Value?.DeepClone());
         }
-        else if (propertyName.IsNumeric())
+        else if (propertyName is not null && propertyName.IsNumeric())
         {
             var array = target.SelectOrCreatePatchArrayToken(parentPath) as JsonArray;
             if (Int32.TryParse(propertyName, out int index))
                 array?.Insert(index, operation.Value?.DeepClone());
         }
-        else
+        else if (propertyName is not null)
         {
             var parent = target.SelectOrCreatePatchToken(parentPath) as JsonObject;
-            if (parent != null)
+            if (parent is not null)
             {
                 if (parent.ContainsKey(propertyName))
                     parent[propertyName] = operation.Value?.DeepClone();
@@ -87,6 +93,9 @@ public class JsonPatcher : AbstractPatcher<JsonNode>
 
     protected override void Remove(RemoveOperation operation, JsonNode target)
     {
+        if (operation.Path is null)
+            throw new ArgumentException("Remove operation requires a 'path' property.");
+
         // Handle JSONPath expressions (e.g., $.books[?(@.author == 'X')])
         if (operation.Path.StartsWith("$.", StringComparison.Ordinal) || operation.Path.StartsWith("$[", StringComparison.Ordinal))
         {
@@ -108,7 +117,7 @@ public class JsonPatcher : AbstractPatcher<JsonNode>
                 else if (tokenParent is JsonObject tokenParentObj)
                 {
                     var key = tokenParentObj.FirstOrDefault(p => ReferenceEquals(p.Value, token)).Key;
-                    if (key != null)
+                    if (key is not null)
                         tokenParentObj.Remove(key);
                 }
             }
@@ -140,18 +149,24 @@ public class JsonPatcher : AbstractPatcher<JsonNode>
 
     protected override void Move(MoveOperation operation, JsonNode target)
     {
+        if (operation.Path is null || operation.FromPath is null)
+            throw new ArgumentException("Move operation requires both 'path' and 'from' properties.");
+
         if (operation.Path == operation.FromPath || operation.Path.StartsWith(operation.FromPath + "/"))
             throw new ArgumentException("To path cannot be below from path");
 
         var token = target.SelectPatchToken(operation.FromPath);
+        if (token is null)
+            throw new InvalidOperationException($"Move source path '{operation.FromPath}' does not exist.");
+
         Remove(new RemoveOperation { Path = operation.FromPath }, target);
         Add(new AddOperation { Path = operation.Path, Value = token?.DeepClone() }, target);
     }
 
     protected override void Test(TestOperation operation, JsonNode target)
     {
-        var existingValue = target.SelectPatchToken(operation.Path);
-        if (!JsonNode.DeepEquals(existingValue, operation.Value))
+        var existingValue = operation.Path is not null ? target.SelectPatchToken(operation.Path) : null;
+        if (existingValue is null || !JsonNode.DeepEquals(existingValue, operation.Value))
         {
             throw new InvalidOperationException($"Value at {operation.Path} does not match.");
         }
@@ -159,7 +174,13 @@ public class JsonPatcher : AbstractPatcher<JsonNode>
 
     protected override void Copy(CopyOperation operation, JsonNode target)
     {
+        if (operation.FromPath is null)
+            throw new ArgumentException("Copy operation requires a 'from' property.");
+
         var token = target.SelectPatchToken(operation.FromPath);
+        if (token is null)
+            throw new InvalidOperationException($"Copy source path '{operation.FromPath}' does not exist.");
+
         Add(new AddOperation { Path = operation.Path, Value = token?.DeepClone() }, target);
     }
 }
@@ -172,7 +193,7 @@ public static class JsonNodeExtensions
     private static readonly Regex _dotPropFilterRegex = new(@"^@\.(\w+)\s*==\s*'(.+)'$", RegexOptions.Compiled);
     private static readonly Regex _directValueFilterRegex = new(@"^@\s*==\s*'(.+)'$", RegexOptions.Compiled);
 
-    public static JsonNode SelectPatchToken(this JsonNode token, string path)
+    public static JsonNode? SelectPatchToken(this JsonNode token, string path)
     {
         return SelectToken(token, path.ToJsonPointerPath());
     }
@@ -183,7 +204,7 @@ public static class JsonNodeExtensions
             return SelectJsonPathTokens(token, path);
 
         var result = SelectToken(token, path.ToJsonPointerPath());
-        if (result != null)
+        if (result is not null)
             return new[] { result };
         return Enumerable.Empty<JsonNode>();
     }
@@ -306,12 +327,12 @@ public static class JsonNodeExtensions
         return segments;
     }
 
-    private static JsonNode SelectToken(JsonNode node, string[] pathParts)
+    private static JsonNode? SelectToken(JsonNode? node, string[] pathParts)
     {
-        JsonNode current = node;
+        JsonNode? current = node;
         foreach (var part in pathParts)
         {
-            if (current == null)
+            if (current is null)
                 return null;
 
             if (current is JsonObject obj)
@@ -335,14 +356,14 @@ public static class JsonNodeExtensions
         return current;
     }
 
-    public static JsonNode SelectOrCreatePatchToken(this JsonNode token, string path)
+    public static JsonNode? SelectOrCreatePatchToken(this JsonNode token, string path)
     {
         var pathParts = path.ToJsonPointerPath();
         if (pathParts.Length == 0)
             return token;
 
         // Validate that the path can be created: numeric parts must resolve to existing array indices
-        JsonNode validationNode = token;
+        JsonNode? validationNode = token;
         for (int i = 0; i < pathParts.Length; i++)
         {
             string part = pathParts[i];
@@ -363,7 +384,7 @@ public static class JsonNodeExtensions
                 else
                     return null;
             }
-            else if (validationNode == null)
+            else if (validationNode is null)
             {
                 if (part.IsNumeric())
                     return null;
@@ -375,7 +396,7 @@ public static class JsonNodeExtensions
         }
 
         // Create missing intermediate objects
-        JsonNode current = token;
+        JsonNode? current = token;
         for (int i = 0; i < pathParts.Length; i++)
         {
             string part = pathParts[i];
@@ -413,14 +434,14 @@ public static class JsonNodeExtensions
         return current;
     }
 
-    public static JsonNode SelectOrCreatePatchArrayToken(this JsonNode token, string path)
+    public static JsonNode? SelectOrCreatePatchArrayToken(this JsonNode token, string path)
     {
         var pathParts = path.ToJsonPointerPath();
         if (pathParts.Length == 0)
             return token;
 
         // Validate that the path can be created: numeric parts must resolve to existing array indices
-        JsonNode validationNode = token;
+        JsonNode? validationNode = token;
         for (int i = 0; i < pathParts.Length; i++)
         {
             string part = pathParts[i];
@@ -441,7 +462,7 @@ public static class JsonNodeExtensions
                 else
                     return null;
             }
-            else if (validationNode == null)
+            else if (validationNode is null)
             {
                 if (part.IsNumeric())
                     return null;
@@ -453,7 +474,7 @@ public static class JsonNodeExtensions
         }
 
         // Create missing intermediate objects (arrays for last segment)
-        JsonNode current = token;
+        JsonNode? current = token;
         for (int i = 0; i < pathParts.Length; i++)
         {
             string part = pathParts[i];

--- a/src/Foundatio.Repositories/JsonPatch/JsonPatcher.cs
+++ b/src/Foundatio.Repositories/JsonPatch/JsonPatcher.cs
@@ -10,14 +10,17 @@ public class JsonPatcher : AbstractPatcher<JToken>
 {
     protected override JToken Replace(ReplaceOperation operation, JToken target)
     {
+        if (operation.Path is null)
+            throw new ArgumentException("Replace operation requires a 'path' property.");
+
         var tokens = target.SelectPatchTokens(operation.Path).ToList();
         if (tokens.Count == 0)
         {
             string[] parts = operation.Path.Split('/');
-            string parentPath = String.Join("/", parts.Select((p, i) => i < parts.Length - 1 ? p : String.Empty).Where(p => p.Length > 0));
-            string propertyName = parts.LastOrDefault();
+            string parentPath = String.Join("/", parts.Take(parts.Length - 1));
+            string? propertyName = parts.LastOrDefault();
 
-            if (target.SelectOrCreatePatchToken(parentPath) is not JObject parent)
+            if (propertyName is null || target.SelectOrCreatePatchToken(parentPath) is not JObject parent)
                 return target;
 
             parent[propertyName] = operation.Value;
@@ -27,10 +30,10 @@ public class JsonPatcher : AbstractPatcher<JToken>
 
         foreach (var token in tokens)
         {
-            if (token.Parent != null)
-                token.Replace(operation.Value);
+            if (token.Parent is not null)
+                token.Replace(operation.Value ?? JValue.CreateNull());
             else // root object
-                return operation.Value;
+                return operation.Value ?? JValue.CreateNull();
         }
 
         return target;
@@ -38,34 +41,42 @@ public class JsonPatcher : AbstractPatcher<JToken>
 
     protected override void Add(AddOperation operation, JToken target)
     {
+        if (operation.Path is null)
+            throw new ArgumentException("Add operation requires a 'path' property.");
+
         string[] parts = operation.Path.Split('/');
-        string parentPath = String.Join("/", parts.Select((p, i) => i < parts.Length - 1 ? p : String.Empty).Where(p => p.Length > 0));
-        string propertyName = parts.LastOrDefault();
+        string parentPath = String.Join("/", parts.Take(parts.Length - 1));
+        string? propertyName = parts.LastOrDefault();
+
+        var value = operation.Value ?? JValue.CreateNull();
 
         if (propertyName == "-")
         {
             var array = target.SelectOrCreatePatchArrayToken(parentPath) as JArray;
-            array?.Add(operation.Value);
+            array?.Add(value);
         }
-        else if (propertyName.IsNumeric())
+        else if (propertyName is not null && propertyName.IsNumeric())
         {
             var array = target.SelectOrCreatePatchArrayToken(parentPath) as JArray;
             if (Int32.TryParse(propertyName, out int index))
-                array?.Insert(index, operation.Value);
+                array?.Insert(index, value);
         }
-        else
+        else if (propertyName is not null)
         {
             var parent = target.SelectOrCreatePatchToken(parentPath) as JObject;
             var property = parent?.Property(propertyName);
-            if (property == null)
-                parent?.Add(propertyName, operation.Value);
+            if (property is null)
+                parent?.Add(propertyName, value);
             else
-                property.Value = operation.Value;
+                property.Value = value;
         }
     }
 
     protected override void Remove(RemoveOperation operation, JToken target)
     {
+        if (operation.Path is null)
+            throw new ArgumentException("Remove operation requires a 'path' property.");
+
         var tokens = target.SelectPatchTokens(operation.Path).ToList();
         if (tokens.Count == 0)
             return;
@@ -85,18 +96,25 @@ public class JsonPatcher : AbstractPatcher<JToken>
 
     protected override void Move(MoveOperation operation, JToken target)
     {
+        if (operation.Path is null || operation.FromPath is null)
+            throw new ArgumentException("Move operation requires both 'path' and 'from' properties.");
+
         if (operation.Path.StartsWith(operation.FromPath))
             throw new ArgumentException("To path cannot be below from path");
 
         var token = target.SelectPatchToken(operation.FromPath);
+        if (token is null)
+            throw new InvalidOperationException($"Move source path '{operation.FromPath}' does not exist.");
+
         Remove(new RemoveOperation { Path = operation.FromPath }, target);
         Add(new AddOperation { Path = operation.Path, Value = token }, target);
     }
 
     protected override void Test(TestOperation operation, JToken target)
     {
-        var existingValue = target.SelectPatchToken(operation.Path);
-        if (!existingValue.Equals(target))
+        // Do I need to clone this?
+        var existingValue = operation.Path is not null ? target.SelectPatchToken(operation.Path) : null;
+        if (existingValue is null || !JToken.DeepEquals(existingValue, operation.Value))
         {
             throw new InvalidOperationException("Value at " + operation.Path + " does not match.");
         }
@@ -104,14 +122,20 @@ public class JsonPatcher : AbstractPatcher<JToken>
 
     protected override void Copy(CopyOperation operation, JToken target)
     {
+        if (operation.FromPath is null)
+            throw new ArgumentException("Copy operation requires a 'from' property.");
+
         var token = target.SelectPatchToken(operation.FromPath);  // Do I need to clone this?
+        if (token is null)
+            throw new InvalidOperationException($"Copy source path '{operation.FromPath}' does not exist.");
+
         Add(new AddOperation { Path = operation.Path, Value = token }, target);
     }
 }
 
 public static class JTokenExtensions
 {
-    public static JToken SelectPatchToken(this JToken token, string path)
+    public static JToken? SelectPatchToken(this JToken token, string path)
     {
         return token.SelectToken(path.ToJTokenPath());
     }
@@ -121,10 +145,10 @@ public static class JTokenExtensions
         return token.SelectTokens(path.ToJTokenPath());
     }
 
-    public static JToken SelectOrCreatePatchToken(this JToken token, string path)
+    public static JToken? SelectOrCreatePatchToken(this JToken token, string path)
     {
         var result = token.SelectToken(path.ToJTokenPath());
-        if (result != null)
+        if (result is not null)
             return result;
 
         string[] parts = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
@@ -136,7 +160,7 @@ public static class JTokenExtensions
         {
             string part = parts[i];
             var partToken = current.SelectPatchToken(part);
-            if (partToken == null)
+            if (partToken is null)
             {
                 if (current is JObject partObject)
                     current = partObject[part] = new JObject();
@@ -150,10 +174,10 @@ public static class JTokenExtensions
         return current;
     }
 
-    public static JToken SelectOrCreatePatchArrayToken(this JToken token, string path)
+    public static JToken? SelectOrCreatePatchArrayToken(this JToken token, string path)
     {
         var result = token.SelectToken(path.ToJTokenPath());
-        if (result != null)
+        if (result is not null)
             return result;
 
         string[] parts = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
@@ -165,7 +189,7 @@ public static class JTokenExtensions
         {
             string part = parts[i];
             var partToken = current.SelectPatchToken(part);
-            if (partToken == null)
+            if (partToken is null)
             {
                 if (current is JObject partObject)
                 {

--- a/src/Foundatio.Repositories/JsonPatch/JsonPatcher.cs
+++ b/src/Foundatio.Repositories/JsonPatch/JsonPatcher.cs
@@ -65,7 +65,7 @@ public class JsonPatcher : AbstractPatcher<JsonNode>
 
         string[] parts = operation.Path.Split('/');
         string parentPath = String.Join("/", parts.Select((p, i) => i < parts.Length - 1 ? p : String.Empty).Where(p => p.Length > 0));
-        string? propertyName = parts.LastOrDefault();
+        string? propertyName = parts.Length > 0 ? JsonNodeExtensions.UnescapeJsonPointer(parts[^1]) : null;
 
         if (propertyName == "-")
         {

--- a/src/Foundatio.Repositories/JsonPatch/MoveOperation.cs
+++ b/src/Foundatio.Repositories/JsonPatch/MoveOperation.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Utility;
 
 public class MoveOperation : Operation
 {
-    public string FromPath { get; set; }
+    public string? FromPath { get; set; }
 
     public override void Write(Utf8JsonWriter writer)
     {

--- a/src/Foundatio.Repositories/JsonPatch/MoveOperation.cs
+++ b/src/Foundatio.Repositories/JsonPatch/MoveOperation.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Utility;
 
 public class MoveOperation : Operation
 {
-    public string FromPath { get; set; }
+    public string? FromPath { get; set; }
 
     public override void Write(JsonWriter writer)
     {

--- a/src/Foundatio.Repositories/JsonPatch/Operation.cs
+++ b/src/Foundatio.Repositories/JsonPatch/Operation.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Repositories.Utility;
 
 public abstract class Operation
 {
-    public string Path { get; set; }
+    public string? Path { get; set; }
 
     public abstract void Write(JsonWriter writer);
 
@@ -16,22 +16,25 @@ public abstract class Operation
         writer.WriteValue(op);
     }
 
-    protected static void WritePath(JsonWriter writer, string path)
+    protected static void WritePath(JsonWriter writer, string? path)
     {
         writer.WritePropertyName("path");
         writer.WriteValue(path);
     }
 
-    protected static void WriteFromPath(JsonWriter writer, string path)
+    protected static void WriteFromPath(JsonWriter writer, string? path)
     {
         writer.WritePropertyName("from");
         writer.WriteValue(path);
     }
 
-    protected static void WriteValue(JsonWriter writer, JToken value)
+    protected static void WriteValue(JsonWriter writer, JToken? value)
     {
         writer.WritePropertyName("value");
-        value.WriteTo(writer);
+        if (value is not null)
+            value.WriteTo(writer);
+        else
+            JValue.CreateNull().WriteTo(writer);
     }
 
     public abstract void Read(JObject jOperation);
@@ -45,7 +48,7 @@ public abstract class Operation
     {
         ArgumentNullException.ThrowIfNull(jOperation);
 
-        var opName = (string)jOperation["op"];
+        var opName = (string?)jOperation["op"];
         ArgumentException.ThrowIfNullOrWhiteSpace(opName, "op");
 
         var op = PatchDocument.CreateOperation(opName)

--- a/src/Foundatio.Repositories/JsonPatch/Operation.cs
+++ b/src/Foundatio.Repositories/JsonPatch/Operation.cs
@@ -11,7 +11,7 @@ namespace Foundatio.Repositories.Utility;
 /// </summary>
 public abstract class Operation
 {
-    public string Path { get; set; }
+    public string? Path { get; set; }
 
     public abstract void Write(Utf8JsonWriter writer);
 
@@ -20,23 +20,23 @@ public abstract class Operation
         writer.WriteString("op", op);
     }
 
-    protected static void WritePath(Utf8JsonWriter writer, string path)
+    protected static void WritePath(Utf8JsonWriter writer, string? path)
     {
         writer.WriteString("path", path);
     }
 
-    protected static void WriteFromPath(Utf8JsonWriter writer, string path)
+    protected static void WriteFromPath(Utf8JsonWriter writer, string? path)
     {
         writer.WriteString("from", path);
     }
 
-    protected static void WriteValue(Utf8JsonWriter writer, JsonNode value)
+    protected static void WriteValue(Utf8JsonWriter writer, JsonNode? value)
     {
         writer.WritePropertyName("value");
-        if (value == null)
-            writer.WriteNullValue();
-        else
+        if (value is not null)
             value.WriteTo(writer);
+        else
+            writer.WriteNullValue();
     }
 
     public abstract void Read(JsonObject jOperation);
@@ -46,7 +46,7 @@ public abstract class Operation
         return Build(JsonNode.Parse(json)?.AsObject());
     }
 
-    public static Operation Build(JsonObject jOperation)
+    public static Operation Build(JsonObject? jOperation)
     {
         ArgumentNullException.ThrowIfNull(jOperation);
 

--- a/src/Foundatio.Repositories/JsonPatch/PatchDocument.cs
+++ b/src/Foundatio.Repositories/JsonPatch/PatchDocument.cs
@@ -53,7 +53,7 @@ public class PatchDocument
     {
         var root = new PatchDocument();
 
-        if (document == null)
+        if (document is null)
             return root;
 
         foreach (var child in document.Children())
@@ -70,12 +70,12 @@ public class PatchDocument
 
     public static PatchDocument Parse(string jsondocument)
     {
-        var root = JToken.Parse(jsondocument) as JArray;
+        var root = JArray.Parse(jsondocument);
 
         return Load(root);
     }
 
-    public static Operation CreateOperation(string op)
+    public static Operation? CreateOperation(string op)
     {
         switch (op)
         {

--- a/src/Foundatio.Repositories/JsonPatch/PatchDocument.cs
+++ b/src/Foundatio.Repositories/JsonPatch/PatchDocument.cs
@@ -27,7 +27,7 @@ public class PatchDocument
 
     public List<Operation> Operations => _operations;
 
-    public void Add(string path, JsonNode value)
+    public void Add(string path, JsonNode? value)
     {
         Operations.Add(new AddOperation { Path = path, Value = value });
     }
@@ -38,7 +38,7 @@ public class PatchDocument
     public void Add(string path, double value) => Add(path, JsonValue.Create(value));
     public void Add(string path, bool value) => Add(path, JsonValue.Create(value));
 
-    public void Replace(string path, JsonNode value)
+    public void Replace(string path, JsonNode? value)
     {
         Operations.Add(new ReplaceOperation { Path = path, Value = value });
     }
@@ -70,7 +70,7 @@ public class PatchDocument
     {
         var root = new PatchDocument();
 
-        if (document == null)
+        if (document is null)
             return root;
 
         foreach (var item in document)
@@ -94,7 +94,7 @@ public class PatchDocument
         return Load(root);
     }
 
-    public static Operation CreateOperation(string op)
+    public static Operation? CreateOperation(string op)
     {
         switch (op)
         {

--- a/src/Foundatio.Repositories/JsonPatch/PatchDocumentConverter.cs
+++ b/src/Foundatio.Repositories/JsonPatch/PatchDocumentConverter.cs
@@ -11,7 +11,7 @@ public class PatchDocumentConverter : JsonConverter
         return true;
     }
 
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
         if (objectType != typeof(PatchDocument))
             throw new ArgumentException("Object must be of type PatchDocument", nameof(objectType));
@@ -30,12 +30,11 @@ public class PatchDocumentConverter : JsonConverter
         }
     }
 
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
-        if (!(value is PatchDocument))
+        if (value is not PatchDocument jsonPatchDoc)
             return;
 
-        var jsonPatchDoc = (PatchDocument)value;
         writer.WriteStartArray();
         foreach (var op in jsonPatchDoc.Operations)
             op.Write(writer);

--- a/src/Foundatio.Repositories/JsonPatch/PatchDocumentConverter.cs
+++ b/src/Foundatio.Repositories/JsonPatch/PatchDocumentConverter.cs
@@ -12,7 +12,7 @@ namespace Foundatio.Repositories.Utility;
 /// </summary>
 public class PatchDocumentConverter : JsonConverter<PatchDocument>
 {
-    public override PatchDocument Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override PatchDocument? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (typeToConvert != typeof(PatchDocument))
             throw new ArgumentException("Object must be of type PatchDocument", nameof(typeToConvert));
@@ -38,9 +38,9 @@ public class PatchDocumentConverter : JsonConverter<PatchDocument>
         }
     }
 
-    public override void Write(Utf8JsonWriter writer, PatchDocument value, JsonSerializerOptions options)
+    public override void Write(Utf8JsonWriter writer, PatchDocument? value, JsonSerializerOptions options)
     {
-        if (value == null)
+        if (value is null)
         {
             writer.WriteNullValue();
             return;

--- a/src/Foundatio.Repositories/JsonPatch/ReplaceOperation.cs
+++ b/src/Foundatio.Repositories/JsonPatch/ReplaceOperation.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Utility;
 
 public class ReplaceOperation : Operation
 {
-    public JsonNode Value { get; set; }
+    public JsonNode? Value { get; set; }
 
     public override void Write(Utf8JsonWriter writer)
     {

--- a/src/Foundatio.Repositories/JsonPatch/ReplaceOperation.cs
+++ b/src/Foundatio.Repositories/JsonPatch/ReplaceOperation.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Utility;
 
 public class ReplaceOperation : Operation
 {
-    public JToken Value { get; set; }
+    public JToken? Value { get; set; }
 
     public override void Write(JsonWriter writer)
     {

--- a/src/Foundatio.Repositories/JsonPatch/TestOperation.cs
+++ b/src/Foundatio.Repositories/JsonPatch/TestOperation.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Utility;
 
 public class TestOperation : Operation
 {
-    public JToken Value { get; set; }
+    public JToken? Value { get; set; }
 
     public override void Write(JsonWriter writer)
     {

--- a/src/Foundatio.Repositories/JsonPatch/TestOperation.cs
+++ b/src/Foundatio.Repositories/JsonPatch/TestOperation.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Utility;
 
 public class TestOperation : Operation
 {
-    public JsonNode Value { get; set; }
+    public JsonNode? Value { get; set; }
 
     public override void Write(Utf8JsonWriter writer)
     {

--- a/src/Foundatio.Repositories/Migration/IMigration.cs
+++ b/src/Foundatio.Repositories/Migration/IMigration.cs
@@ -62,7 +62,7 @@ public enum MigrationType
 
 public static class MigrationExtensions
 {
-    public static string GetId(this IMigration migration)
+    public static string? GetId(this IMigration migration)
     {
         return migration.MigrationType != MigrationType.Repeatable ? migration.Version.ToString() : migration.GetType().FullName;
     }

--- a/src/Foundatio.Repositories/Migration/MigrationBase.cs
+++ b/src/Foundatio.Repositories/Migration/MigrationBase.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Repositories.Migrations;
 
 public abstract class MigrationBase : IMigration
 {
-    protected ILogger _logger;
+    protected ILogger _logger = null!;
 
     public MigrationBase()
     {

--- a/src/Foundatio.Repositories/Migration/MigrationManager.cs
+++ b/src/Foundatio.Repositories/Migration/MigrationManager.cs
@@ -67,7 +67,7 @@ public class MigrationManager
         if (migrationType == null)
             throw new ArgumentNullException(nameof(migrationType));
 
-        object migrationInstance = _serviceProvider.GetService(migrationType);
+        object? migrationInstance = _serviceProvider.GetService(migrationType);
         if (migrationInstance == null)
             throw new ArgumentException($"Unable to get instance of type '{migrationType.Name}'. Please ensure it's registered in Dependency Injection.", nameof(migrationType));
 
@@ -75,7 +75,7 @@ public class MigrationManager
             throw new ArgumentException($"Type '{migrationType.Name}' must implement interface '{nameof(IMigration)}'.", nameof(migrationType));
 
         var versionedMigrations = _migrations.Where(m => m.MigrationType != MigrationType.Repeatable && m.Version.HasValue);
-        if (migration.Version.HasValue && versionedMigrations.Any(m => m.Version.Value == migration.Version))
+        if (migration.Version.HasValue && versionedMigrations.Any(m => m.Version is { } v && v == migration.Version))
             throw new ArgumentException($"Duplicate migration version detected for '{migrationType.Name}'", nameof(migrationType));
 
         _migrations.Add(migration);
@@ -138,7 +138,7 @@ public class MigrationManager
                 {
                     _logger.LogError(ex, "Failed running migration {Id}", migrationInfo.Migration.GetId());
 
-                    migrationInfo.State.ErrorMessage = ex.Message;
+                    migrationInfo.State!.ErrorMessage = ex.Message;
                     await _migrationStatusRepository.SaveAsync(migrationInfo.State).AnyContext();
 
                     return MigrationResult.Failed;
@@ -165,7 +165,7 @@ public class MigrationManager
         {
             info.State = new MigrationState
             {
-                Id = info.Migration.GetId(),
+                Id = info.Migration.GetId()!,
                 MigrationType = info.Migration.MigrationType,
                 Version = info.Migration.Version ?? 0,
                 StartedUtc = _timeProvider.GetUtcNow().UtcDateTime
@@ -183,7 +183,7 @@ public class MigrationManager
 
     private async Task MarkMigrationCompleteAsync(MigrationInfo info)
     {
-        info.State.CompletedUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        info.State!.CompletedUtc = _timeProvider.GetUtcNow().UtcDateTime;
         info.State.ErrorMessage = null;
         await _migrationStatusRepository.SaveAsync(info.State).AnyContext();
         _logger.LogInformation("Completed migration {Id}", info.State.Id);
@@ -192,7 +192,7 @@ public class MigrationManager
     public async Task<MigrationStatus> GetMigrationStatus()
     {
         var migrations = Migrations.OrderBy(m => m.Version).ToList();
-        string[] migrationIds = migrations.Select(m => m.GetId()).ToArray();
+        string[] migrationIds = migrations.Select(m => m.GetId()!).ToArray();
 
         // get by id to ensure latest document versions
         var migrationStatesByIds = await _migrationStatusRepository.GetByIdsAsync(migrationIds).AnyContext();
@@ -200,7 +200,7 @@ public class MigrationManager
 
         // get all to add any additional migrations that are not configured
         var otherMigrationStates = await _migrationStatusRepository.GetAllAsync(o => o.PageLimit(1000)).AnyContext();
-        migrationStates.AddRange(otherMigrationStates.Documents.Where(m => !migrationStates.Any(s => s.Id == m.Id)));
+        migrationStates.AddRange(otherMigrationStates.Documents.Where(m => !migrationStates.Any(s => String.Equals(s.Id, m.Id, StringComparison.Ordinal))));
 
         var migrationInfos = migrations.Select(m => new MigrationInfo
         {
@@ -219,7 +219,7 @@ public class MigrationManager
                 if (versioned.Length > 0)
                 {
                     var now = _timeProvider.GetUtcNow().UtcDateTime;
-                    max = versioned.Max(v => v.Migration.Version.Value);
+                    max = versioned.Max(v => v.Migration.Version!.Value);
 
                     // marking highest version as completed
                     await _migrationStatusRepository.SaveAsync(new MigrationState
@@ -244,7 +244,7 @@ public class MigrationManager
             currentVersion = completedVersionedMigrations.Max(m => m.Version);
 
         var pendingMigrations = new List<MigrationInfo>();
-        pendingMigrations.AddRange(versioned.Where(m => m.Migration.Version.Value > currentVersion).OrderBy(m => m.Migration.Version.Value));
+        pendingMigrations.AddRange(versioned.Where(m => m.Migration.Version!.Value > currentVersion).OrderBy(m => m.Migration.Version!.Value));
 
         // repeatable migrations that haven't run or have a newer version
         pendingMigrations.AddRange(migrationInfos.Where(i => i.Migration.MigrationType == MigrationType.Repeatable && (i.State == null || i.State.Version < i.Migration.Version)));
@@ -252,7 +252,7 @@ public class MigrationManager
         return new MigrationStatus(pendingMigrations, currentVersion);
     }
 
-    private IEnumerable<Type> GetDerivedTypes<TAction>(IList<Assembly> assemblies = null)
+    private IEnumerable<Type> GetDerivedTypes<TAction>(IList<Assembly>? assemblies = null)
     {
         if (assemblies == null || assemblies.Count == 0)
             assemblies = AppDomain.CurrentDomain.GetAssemblies();
@@ -266,8 +266,8 @@ public class MigrationManager
             }
             catch (ReflectionTypeLoadException ex)
             {
-                string loaderMessages = String.Join(", ", ex.LoaderExceptions.ToList().Select(le => le.Message));
-                _logger.LogInformation(ex, "Unable to search types from assembly \"{Assembly}\" for plugins of type \"{PluginType}\": {LoaderMessages}", assembly.FullName, typeof(TAction).Name, loaderMessages);
+                string loaderMessages = String.Join(", ", (ex.LoaderExceptions ?? []).OfType<Exception>().Select(le => le.Message));
+                _logger.LogInformation("Unable to search types from assembly {Assembly} for plugins of type {PluginType}: {LoaderMessages}", assembly.FullName, typeof(TAction).Name, loaderMessages);
             }
         }
 
@@ -284,15 +284,15 @@ public enum MigrationResult
 }
 
 [DebuggerDisplay("Type: {Migration.MigrationType} Version {Migration.Version}")]
-public class MigrationInfo
+public record MigrationInfo
 {
-    public IMigration Migration { get; set; }
-    public MigrationState State { get; set; }
+    public required IMigration Migration { get; init; }
+    public MigrationState? State { get; set; }
 }
 
 public class MigrationStatus
 {
-    public MigrationStatus(IReadOnlyCollection<MigrationInfo> pendingMigrations, int currentVersion)
+    public MigrationStatus(IReadOnlyCollection<MigrationInfo>? pendingMigrations, int currentVersion)
     {
         PendingMigrations = pendingMigrations ?? EmptyReadOnly<MigrationInfo>.Collection;
         CurrentVersion = currentVersion;

--- a/src/Foundatio.Repositories/Migration/MigrationManager.cs
+++ b/src/Foundatio.Repositories/Migration/MigrationManager.cs
@@ -67,7 +67,7 @@ public class MigrationManager
         if (migrationType == null)
             throw new ArgumentNullException(nameof(migrationType));
 
-        object migrationInstance = _serviceProvider.GetService(migrationType);
+        object? migrationInstance = _serviceProvider.GetService(migrationType);
         if (migrationInstance == null)
             throw new ArgumentException($"Unable to get instance of type '{migrationType.Name}'. Please ensure it's registered in Dependency Injection.", nameof(migrationType));
 
@@ -75,7 +75,7 @@ public class MigrationManager
             throw new ArgumentException($"Type '{migrationType.Name}' must implement interface '{nameof(IMigration)}'.", nameof(migrationType));
 
         var versionedMigrations = _migrations.Where(m => m.MigrationType != MigrationType.Repeatable && m.Version.HasValue);
-        if (migration.Version.HasValue && versionedMigrations.Any(m => m.Version.Value == migration.Version))
+        if (migration.Version.HasValue && versionedMigrations.Any(m => m.Version is { } v && v == migration.Version))
             throw new ArgumentException($"Duplicate migration version detected for '{migrationType.Name}'", nameof(migrationType));
 
         _migrations.Add(migration);
@@ -138,7 +138,7 @@ public class MigrationManager
                 {
                     _logger.LogError(ex, "Failed running migration {Id}", migrationInfo.Migration.GetId());
 
-                    migrationInfo.State.ErrorMessage = ex.Message;
+                    migrationInfo.State!.ErrorMessage = ex.Message;
                     await _migrationStatusRepository.SaveAsync(migrationInfo.State).AnyContext();
 
                     return MigrationResult.Failed;
@@ -165,7 +165,7 @@ public class MigrationManager
         {
             info.State = new MigrationState
             {
-                Id = info.Migration.GetId(),
+                Id = info.Migration.GetId()!,
                 MigrationType = info.Migration.MigrationType,
                 Version = info.Migration.Version ?? 0,
                 StartedUtc = _timeProvider.GetUtcNow().UtcDateTime
@@ -183,7 +183,7 @@ public class MigrationManager
 
     private async Task MarkMigrationCompleteAsync(MigrationInfo info)
     {
-        info.State.CompletedUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        info.State!.CompletedUtc = _timeProvider.GetUtcNow().UtcDateTime;
         info.State.ErrorMessage = null;
         await _migrationStatusRepository.SaveAsync(info.State).AnyContext();
         _logger.LogInformation("Completed migration {Id}", info.State.Id);
@@ -192,7 +192,7 @@ public class MigrationManager
     public async Task<MigrationStatus> GetMigrationStatus()
     {
         var migrations = Migrations.OrderBy(m => m.Version).ToList();
-        string[] migrationIds = migrations.Select(m => m.GetId()).ToArray();
+        string[] migrationIds = migrations.Select(m => m.GetId()!).ToArray();
 
         // get by id to ensure latest document versions
         var migrationStatesByIds = await _migrationStatusRepository.GetByIdsAsync(migrationIds).AnyContext();
@@ -200,7 +200,7 @@ public class MigrationManager
 
         // get all to add any additional migrations that are not configured
         var otherMigrationStates = await _migrationStatusRepository.GetAllAsync(o => o.PageLimit(1000)).AnyContext();
-        migrationStates.AddRange(otherMigrationStates.Documents.Where(m => !migrationStates.Any(s => s.Id == m.Id)));
+        migrationStates.AddRange(otherMigrationStates.Documents.Where(m => !migrationStates.Any(s => String.Equals(s.Id, m.Id, StringComparison.Ordinal))));
 
         var migrationInfos = migrations.Select(m => new MigrationInfo
         {
@@ -219,7 +219,7 @@ public class MigrationManager
                 if (versioned.Length > 0)
                 {
                     var now = _timeProvider.GetUtcNow().UtcDateTime;
-                    max = versioned.Max(v => v.Migration.Version.Value);
+                    max = versioned.Max(v => v.Migration.Version!.Value);
 
                     // marking highest version as completed
                     await _migrationStatusRepository.SaveAsync(new MigrationState
@@ -244,7 +244,7 @@ public class MigrationManager
             currentVersion = completedVersionedMigrations.Max(m => m.Version);
 
         var pendingMigrations = new List<MigrationInfo>();
-        pendingMigrations.AddRange(versioned.Where(m => m.Migration.Version.Value > currentVersion).OrderBy(m => m.Migration.Version.Value));
+        pendingMigrations.AddRange(versioned.Where(m => m.Migration.Version!.Value > currentVersion).OrderBy(m => m.Migration.Version!.Value));
 
         // repeatable migrations that haven't run or have a newer version
         pendingMigrations.AddRange(migrationInfos.Where(i => i.Migration.MigrationType == MigrationType.Repeatable && (i.State == null || i.State.Version < i.Migration.Version)));
@@ -252,7 +252,7 @@ public class MigrationManager
         return new MigrationStatus(pendingMigrations, currentVersion);
     }
 
-    private IEnumerable<Type> GetDerivedTypes<TAction>(IList<Assembly> assemblies = null)
+    private IEnumerable<Type> GetDerivedTypes<TAction>(IList<Assembly>? assemblies = null)
     {
         if (assemblies == null || assemblies.Count == 0)
             assemblies = AppDomain.CurrentDomain.GetAssemblies();
@@ -266,7 +266,7 @@ public class MigrationManager
             }
             catch (ReflectionTypeLoadException ex)
             {
-                string loaderMessages = String.Join(", ", ex.LoaderExceptions.ToList().Select(le => le.Message));
+                string loaderMessages = String.Join(", ", (ex.LoaderExceptions ?? []).OfType<Exception>().Select(le => le.Message));
                 _logger.LogInformation("Unable to search types from assembly {Assembly} for plugins of type {PluginType}: {LoaderMessages}", assembly.FullName, typeof(TAction).Name, loaderMessages);
             }
         }
@@ -284,15 +284,15 @@ public enum MigrationResult
 }
 
 [DebuggerDisplay("Type: {Migration.MigrationType} Version {Migration.Version}")]
-public class MigrationInfo
+public record MigrationInfo
 {
-    public IMigration Migration { get; set; }
-    public MigrationState State { get; set; }
+    public required IMigration Migration { get; init; }
+    public MigrationState? State { get; set; }
 }
 
 public class MigrationStatus
 {
-    public MigrationStatus(IReadOnlyCollection<MigrationInfo> pendingMigrations, int currentVersion)
+    public MigrationStatus(IReadOnlyCollection<MigrationInfo>? pendingMigrations, int currentVersion)
     {
         PendingMigrations = pendingMigrations ?? EmptyReadOnly<MigrationInfo>.Collection;
         CurrentVersion = currentVersion;

--- a/src/Foundatio.Repositories/Migration/MigrationManager.cs
+++ b/src/Foundatio.Repositories/Migration/MigrationManager.cs
@@ -267,7 +267,7 @@ public class MigrationManager
             catch (ReflectionTypeLoadException ex)
             {
                 string loaderMessages = String.Join(", ", (ex.LoaderExceptions ?? []).OfType<Exception>().Select(le => le.Message));
-                _logger.LogInformation("Unable to search types from assembly {Assembly} for plugins of type {PluginType}: {LoaderMessages}", assembly.FullName, typeof(TAction).Name, loaderMessages);
+                _logger.LogInformation(ex, "Unable to search types from assembly {Assembly} for plugins of type {PluginType}: {LoaderMessages}", assembly.FullName, typeof(TAction).Name, loaderMessages);
             }
         }
 

--- a/src/Foundatio.Repositories/Migration/MigrationState.cs
+++ b/src/Foundatio.Repositories/Migration/MigrationState.cs
@@ -5,10 +5,10 @@ namespace Foundatio.Repositories.Migrations;
 
 public class MigrationState : IIdentity
 {
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
     public MigrationType MigrationType { get; set; }
     public int Version { get; set; }
     public DateTime StartedUtc { get; set; }
     public DateTime? CompletedUtc { get; set; }
-    public string ErrorMessage { get; set; }
+    public string? ErrorMessage { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/AggregationsHelper.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/AggregationsHelper.cs
@@ -8,14 +8,14 @@ public class AggregationsHelper
 
     public AggregationsHelper() { }
 
-    protected AggregationsHelper(IDictionary<string, IAggregate> aggregations)
+    protected AggregationsHelper(IDictionary<string, IAggregate>? aggregations)
     {
         Aggregations = aggregations != null ?
             new Dictionary<string, IAggregate>(aggregations)
             : EmptyReadOnly<string, IAggregate>.Dictionary;
     }
 
-    public AggregationsHelper(IReadOnlyDictionary<string, IAggregate> aggregations)
+    public AggregationsHelper(IReadOnlyDictionary<string, IAggregate>? aggregations)
     {
         Aggregations = aggregations ?? EmptyReadOnly<string, IAggregate>.Dictionary;
     }

--- a/src/Foundatio.Repositories/Models/Aggregations/BucketAggregate.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/BucketAggregate.cs
@@ -5,6 +5,6 @@ namespace Foundatio.Repositories.Models;
 public class BucketAggregate : IAggregate
 {
     public IReadOnlyCollection<IBucket> Items { get; set; } = EmptyReadOnly<IBucket>.Collection;
-    public IReadOnlyDictionary<string, object> Data { get; set; } = EmptyReadOnly<string, object>.Dictionary;
+    public IReadOnlyDictionary<string, object>? Data { get; set; } = EmptyReadOnly<string, object>.Dictionary;
     public long Total { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/BucketAggregateBase.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/BucketAggregateBase.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Models;
 public abstract class BucketAggregateBase : AggregationsHelper, IAggregate
 {
     protected BucketAggregateBase() { }
-    protected BucketAggregateBase(IReadOnlyDictionary<string, IAggregate> aggregations) : base(aggregations) { }
+    protected BucketAggregateBase(IReadOnlyDictionary<string, IAggregate>? aggregations) : base(aggregations) { }
 
-    public IReadOnlyDictionary<string, object> Data { get; set; }
+    public IReadOnlyDictionary<string, object>? Data { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/BucketBase.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/BucketBase.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Models;
 public abstract class BucketBase : AggregationsHelper, IBucket
 {
     protected BucketBase() { }
-    protected BucketBase(IReadOnlyDictionary<string, IAggregate> aggregations) : base(aggregations) { }
+    protected BucketBase(IReadOnlyDictionary<string, IAggregate>? aggregations) : base(aggregations) { }
 
-    public IReadOnlyDictionary<string, object> Data { get; set; }
+    public IReadOnlyDictionary<string, object>? Data { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/DateHistogramBucket.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/DateHistogramBucket.cs
@@ -12,7 +12,7 @@ public class DateHistogramBucket : KeyedBucket<double>
     }
 
     [System.Text.Json.Serialization.JsonConstructor]
-    public DateHistogramBucket(DateTime date, IReadOnlyDictionary<string, IAggregate> aggregations) : base(aggregations)
+    public DateHistogramBucket(DateTime date, IReadOnlyDictionary<string, IAggregate>? aggregations) : base(aggregations)
     {
         Date = date;
     }

--- a/src/Foundatio.Repositories/Models/Aggregations/ExtendedStatsAggregate.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/ExtendedStatsAggregate.cs
@@ -8,5 +8,5 @@ public class ExtendedStatsAggregate : StatsAggregate
     public double? SumOfSquares { get; set; }
     public double? Variance { get; set; }
     public double? StdDeviation { get; set; }
-    public StandardDeviationBounds StdDeviationBounds { get; set; }
+    public StandardDeviationBounds? StdDeviationBounds { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/IAggregate.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/IAggregate.cs
@@ -17,5 +17,5 @@ public interface IAggregate
     /// <summary>
     /// Gets or sets the aggregation data.
     /// </summary>
-    IReadOnlyDictionary<string, object> Data { get; set; }
+    IReadOnlyDictionary<string, object>? Data { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/IBucket.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/IBucket.cs
@@ -17,5 +17,5 @@ public interface IBucket
     /// <summary>
     /// Gets or sets the bucket data, including document count and nested aggregations.
     /// </summary>
-    IReadOnlyDictionary<string, object> Data { get; set; }
+    IReadOnlyDictionary<string, object>? Data { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/KeyedAggregation.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/KeyedAggregation.cs
@@ -2,5 +2,5 @@
 
 public class KeyedAggregation<T> : ValueAggregate
 {
-    public T Key { get; set; }
+    public T Key { get; set; } = default!;
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/KeyedBucket.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/KeyedBucket.cs
@@ -12,12 +12,12 @@ public class KeyedBucket<T> : BucketBase
     }
 
     [System.Text.Json.Serialization.JsonConstructor]
-    public KeyedBucket(IReadOnlyDictionary<string, IAggregate> aggregations) : base(aggregations)
+    public KeyedBucket(IReadOnlyDictionary<string, IAggregate>? aggregations) : base(aggregations)
     {
     }
 
     [System.Text.Json.Serialization.JsonConverter(typeof(InferredTypesConverterFactory))]
-    public T Key { get; set; }
-    public string KeyAsString { get; set; }
+    public T Key { get; set; } = default!;
+    public string? KeyAsString { get; set; }
     public long? Total { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/KeyedBucket.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/KeyedBucket.cs
@@ -12,12 +12,12 @@ public class KeyedBucket<T> : BucketBase
     }
 
     [System.Text.Json.Serialization.JsonConstructor]
-    public KeyedBucket(IReadOnlyDictionary<string, IAggregate> aggregations) : base(aggregations)
+    public KeyedBucket(IReadOnlyDictionary<string, IAggregate>? aggregations) : base(aggregations)
     {
     }
 
     [System.Text.Json.Serialization.JsonConverter(typeof(ObjectToInferredTypesConverter))]
-    public T Key { get; set; }
-    public string KeyAsString { get; set; }
+    public T Key { get; set; } = default!;
+    public string? KeyAsString { get; set; }
     public long? Total { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/MetricAggregateBase.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/MetricAggregateBase.cs
@@ -4,5 +4,5 @@ namespace Foundatio.Repositories.Models;
 
 public class MetricAggregateBase : IAggregate
 {
-    public IReadOnlyDictionary<string, object> Data { get; set; }
+    public IReadOnlyDictionary<string, object>? Data { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/MultiBucketAggregate.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/MultiBucketAggregate.cs
@@ -7,7 +7,7 @@ public class MultiBucketAggregate<TBucket> : BucketAggregateBase
 {
     public MultiBucketAggregate() { }
 
-    public MultiBucketAggregate(IReadOnlyDictionary<string, IAggregate> aggregations) : base(aggregations) { }
+    public MultiBucketAggregate(IReadOnlyDictionary<string, IAggregate>? aggregations) : base(aggregations) { }
 
     public IReadOnlyCollection<TBucket> Buckets { get; set; } = EmptyReadOnly<TBucket>.Collection;
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/ObjectValueAggregate.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/ObjectValueAggregate.cs
@@ -9,21 +9,25 @@ namespace Foundatio.Repositories.Models;
 [DebuggerDisplay("Value: {Value}")]
 public class ObjectValueAggregate : MetricAggregateBase
 {
-    public object Value { get; set; }
+    public object? Value { get; set; }
 
-    public T ValueAs<T>(ITextSerializer serializer)
+    public T? ValueAs<T>(ITextSerializer? serializer = null)
     {
-        ArgumentNullException.ThrowIfNull(serializer);
+        if (Value is null)
+            return default;
 
-        if (Value is string stringValue)
-            return serializer.Deserialize<T>(stringValue);
+        if (serializer is not null)
+        {
+            if (Value is string stringValue)
+                return serializer.Deserialize<T>(stringValue);
 
-        if (Value is JsonNode jNode)
-            return serializer.Deserialize<T>(jNode.ToJsonString());
+            if (Value is JsonNode jNode)
+                return serializer.Deserialize<T>(jNode.ToJsonString());
 
-        if (Value is JsonElement jElement)
-            return serializer.Deserialize<T>(jElement.GetRawText());
+            if (Value is JsonElement jElement)
+                return serializer.Deserialize<T>(jElement.GetRawText());
+        }
 
-        return (T)Convert.ChangeType(Value, typeof(T));
+        return (T?)Convert.ChangeType(Value, typeof(T));
     }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/ObjectValueAggregate.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/ObjectValueAggregate.cs
@@ -16,16 +16,31 @@ public class ObjectValueAggregate : MetricAggregateBase
         if (Value is null)
             return default;
 
-        if (serializer is not null)
+        if (Value is T typed)
+            return typed;
+
+        if (Value is string stringValue)
         {
-            if (Value is string stringValue)
+            if (serializer is not null)
                 return serializer.Deserialize<T>(stringValue);
 
-            if (Value is JsonNode jNode)
-                return serializer.Deserialize<T>(jNode.ToJsonString());
+            return (T?)Convert.ChangeType(stringValue, typeof(T));
+        }
 
-            if (Value is JsonElement jElement)
-                return serializer.Deserialize<T>(jElement.GetRawText());
+        if (Value is JsonNode jNode)
+        {
+            if (serializer is null)
+                throw new InvalidOperationException($"Cannot convert {Value.GetType().Name} to {typeof(T).Name} without a serializer.");
+
+            return serializer.Deserialize<T>(jNode.ToJsonString());
+        }
+
+        if (Value is JsonElement jElement)
+        {
+            if (serializer is null)
+                throw new InvalidOperationException($"Cannot convert {Value.GetType().Name} to {typeof(T).Name} without a serializer.");
+
+            return serializer.Deserialize<T>(jElement.GetRawText());
         }
 
         return (T?)Convert.ChangeType(Value, typeof(T));

--- a/src/Foundatio.Repositories/Models/Aggregations/ObjectValueAggregate.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/ObjectValueAggregate.cs
@@ -8,10 +8,13 @@ namespace Foundatio.Repositories.Models;
 [DebuggerDisplay("Value: {Value}")]
 public class ObjectValueAggregate : MetricAggregateBase
 {
-    public object Value { get; set; }
+    public object? Value { get; set; }
 
-    public T ValueAs<T>(ITextSerializer serializer = null)
+    public T? ValueAs<T>(ITextSerializer? serializer = null)
     {
+        if (Value is null)
+            return default;
+
         if (serializer != null)
         {
             if (Value is string stringValue)
@@ -22,6 +25,6 @@ public class ObjectValueAggregate : MetricAggregateBase
 
         return Value is JToken jToken
             ? jToken.ToObject<T>()
-            : (T)Convert.ChangeType(Value, typeof(T));
+            : (T?)Convert.ChangeType(Value, typeof(T));
     }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/PercentilesAggregate.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/PercentilesAggregate.cs
@@ -14,10 +14,11 @@ public class PercentilesAggregate : MetricAggregateBase
 {
     public PercentilesAggregate() { }
 
-    public PercentilesAggregate(IEnumerable<PercentileItem> items)
+    public PercentilesAggregate(IEnumerable<PercentileItem>? items)
     {
-        Items = new List<PercentileItem>(items).AsReadOnly();
+        if (items is not null)
+            Items = new List<PercentileItem>(items).AsReadOnly();
     }
 
-    public IReadOnlyCollection<PercentileItem> Items { get; internal set; }
+    public IReadOnlyCollection<PercentileItem> Items { get; internal set; } = [];
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/RangeBucket.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/RangeBucket.cs
@@ -9,12 +9,12 @@ public class RangeBucket : BucketBase
     public RangeBucket() { }
 
     [System.Text.Json.Serialization.JsonConstructor]
-    public RangeBucket(IReadOnlyDictionary<string, IAggregate> aggregations) : base(aggregations) { }
+    public RangeBucket(IReadOnlyDictionary<string, IAggregate>? aggregations) : base(aggregations) { }
 
-    public string Key { get; set; }
+    public string? Key { get; set; }
     public double? From { get; set; }
-    public string FromAsString { get; set; }
+    public string? FromAsString { get; set; }
     public double? To { get; set; }
-    public string ToAsString { get; set; }
+    public string? ToAsString { get; set; }
     public long Total { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/SingleBucketAggregate.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/SingleBucketAggregate.cs
@@ -8,7 +8,7 @@ public class SingleBucketAggregate : BucketAggregateBase
 {
     public SingleBucketAggregate() { }
 
-    public SingleBucketAggregate(IReadOnlyDictionary<string, IAggregate> aggregations) : base(aggregations) { }
+    public SingleBucketAggregate(IReadOnlyDictionary<string, IAggregate>? aggregations) : base(aggregations) { }
 
     public long Total { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/TopHitsAggregate.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/TopHitsAggregate.cs
@@ -16,7 +16,7 @@ public class TopHitsAggregate : MetricAggregateBase
     /// <summary>
     /// Raw JSON sources for each hit, used for serialization/deserialization round-tripping (e.g., caching).
     /// </summary>
-    public IReadOnlyList<string> Hits { get; set; }
+    public IReadOnlyList<string> Hits { get; set; } = [];
 
     public TopHitsAggregate(IList<ILazyDocument> hits)
     {
@@ -30,10 +30,10 @@ public class TopHitsAggregate : MetricAggregateBase
     /// Can be omitted when reading directly from an Elasticsearch response where <c>_hits</c> are populated from
     /// the live response.
     /// </param>
-    public IReadOnlyCollection<T> Documents<T>(ITextSerializer serializer = null) where T : class
+    public IReadOnlyCollection<T> Documents<T>(ITextSerializer? serializer = null) where T : class
     {
         if (_hits.Count > 0)
-            return _hits.Select(h => h.As<T>()).ToList();
+            return _hits.Select(h => h.As<T>()).OfType<T>().ToList().AsReadOnly();
 
         if (Hits is { Count: > 0 })
         {
@@ -47,8 +47,9 @@ public class TopHitsAggregate : MetricAggregateBase
                     var lazy = new LazyDocument(Encoding.UTF8.GetBytes(json), serializer);
                     return lazy.As<T>();
                 })
-                .Where(d => d != null)
-                .ToList();
+                .OfType<T>()
+                .ToList()
+                .AsReadOnly();
         }
 
         return new List<T>();

--- a/src/Foundatio.Repositories/Models/Aggregations/TopHitsAggregate.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/TopHitsAggregate.cs
@@ -17,6 +17,6 @@ public class TopHitsAggregate : MetricAggregateBase
 
     public IReadOnlyCollection<T> Documents<T>() where T : class
     {
-        return _hits.Select(h => h.As<T>()).ToList();
+        return _hits.Select(h => h.As<T>()).OfType<T>().ToList().AsReadOnly();
     }
 }

--- a/src/Foundatio.Repositories/Models/Aggregations/ValueAggregate.cs
+++ b/src/Foundatio.Repositories/Models/Aggregations/ValueAggregate.cs
@@ -11,5 +11,5 @@ public class ValueAggregate : MetricAggregateBase
 [DebuggerDisplay("Value: {Value}")]
 public class ValueAggregate<T> : MetricAggregateBase
 {
-    public T Value { get; set; }
+    public T Value { get; set; } = default!;
 }

--- a/src/Foundatio.Repositories/Models/DocumentChangeEventArgs.cs
+++ b/src/Foundatio.Repositories/Models/DocumentChangeEventArgs.cs
@@ -49,12 +49,12 @@ public class ModifiedDocumentsEventArgs<T> : EventArgs where T : class, IIdentit
 
 public class ModifiedDocument<T> where T : class, new()
 {
-    public ModifiedDocument(T value, T original)
+    public ModifiedDocument(T value, T? original)
     {
         Value = value;
         Original = original;
     }
 
     public T Value { get; set; }
-    public T Original { get; private set; }
+    public T? Original { get; private set; }
 }

--- a/src/Foundatio.Repositories/Models/EmptyReadOnly.cs
+++ b/src/Foundatio.Repositories/Models/EmptyReadOnly.cs
@@ -8,7 +8,7 @@ public static class EmptyReadOnly<T>
     public static readonly IReadOnlyCollection<T> Collection = new ReadOnlyCollection<T>(new List<T>());
 }
 
-public static class EmptyReadOnly<TKey, TValue>
+public static class EmptyReadOnly<TKey, TValue> where TKey : notnull
 {
     public static readonly IReadOnlyDictionary<TKey, TValue> Dictionary = new ReadOnlyDictionary<TKey, TValue>(new Dictionary<TKey, TValue>());
 }

--- a/src/Foundatio.Repositories/Models/EntityChanged.cs
+++ b/src/Foundatio.Repositories/Models/EntityChanged.cs
@@ -12,8 +12,16 @@ public class EntityChanged : IHaveData
         Data = new DataDictionary();
     }
 
-    public string Type { get; set; }
-    public string Id { get; set; }
+    /// <summary>
+    /// The entity type name. May be null for non-entity-specific change notifications.
+    /// </summary>
+    public string? Type { get; set; }
+
+    /// <summary>
+    /// The entity identifier. Null for bulk or collection-level change notifications
+    /// that do not target a single document.
+    /// </summary>
+    public string? Id { get; set; }
     public ChangeType ChangeType { get; set; }
     public IDictionary<string, object> Data { get; set; }
 }

--- a/src/Foundatio.Repositories/Models/FindResults.cs
+++ b/src/Foundatio.Repositories/Models/FindResults.cs
@@ -39,7 +39,7 @@ public class FindResults<T> : CountResult, IFindResults<T> where T : class
     /// <param name="getNextPageFunc">A function to retrieve the next page of results.</param>
     /// <param name="data">Additional metadata.</param>
     [Newtonsoft.Json.JsonConstructor]
-    public FindResults(IEnumerable<FindHit<T>> hits = null, long total = 0, IReadOnlyDictionary<string, IAggregate> aggregations = null, Func<FindResults<T>, Task<FindResults<T>>> getNextPageFunc = null, IDictionary<string, object> data = null)
+    public FindResults(IEnumerable<FindHit<T>>? hits = null, long total = 0, IReadOnlyDictionary<string, IAggregate>? aggregations = null, Func<FindResults<T>, Task<FindResults<T>>>? getNextPageFunc = null, IDictionary<string, object>? data = null)
         : base(total, aggregations, data)
     {
         ((IFindResults<T>)this).GetNextPageFunc = getNextPageFunc;
@@ -66,7 +66,7 @@ public class FindResults<T> : CountResult, IFindResults<T> where T : class
             if (value is { Count: > 0 })
             {
                 field = value;
-                Documents = field.Where(r => r.Document is not null).Select(r => r.Document).ToList().AsReadOnly();
+                Documents = field.Where(r => r.Document is not null).Select(r => r.Document!).ToList().AsReadOnly();
             }
             else
             {
@@ -102,7 +102,7 @@ public class FindResults<T> : CountResult, IFindResults<T> where T : class
         set { HasMore = value; }
     }
 
-    Func<FindResults<T>, Task<FindResults<T>>> IFindResults<T>.GetNextPageFunc { get; set; }
+    Func<FindResults<T>, Task<FindResults<T>>>? IFindResults<T>.GetNextPageFunc { get; set; }
 
     void IFindResults<T>.Reverse()
     {
@@ -175,7 +175,7 @@ public interface IFindResults<T> where T : class
     /// <summary>
     /// Gets or sets the function used to retrieve the next page of results.
     /// </summary>
-    Func<FindResults<T>, Task<FindResults<T>>> GetNextPageFunc { get; set; }
+    Func<FindResults<T>, Task<FindResults<T>>>? GetNextPageFunc { get; set; }
 
     /// <summary>
     /// Reverses the order of the results.
@@ -201,7 +201,7 @@ public class CountResult : IHaveData
     /// <param name="data">Additional metadata.</param>
     [JsonConstructor]
     [Newtonsoft.Json.JsonConstructor]
-    public CountResult(long total = 0, IReadOnlyDictionary<string, IAggregate> aggregations = null, IDictionary<string, object> data = null)
+    public CountResult(long total = 0, IReadOnlyDictionary<string, IAggregate>? aggregations = null, IDictionary<string, object>? data = null)
     {
         Aggregations = aggregations ?? EmptyReadOnly<string, IAggregate>.Dictionary;
         Total = total;
@@ -224,7 +224,7 @@ public class CountResult : IHaveData
         set
         {
             field = value ?? EmptyReadOnly<string, IAggregate>.Dictionary;
-            Aggs = null;
+            Aggs = null!;
         }
     }
 
@@ -286,7 +286,7 @@ public class FindHit<T> : IHaveData
     /// <param name="data">Additional metadata.</param>
     [JsonConstructor]
     [Newtonsoft.Json.JsonConstructor]
-    public FindHit(string id, T document, double score, string version = null, string routing = null, IDictionary<string, object> data = null)
+    public FindHit(string? id, T? document, double score, string? version = null, string? routing = null, IDictionary<string, object>? data = null)
     {
         Id = id;
         Document = document;
@@ -299,7 +299,7 @@ public class FindHit<T> : IHaveData
     /// <summary>
     /// Gets the document.
     /// </summary>
-    public T Document { get; }
+    public T? Document { get; }
 
     /// <summary>
     /// Gets the relevance score for this hit.
@@ -309,17 +309,17 @@ public class FindHit<T> : IHaveData
     /// <summary>
     /// Gets the document version.
     /// </summary>
-    public string Version { get; }
+    public string? Version { get; }
 
     /// <summary>
     /// Gets the document identifier.
     /// </summary>
-    public string Id { get; }
+    public string? Id { get; }
 
     /// <summary>
     /// Gets the routing value used for this document.
     /// </summary>
-    public string Routing { get; }
+    public string? Routing { get; }
 
     /// <summary>
     /// Gets additional metadata associated with this hit.

--- a/src/Foundatio.Repositories/Models/IPatchOperation.cs
+++ b/src/Foundatio.Repositories/Models/IPatchOperation.cs
@@ -169,7 +169,7 @@ public class ScriptPatch : IPatchOperation
     /// <summary>
     /// Gets or sets the parameters to pass to the script.
     /// </summary>
-    public Dictionary<string, object> Params { get; set; }
+    public Dictionary<string, object>? Params { get; set; }
 }
 
 /// <summary>
@@ -178,7 +178,7 @@ public class ScriptPatch : IPatchOperation
 public static class ActionPatchExtensions
 {
     /// <inheritdoc cref="IRepository{T}.PatchAsync(Id, IPatchOperation, ICommandOptions)"/>
-    public static Task<bool> PatchAsync<T>(this IRepository<T> repository, Id id, ActionPatch<T> operation, ICommandOptions options = null) where T : class, IIdentity, new()
+    public static Task<bool> PatchAsync<T>(this IRepository<T> repository, Id id, ActionPatch<T> operation, ICommandOptions? options = null) where T : class, IIdentity, new()
     {
         return repository.PatchAsync(id, operation, options);
     }

--- a/src/Foundatio.Repositories/Models/LazyDocument.cs
+++ b/src/Foundatio.Repositories/Models/LazyDocument.cs
@@ -17,14 +17,14 @@ public interface ILazyDocument
     /// </summary>
     /// <typeparam name="T">The type to deserialize to.</typeparam>
     /// <returns>The deserialized document, or <c>null</c> if the document data is empty.</returns>
-    T As<T>() where T : class;
+    T? As<T>() where T : class;
 
     /// <summary>
     /// Deserializes the document to the specified type.
     /// </summary>
     /// <param name="objectType">The type to deserialize to.</param>
     /// <returns>The deserialized document, or <c>null</c> if the document data is empty.</returns>
-    object As(Type objectType);
+    object? As(Type objectType);
 }
 
 /// <summary>
@@ -49,7 +49,7 @@ public class LazyDocument : ILazyDocument
     }
 
     /// <inheritdoc/>
-    public T As<T>() where T : class
+    public T? As<T>() where T : class
     {
         if (_data == null || _data.Length == 0)
             return default;
@@ -58,7 +58,7 @@ public class LazyDocument : ILazyDocument
     }
 
     /// <inheritdoc/>
-    public object As(Type objectType)
+    public object? As(Type objectType)
     {
         if (_data == null || _data.Length == 0)
             return null;

--- a/src/Foundatio.Repositories/Models/LazyDocument.cs
+++ b/src/Foundatio.Repositories/Models/LazyDocument.cs
@@ -17,14 +17,14 @@ public interface ILazyDocument
     /// </summary>
     /// <typeparam name="T">The type to deserialize to.</typeparam>
     /// <returns>The deserialized document, or <c>null</c> if the document data is empty.</returns>
-    T As<T>() where T : class;
+    T? As<T>() where T : class;
 
     /// <summary>
     /// Deserializes the document to the specified type.
     /// </summary>
     /// <param name="objectType">The type to deserialize to.</param>
     /// <returns>The deserialized document, or <c>null</c> if the document data is empty.</returns>
-    object As(Type objectType);
+    object? As(Type objectType);
 }
 
 /// <summary>
@@ -40,14 +40,14 @@ public class LazyDocument : ILazyDocument
     /// </summary>
     /// <param name="data">The raw document data.</param>
     /// <param name="serializer">The serializer to use for deserialization. Defaults to JSON.</param>
-    public LazyDocument(byte[] data, ITextSerializer serializer = null)
+    public LazyDocument(byte[] data, ITextSerializer? serializer = null)
     {
         _data = data;
         _serializer = serializer ?? new JsonNetSerializer();
     }
 
     /// <inheritdoc/>
-    public T As<T>() where T : class
+    public T? As<T>() where T : class
     {
         if (_data == null || _data.Length == 0)
             return default;
@@ -56,7 +56,7 @@ public class LazyDocument : ILazyDocument
     }
 
     /// <inheritdoc/>
-    public object As(Type objectType)
+    public object? As(Type objectType)
     {
         if (_data == null || _data.Length == 0)
             return null;

--- a/src/Foundatio.Repositories/Options/AsyncQueryOptions.cs
+++ b/src/Foundatio.Repositories/Options/AsyncQueryOptions.cs
@@ -89,9 +89,9 @@ namespace Foundatio.Repositories.Options
             return options.SafeHasOption(AsyncQueryOptionsExtensions.AsyncQueryIdKey);
         }
 
-        public static string GetAsyncQueryId(this ICommandOptions options)
+        public static string? GetAsyncQueryId(this ICommandOptions options)
         {
-            return options.SafeGetOption<string>(AsyncQueryOptionsExtensions.AsyncQueryIdKey, null);
+            return options.SafeGetOption<string?>(AsyncQueryOptionsExtensions.AsyncQueryIdKey, null);
         }
 
         public static bool ShouldAutoDeleteAsyncQuery(this ICommandOptions options)

--- a/src/Foundatio.Repositories/Options/CacheOptions.cs
+++ b/src/Foundatio.Repositories/Options/CacheOptions.cs
@@ -102,14 +102,14 @@ namespace Foundatio.Repositories.Options
             return options.SafeHasOption(SetCacheOptionsExtensions.CacheKeyKey) || options.SafeHasOption(SetCacheOptionsExtensions.DefaultCacheKeyKey);
         }
 
-        public static string GetCacheKey(this ICommandOptions options, string defaultCacheKey = null)
+        public static string? GetCacheKey(this ICommandOptions options, string? defaultCacheKey = null)
         {
-            return options.SafeGetOption<string>(SetCacheOptionsExtensions.CacheKeyKey, defaultCacheKey ?? options.GetDefaultCacheKey());
+            return options.SafeGetOption<string>(SetCacheOptionsExtensions.CacheKeyKey, defaultCacheKey ?? options.GetDefaultCacheKey()!);
         }
 
-        public static string GetDefaultCacheKey(this ICommandOptions options)
+        public static string? GetDefaultCacheKey(this ICommandOptions options)
         {
-            return options.SafeGetOption<string>(SetCacheOptionsExtensions.DefaultCacheKeyKey, null);
+            return options.SafeGetOption<string?>(SetCacheOptionsExtensions.DefaultCacheKeyKey, null);
         }
 
         private static TimeSpan DefaultCacheExpiration { get; set; } = TimeSpan.FromSeconds(60 * 5);

--- a/src/Foundatio.Repositories/Options/CommandOptionsDescriptor.cs
+++ b/src/Foundatio.Repositories/Options/CommandOptionsDescriptor.cs
@@ -2,7 +2,7 @@
 
 public static class CommandOptionsDescriptorExtensions
 {
-    public static ICommandOptions<T> Configure<T>(this CommandOptionsDescriptor<T> configure) where T : class
+    public static ICommandOptions<T> Configure<T>(this CommandOptionsDescriptor<T>? configure) where T : class
     {
         ICommandOptions<T> o = new CommandOptions<T>();
         if (configure != null)
@@ -11,7 +11,7 @@ public static class CommandOptionsDescriptorExtensions
         return o;
     }
 
-    public static ICommandOptions Configure(this CommandOptionsDescriptor configure)
+    public static ICommandOptions Configure(this CommandOptionsDescriptor? configure)
     {
         ICommandOptions o = new CommandOptions();
         if (configure != null)

--- a/src/Foundatio.Repositories/Options/IOptions.cs
+++ b/src/Foundatio.Repositories/Options/IOptions.cs
@@ -16,7 +16,7 @@ public interface IOptionsDictionary : IEnumerable<KeyValuePair<string, object>>
     void Set(string name, object value);
     bool Contains(string name);
     bool Remove(string name);
-    T Get<T>(string name, T defaultValue = default);
+    T Get<T>(string name, T defaultValue = default!);
 }
 
 public class OptionsDictionary : IOptionsDictionary
@@ -44,11 +44,17 @@ public class OptionsDictionary : IOptionsDictionary
             return defaultValue;
 
         object data = _options[name];
-        if (!(data is T))
+        if (data is null)
+            return defaultValue;
+
+        if (data is not T)
         {
             try
             {
-                return TypeHelper.ToType<T>(data);
+                if (TypeHelper.ToType<T>(data) is T converted)
+                    return converted;
+
+                return defaultValue;
             }
             catch
             {
@@ -86,7 +92,7 @@ public static class OptionsExtensions
         return options;
     }
 
-    public static T SafeGetOption<T>(this IOptions options, string name, T defaultValue = default)
+    public static T SafeGetOption<T>(this IOptions? options, string name, T defaultValue = default!)
     {
         if (options == null)
             return defaultValue;
@@ -94,7 +100,7 @@ public static class OptionsExtensions
         return options.Values.Get(name, defaultValue);
     }
 
-    public static bool SafeHasOption(this IOptions options, string name)
+    public static bool SafeHasOption(this IOptions? options, string name)
     {
         if (options == null)
             return false;
@@ -102,7 +108,7 @@ public static class OptionsExtensions
         return options.Values.Contains(name);
     }
 
-    public static ICollection<T> SafeGetCollection<T>(this IOptions options, string name)
+    public static ICollection<T> SafeGetCollection<T>(this IOptions? options, string name)
     {
         if (options == null)
             return new List<T>();

--- a/src/Foundatio.Repositories/Options/UpdatedIdsCallbackOptions.cs
+++ b/src/Foundatio.Repositories/Options/UpdatedIdsCallbackOptions.cs
@@ -19,9 +19,9 @@ namespace Foundatio.Repositories.Options
 {
     public static class ReadUpdatedIdsCallbackOptionsExtensions
     {
-        public static Action<IEnumerable<string>> GetUpdatedIdsCallback(this ICommandOptions options)
+        public static Action<IEnumerable<string>>? GetUpdatedIdsCallback(this ICommandOptions options)
         {
-            return options.SafeGetOption<Action<IEnumerable<string>>>(UpdatedIdsCallbackOptionsExtensions.UpdatedIdsCallbackKey, null);
+            return options.SafeGetOption<Action<IEnumerable<string>>?>(UpdatedIdsCallbackOptionsExtensions.UpdatedIdsCallbackKey, null);
         }
     }
 }

--- a/src/Foundatio.Repositories/Serialization/AggregationsNewtonsoftJsonConverter.cs
+++ b/src/Foundatio.Repositories/Serialization/AggregationsNewtonsoftJsonConverter.cs
@@ -13,13 +13,13 @@ public class AggregationsNewtonsoftJsonConverter : JsonConverter
         return typeof(IAggregate).IsAssignableFrom(objectType);
     }
 
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
         var item = JObject.Load(reader);
         var typeToken = item.SelectToken("Data.@type") ?? item.SelectToken("data.@type");
-        string type = typeToken?.Value<string>();
+        string? type = typeToken?.Value<string>();
 
-        IAggregate value = type switch
+        IAggregate? value = type switch
         {
             "bucket" => new BucketAggregate(),
             "exstats" => new ExtendedStatsAggregate(),
@@ -57,7 +57,7 @@ public class AggregationsNewtonsoftJsonConverter : JsonConverter
 
     public override bool CanWrite => false;
 
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
         throw new NotSupportedException();
     }

--- a/src/Foundatio.Repositories/Serialization/AggregationsSystemTextJsonConverter.cs
+++ b/src/Foundatio.Repositories/Serialization/AggregationsSystemTextJsonConverter.cs
@@ -15,9 +15,9 @@ public class AggregationsSystemTextJsonConverter : System.Text.Json.Serializatio
     public override IAggregate Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var element = JsonElement.ParseValue(ref reader);
-        string typeToken = GetTokenType(element);
+        string? typeToken = GetTokenType(element);
 
-        IAggregate value = typeToken switch
+        IAggregate? value = typeToken switch
         {
             "bucket" => element.Deserialize<BucketAggregate>(options),
             "exstats" => element.Deserialize<ExtendedStatsAggregate>(options),
@@ -31,7 +31,13 @@ public class AggregationsSystemTextJsonConverter : System.Text.Json.Serializatio
             _ => null
         };
 
-        return value ?? element.Deserialize<ValueAggregate>(options);
+        if (value is null)
+            value = element.Deserialize<ValueAggregate>(options);
+
+        if (value is null)
+            throw new JsonException("Failed to deserialize aggregate.");
+
+        return value;
     }
 
     public override void Write(Utf8JsonWriter writer, IAggregate value, JsonSerializerOptions options)
@@ -44,8 +50,8 @@ public class AggregationsSystemTextJsonConverter : System.Text.Json.Serializatio
         if (element.Deserialize<PercentilesAggregate>(options) is not { } agg)
             return new PercentilesAggregate();
 
-        if (agg.Items is null && GetProperty(element, "Items") is { } itemsElement)
-            agg.Items = itemsElement.Deserialize<IReadOnlyList<PercentileItem>>(options);
+        if (agg.Items is not { Count: > 0 } && GetProperty(element, "Items") is { } itemsElement)
+            agg.Items = itemsElement.Deserialize<IReadOnlyList<PercentileItem>>(options) ?? [];
 
         return agg;
     }
@@ -75,7 +81,7 @@ public class AggregationsSystemTextJsonConverter : System.Text.Json.Serializatio
         return null;
     }
 
-    private static string GetTokenType(JsonElement element)
+    private static string? GetTokenType(JsonElement element)
     {
         var dataPropertyElement = GetProperty(element, "Data");
         if (dataPropertyElement != null && dataPropertyElement.Value.TryGetProperty("@type", out var typeElement))

--- a/src/Foundatio.Repositories/Serialization/BucketsNewtonsoftJsonConverter.cs
+++ b/src/Foundatio.Repositories/Serialization/BucketsNewtonsoftJsonConverter.cs
@@ -15,16 +15,16 @@ public class BucketsNewtonsoftJsonConverter : JsonConverter
         return typeof(IBucket).IsAssignableFrom(objectType);
     }
 
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
         var item = JObject.Load(reader);
         var typeToken = item.SelectToken("Data.@type") ?? item.SelectToken("data.@type");
 
-        IBucket value = null;
+        IBucket? value = null;
         if (typeToken != null)
         {
-            string type = typeToken.Value<string>();
-            IReadOnlyDictionary<string, IAggregate> aggregations = null;
+            string? type = typeToken.Value<string>();
+            IReadOnlyDictionary<string, IAggregate>? aggregations = null;
             var aggregationsToken = item.SelectToken("Aggregations") ?? item.SelectToken("aggregations");
             aggregations = aggregationsToken?.ToObject<IReadOnlyDictionary<string, IAggregate>>();
 
@@ -34,6 +34,9 @@ public class BucketsNewtonsoftJsonConverter : JsonConverter
                     var timeZoneToken = item.SelectToken("Data.@timezone") ?? item.SelectToken("data.@timezone");
                     var kind = timeZoneToken != null ? DateTimeKind.Unspecified : DateTimeKind.Utc;
                     var key = item.SelectToken("Key") ?? item.SelectToken("key");
+                    if (key is null)
+                        break;
+
                     var date = new DateTime(_epochTicks + ((long)key * TimeSpan.TicksPerMillisecond), kind);
 
                     value = new DateHistogramBucket(date, aggregations);
@@ -66,7 +69,7 @@ public class BucketsNewtonsoftJsonConverter : JsonConverter
 
     public override bool CanWrite => false;
 
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
         throw new NotSupportedException();
     }

--- a/src/Foundatio.Repositories/Serialization/BucketsSystemTextJsonConverter.cs
+++ b/src/Foundatio.Repositories/Serialization/BucketsSystemTextJsonConverter.cs
@@ -15,21 +15,21 @@ public class BucketsSystemTextJsonConverter : System.Text.Json.Serialization.Jso
 
     public override IBucket Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        IBucket value = null;
+        IBucket? value = null;
 
         var element = JsonElement.ParseValue(ref reader);
-        string typeToken = GetDataToken(element, "@type");
-        if (typeToken != null)
+        string? typeToken = GetDataToken(element, "@type");
+        if (typeToken is not null)
         {
             switch (typeToken)
             {
                 case "datehistogram":
                     // First deserialize as KeyedBucket<double> to get all properties
-                    var tempBucket = element.Deserialize<KeyedBucket<double>>(options);
+                    var tempBucket = element.Deserialize<KeyedBucket<double>>(options) ?? throw new JsonException("Failed to deserialize date histogram bucket.");
 
                     // Calculate date from Key (epoch milliseconds)
-                    string timeZoneToken = GetDataToken(element, "@timezone");
-                    var kind = timeZoneToken != null ? DateTimeKind.Unspecified : DateTimeKind.Utc;
+                    string? timeZoneToken = GetDataToken(element, "@timezone");
+                    var kind = timeZoneToken is not null ? DateTimeKind.Unspecified : DateTimeKind.Utc;
                     long keyAsLong = (long)tempBucket.Key;
                     var date = new DateTime(_epochTicks + (keyAsLong * TimeSpan.TicksPerMillisecond), kind);
 
@@ -64,6 +64,9 @@ public class BucketsSystemTextJsonConverter : System.Text.Json.Serialization.Jso
         if (value is null)
             value = element.Deserialize<KeyedBucket<object>>(options);
 
+        if (value is null)
+            throw new JsonException("Failed to deserialize bucket.");
+
         return value;
     }
 
@@ -83,10 +86,10 @@ public class BucketsSystemTextJsonConverter : System.Text.Json.Serialization.Jso
         return null;
     }
 
-    private string GetDataToken(JsonElement element, string key)
+    private string? GetDataToken(JsonElement element, string key)
     {
         var dataPropertyElement = GetProperty(element, "Data");
-        if (dataPropertyElement != null && dataPropertyElement.Value.TryGetProperty(key, out var typeElement))
+        if (dataPropertyElement is not null && dataPropertyElement.Value.TryGetProperty(key, out var typeElement))
             return typeElement.ToString();
 
         return null;

--- a/src/Foundatio.Repositories/Serialization/InferredTypesConverterFactory.cs
+++ b/src/Foundatio.Repositories/Serialization/InferredTypesConverterFactory.cs
@@ -16,26 +16,30 @@ public class InferredTypesConverterFactory : JsonConverterFactory
     public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
     {
         var converterType = typeof(InferredTypesConverter<>).MakeGenericType(typeToConvert);
-        return (JsonConverter)Activator.CreateInstance(converterType);
+        var converter = Activator.CreateInstance(converterType) as JsonConverter;
+        if (converter is null)
+            throw new InvalidOperationException($"Failed to create converter for type {typeToConvert}");
+
+        return converter;
     }
 
     private class InferredTypesConverter<T> : JsonConverter<T>
     {
         public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            object result = reader.TokenType switch
+            object? result = reader.TokenType switch
             {
                 JsonTokenType.Number when reader.TryGetInt64(out long l) => l,
                 JsonTokenType.Number => reader.GetDouble(),
                 JsonTokenType.String when reader.TryGetDateTime(out DateTime datetime) => datetime,
-                JsonTokenType.String => reader.GetString()!,
+                JsonTokenType.String => reader.GetString(),
                 JsonTokenType.True => true,
                 JsonTokenType.False => false,
-                JsonTokenType.Null => null!,
+                JsonTokenType.Null => null,
                 _ => JsonDocument.ParseValue(ref reader).RootElement.Clone()
             };
 
-            if (result == null)
+            if (result is null)
                 return default!;
 
             if (result is T typedResult)

--- a/src/Foundatio.Repositories/Serialization/ObjectToInferredTypesConverter.cs
+++ b/src/Foundatio.Repositories/Serialization/ObjectToInferredTypesConverter.cs
@@ -29,7 +29,7 @@ namespace Foundatio.Repositories.Serialization;
 /// <seealso href="https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/converters-how-to#deserialize-inferred-types-to-object-properties"/>
 public sealed class ObjectToInferredTypesConverter : JsonConverter<object>
 {
-    public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         return reader.TokenType switch
         {
@@ -99,7 +99,7 @@ public sealed class ObjectToInferredTypesConverter : JsonConverter<object>
                 return dt;
         }
 
-        return reader.GetString();
+        return reader.GetString()!;
     }
 
     private Dictionary<string, object> ReadObject(ref Utf8JsonReader reader, JsonSerializerOptions options)
@@ -119,7 +119,7 @@ public sealed class ObjectToInferredTypesConverter : JsonConverter<object>
             if (!reader.Read())
                 continue;
 
-            dictionary[propertyName] = ReadValue(ref reader, options);
+            dictionary[propertyName] = ReadValue(ref reader, options)!;
         }
 
         return dictionary;
@@ -134,13 +134,13 @@ public sealed class ObjectToInferredTypesConverter : JsonConverter<object>
             if (reader.TokenType == JsonTokenType.EndArray)
                 return list;
 
-            list.Add(ReadValue(ref reader, options));
+            list.Add(ReadValue(ref reader, options)!);
         }
 
         return list;
     }
 
-    private object ReadValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    private object? ReadValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
     {
         return reader.TokenType switch
         {

--- a/src/Foundatio.Repositories/Utility/AggregationsNewtonsoftJsonConverter.cs
+++ b/src/Foundatio.Repositories/Utility/AggregationsNewtonsoftJsonConverter.cs
@@ -13,13 +13,13 @@ public class AggregationsNewtonsoftJsonConverter : JsonConverter
         return typeof(IAggregate).IsAssignableFrom(objectType);
     }
 
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
         var item = JObject.Load(reader);
         var typeToken = item.SelectToken("Data.@type") ?? item.SelectToken("data.@type");
-        string type = typeToken?.Value<string>();
+        string? type = typeToken?.Value<string>();
 
-        IAggregate value = type switch
+        IAggregate? value = type switch
         {
             "bucket" => new BucketAggregate(),
             "exstats" => new ExtendedStatsAggregate(),
@@ -57,7 +57,7 @@ public class AggregationsNewtonsoftJsonConverter : JsonConverter
 
     public override bool CanWrite => false;
 
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
         throw new NotImplementedException();
     }

--- a/src/Foundatio.Repositories/Utility/AggregationsSystemTextJsonConverter.cs
+++ b/src/Foundatio.Repositories/Utility/AggregationsSystemTextJsonConverter.cs
@@ -15,9 +15,9 @@ public class AggregationsSystemTextJsonConverter : System.Text.Json.Serializatio
     public override IAggregate Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var element = JsonElement.ParseValue(ref reader);
-        string typeToken = GetTokenType(element);
+        string? typeToken = GetTokenType(element);
 
-        IAggregate value = typeToken switch
+        IAggregate? value = typeToken switch
         {
             "bucket" => element.Deserialize<BucketAggregate>(options),
             "exstats" => element.Deserialize<ExtendedStatsAggregate>(options),
@@ -31,7 +31,13 @@ public class AggregationsSystemTextJsonConverter : System.Text.Json.Serializatio
             _ => null
         };
 
-        return value ?? element.Deserialize<ValueAggregate>(options);
+        if (value is null)
+            value = element.Deserialize<ValueAggregate>(options);
+
+        if (value is null)
+            throw new JsonException("Failed to deserialize aggregate.");
+
+        return value;
     }
 
     public override void Write(Utf8JsonWriter writer, IAggregate value, JsonSerializerOptions options)
@@ -49,8 +55,8 @@ public class AggregationsSystemTextJsonConverter : System.Text.Json.Serializatio
         if (element.Deserialize<PercentilesAggregate>(options) is not { } agg)
             return new PercentilesAggregate();
 
-        if (agg.Items is null && GetProperty(element, "Items") is { } itemsElement)
-            agg.Items = itemsElement.Deserialize<IReadOnlyList<PercentileItem>>(options);
+        if (agg.Items is not { Count: > 0 } && GetProperty(element, "Items") is { } itemsElement)
+            agg.Items = itemsElement.Deserialize<IReadOnlyList<PercentileItem>>(options) ?? [];
 
         return agg;
     }
@@ -80,7 +86,7 @@ public class AggregationsSystemTextJsonConverter : System.Text.Json.Serializatio
         return null;
     }
 
-    private static string GetTokenType(JsonElement element)
+    private static string? GetTokenType(JsonElement element)
     {
         var dataPropertyElement = GetProperty(element, "Data");
 

--- a/src/Foundatio.Repositories/Utility/BucketsNewtonsoftJsonConverter.cs
+++ b/src/Foundatio.Repositories/Utility/BucketsNewtonsoftJsonConverter.cs
@@ -15,16 +15,16 @@ public class BucketsNewtonsoftJsonConverter : JsonConverter
         return typeof(IBucket).IsAssignableFrom(objectType);
     }
 
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
         var item = JObject.Load(reader);
         var typeToken = item.SelectToken("Data.@type") ?? item.SelectToken("data.@type");
 
-        IBucket value = null;
+        IBucket? value = null;
         if (typeToken != null)
         {
-            string type = typeToken.Value<string>();
-            IReadOnlyDictionary<string, IAggregate> aggregations = null;
+            string? type = typeToken.Value<string>();
+            IReadOnlyDictionary<string, IAggregate>? aggregations = null;
             var aggregationsToken = item.SelectToken("Aggregations") ?? item.SelectToken("aggregations");
             aggregations = aggregationsToken?.ToObject<IReadOnlyDictionary<string, IAggregate>>();
 
@@ -34,6 +34,9 @@ public class BucketsNewtonsoftJsonConverter : JsonConverter
                     var timeZoneToken = item.SelectToken("Data.@timezone") ?? item.SelectToken("data.@timezone");
                     var kind = timeZoneToken != null ? DateTimeKind.Unspecified : DateTimeKind.Utc;
                     var key = item.SelectToken("Key") ?? item.SelectToken("key");
+                    if (key is null)
+                        break;
+
                     var date = new DateTime(_epochTicks + ((long)key * TimeSpan.TicksPerMillisecond), kind);
 
                     value = new DateHistogramBucket(date, aggregations);
@@ -63,7 +66,7 @@ public class BucketsNewtonsoftJsonConverter : JsonConverter
 
     public override bool CanWrite => false;
 
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
         throw new NotImplementedException();
     }

--- a/src/Foundatio.Repositories/Utility/BucketsSystemTextJsonConverter.cs
+++ b/src/Foundatio.Repositories/Utility/BucketsSystemTextJsonConverter.cs
@@ -15,21 +15,21 @@ public class BucketsSystemTextJsonConverter : System.Text.Json.Serialization.Jso
 
     public override IBucket Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        IBucket value = null;
+        IBucket? value = null;
 
         var element = JsonElement.ParseValue(ref reader);
-        string typeToken = GetDataToken(element, "@type");
-        if (typeToken != null)
+        string? typeToken = GetDataToken(element, "@type");
+        if (typeToken is not null)
         {
             switch (typeToken)
             {
                 case "datehistogram":
                     // First deserialize as KeyedBucket<double> to get all properties
-                    var tempBucket = element.Deserialize<KeyedBucket<double>>(options);
+                    var tempBucket = element.Deserialize<KeyedBucket<double>>(options) ?? throw new JsonException("Failed to deserialize date histogram bucket.");
 
                     // Calculate date from Key (epoch milliseconds)
-                    string timeZoneToken = GetDataToken(element, "@timezone");
-                    var kind = timeZoneToken != null ? DateTimeKind.Unspecified : DateTimeKind.Utc;
+                    string? timeZoneToken = GetDataToken(element, "@timezone");
+                    var kind = timeZoneToken is not null ? DateTimeKind.Unspecified : DateTimeKind.Utc;
                     long keyAsLong = (long)tempBucket.Key;
                     var date = new DateTime(_epochTicks + (keyAsLong * TimeSpan.TicksPerMillisecond), kind);
 
@@ -61,6 +61,9 @@ public class BucketsSystemTextJsonConverter : System.Text.Json.Serialization.Jso
         if (value is null)
             value = element.Deserialize<KeyedBucket<object>>(options);
 
+        if (value is null)
+            throw new JsonException("Failed to deserialize bucket.");
+
         return value;
     }
 
@@ -74,16 +77,16 @@ public class BucketsSystemTextJsonConverter : System.Text.Json.Serialization.Jso
         if (element.TryGetProperty(propertyName, out var dataElement))
             return dataElement;
 
-        if (element.TryGetProperty(propertyName.ToLower(), out dataElement))
+        if (element.TryGetProperty(propertyName.ToLowerInvariant(), out dataElement))
             return dataElement;
 
         return null;
     }
 
-    private string GetDataToken(JsonElement element, string key)
+    private string? GetDataToken(JsonElement element, string key)
     {
         var dataPropertyElement = GetProperty(element, "Data");
-        if (dataPropertyElement != null && dataPropertyElement.Value.TryGetProperty(key, out var typeElement))
+        if (dataPropertyElement is not null && dataPropertyElement.Value.TryGetProperty(key, out var typeElement))
             return typeElement.ToString();
 
         return null;

--- a/src/Foundatio.Repositories/Utility/ObjectId.cs
+++ b/src/Foundatio.Repositories/Utility/ObjectId.cs
@@ -186,7 +186,7 @@ public struct ObjectId : IComparable<ObjectId>, IEquatable<ObjectId>, IConvertib
     {
         if (s != null && s.Length == 24)
         {
-            if (Utils.TryParseHexString(s, out byte[] bytes))
+            if (Utils.TryParseHexString(s, out byte[]? bytes) && bytes is not null)
             {
                 objectId = new ObjectId(bytes);
                 return true;
@@ -266,7 +266,7 @@ public struct ObjectId : IComparable<ObjectId>, IEquatable<ObjectId>, IConvertib
         return _timestamp == rhs._timestamp && _machine == rhs._machine && _pid == rhs._pid && _increment == rhs._increment;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (obj is ObjectId id)
         {
@@ -319,67 +319,67 @@ public struct ObjectId : IComparable<ObjectId>, IEquatable<ObjectId>, IConvertib
         return TypeCode.Object;
     }
 
-    bool IConvertible.ToBoolean(IFormatProvider provider)
+    bool IConvertible.ToBoolean(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    byte IConvertible.ToByte(IFormatProvider provider)
+    byte IConvertible.ToByte(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    char IConvertible.ToChar(IFormatProvider provider)
+    char IConvertible.ToChar(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    DateTime IConvertible.ToDateTime(IFormatProvider provider)
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    decimal IConvertible.ToDecimal(IFormatProvider provider)
+    decimal IConvertible.ToDecimal(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    double IConvertible.ToDouble(IFormatProvider provider)
+    double IConvertible.ToDouble(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    short IConvertible.ToInt16(IFormatProvider provider)
+    short IConvertible.ToInt16(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    int IConvertible.ToInt32(IFormatProvider provider)
+    int IConvertible.ToInt32(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    long IConvertible.ToInt64(IFormatProvider provider)
+    long IConvertible.ToInt64(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    sbyte IConvertible.ToSByte(IFormatProvider provider)
+    sbyte IConvertible.ToSByte(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    float IConvertible.ToSingle(IFormatProvider provider)
+    float IConvertible.ToSingle(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    string IConvertible.ToString(IFormatProvider provider)
+    string IConvertible.ToString(IFormatProvider? provider)
     {
         return ToString();
     }
 
-    object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider)
     {
         switch (Type.GetTypeCode(conversionType))
         {
@@ -396,17 +396,17 @@ public struct ObjectId : IComparable<ObjectId>, IEquatable<ObjectId>, IConvertib
         throw new InvalidCastException();
     }
 
-    ushort IConvertible.ToUInt16(IFormatProvider provider)
+    ushort IConvertible.ToUInt16(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    uint IConvertible.ToUInt32(IFormatProvider provider)
+    uint IConvertible.ToUInt32(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
 
-    ulong IConvertible.ToUInt64(IFormatProvider provider)
+    ulong IConvertible.ToUInt64(IFormatProvider? provider)
     {
         throw new InvalidCastException();
     }
@@ -473,7 +473,7 @@ public struct ObjectId : IComparable<ObjectId>, IEquatable<ObjectId>, IConvertib
             }
         }
 
-        public static bool TryParseHexString(string s, out byte[] bytes)
+        public static bool TryParseHexString(string s, out byte[]? bytes)
         {
             try
             {

--- a/src/Foundatio.Repositories/Utility/ObjectToInferredTypesConverter.cs
+++ b/src/Foundatio.Repositories/Utility/ObjectToInferredTypesConverter.cs
@@ -11,26 +11,30 @@ public class ObjectToInferredTypesConverter : JsonConverterFactory
     public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
     {
         var converterType = typeof(ObjectToInferredTypesConverterInner<>).MakeGenericType(typeToConvert);
-        return (JsonConverter)Activator.CreateInstance(converterType);
+        var converter = Activator.CreateInstance(converterType) as JsonConverter;
+        if (converter is null)
+            throw new InvalidOperationException($"Failed to create converter for type {typeToConvert}");
+
+        return converter;
     }
 
     private class ObjectToInferredTypesConverterInner<T> : JsonConverter<T>
     {
         public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            object result = reader.TokenType switch
+            object? result = reader.TokenType switch
             {
                 JsonTokenType.Number when reader.TryGetInt64(out long l) => l,
                 JsonTokenType.Number => reader.GetDouble(),
                 JsonTokenType.String when reader.TryGetDateTime(out DateTime datetime) => datetime,
-                JsonTokenType.String => reader.GetString()!,
+                JsonTokenType.String => reader.GetString(),
                 JsonTokenType.True => true,
                 JsonTokenType.False => false,
-                JsonTokenType.Null => null!,
+                JsonTokenType.Null => null,
                 _ => JsonDocument.ParseValue(ref reader).RootElement.Clone()
             };
 
-            if (result == null)
+            if (result is null)
                 return default!;
 
             if (result is T typedResult)

--- a/src/Foundatio.Repositories/Utility/TypeHelper.cs
+++ b/src/Foundatio.Repositories/Utility/TypeHelper.cs
@@ -12,6 +12,7 @@ public static class TypeHelper
         if (value is null)
             return default;
 
+        Type underlyingType = Nullable.GetUnderlyingType(targetType) ?? targetType;
         TypeConverter converter = TypeDescriptor.GetConverter(targetType);
         Type valueType = value.GetType();
 
@@ -42,6 +43,9 @@ public static class TypeHelper
             if (convertedValue is T typedValue)
                 return typedValue;
 
+            if (convertedValue is not null && underlyingType != targetType)
+                return (T)convertedValue;
+
             return default;
         }
 
@@ -50,11 +54,8 @@ public static class TypeHelper
 
         try
         {
-            object? convertedValue = Convert.ChangeType(value, targetType);
-            if (convertedValue is T typedConvertedValue)
-                return typedConvertedValue;
-
-            return default;
+            object convertedValue = Convert.ChangeType(value, underlyingType);
+            return (T)convertedValue;
         }
         catch (Exception e)
         {

--- a/src/Foundatio.Repositories/Utility/TypeHelper.cs
+++ b/src/Foundatio.Repositories/Utility/TypeHelper.cs
@@ -6,20 +6,11 @@ namespace Foundatio.Repositories.Utility;
 
 public static class TypeHelper
 {
-    public static T ToType<T>(object value)
+    public static T? ToType<T>(object? value)
     {
         Type targetType = typeof(T);
-        if (value == null)
-        {
-            try
-            {
-                return (T)Convert.ChangeType(value, targetType);
-            }
-            catch
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-        }
+        if (value is null)
+            return default;
 
         TypeConverter converter = TypeDescriptor.GetConverter(targetType);
         Type valueType = value.GetType();
@@ -30,10 +21,11 @@ public static class TypeHelper
         TypeInfo targetTypeInfo = targetType.GetTypeInfo();
         if (targetTypeInfo.IsEnum && (value is string || valueType.GetTypeInfo().IsEnum))
         {
+            string? valueString = value.ToString();
             // attempt to match enum by name.
-            if (TryEnumIsDefined<T>(targetType, value.ToString()))
+            if (valueString is not null && TryEnumIsDefined<T>(targetType, valueString))
             {
-                object parsedValue = Enum.Parse(targetType, value.ToString(), false);
+                object parsedValue = Enum.Parse(targetType, valueString, false);
                 return (T)parsedValue;
             }
 
@@ -46,16 +38,23 @@ public static class TypeHelper
 
         if (converter.CanConvertFrom(valueType))
         {
-            object convertedValue = converter.ConvertFrom(value);
-            return (T)convertedValue;
+            object? convertedValue = converter.ConvertFrom(value);
+            if (convertedValue is T typedValue)
+                return typedValue;
+
+            return default;
         }
 
-        if (!(value is IConvertible))
+        if (value is not IConvertible)
             throw new ArgumentException($"An incompatible value specified.  Target Type: {targetType.FullName} Value Type: {value.GetType().FullName}", nameof(value));
+
         try
         {
-            object convertedValue = Convert.ChangeType(value, targetType);
-            return (T)convertedValue;
+            object? convertedValue = Convert.ChangeType(value, targetType);
+            if (convertedValue is T typedConvertedValue)
+                return typedConvertedValue;
+
+            return default;
         }
         catch (Exception e)
         {

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.45" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -7,12 +7,12 @@
     <NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" PrivateAssets="All" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.13" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/AggregationQueryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/AggregationQueryTests.cs
@@ -38,20 +38,47 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression(aggregations));
         Assert.Equal(10, result.Total);
         Assert.Equal(7, result.Aggregations.Count);
-        Assert.Equal(19, result.Aggregations.Min("min_age").Value);
-        Assert.Equal(60, result.Aggregations.Max("max_age").Value);
-        Assert.Equal(34.7, result.Aggregations.Average("avg_age").Value);
-        Assert.Equal(347, result.Aggregations.Sum("sum_age").Value);
+        var minAge = result.Aggregations.Min("min_age");
+        Assert.NotNull(minAge);
+        Assert.Equal(19, minAge.Value);
+        var maxAge = result.Aggregations.Max("max_age");
+        Assert.NotNull(maxAge);
+        Assert.Equal(60, maxAge.Value);
+        var avgAge = result.Aggregations.Average("avg_age");
+        Assert.NotNull(avgAge);
+        Assert.Equal(34.7, avgAge.Value);
+        var sumAge = result.Aggregations.Sum("sum_age");
+        Assert.NotNull(sumAge);
+        Assert.Equal(347, sumAge.Value);
         var percentiles = result.Aggregations.Percentiles("percentiles_age");
-        Assert.Equal(DateTime.UtcNow.Date.SubtractYears(10), result.Aggregations.Min<DateTime>("min_createdUtc").Value);
-        Assert.Equal(DateTime.UtcNow.Date.SubtractYears(1), result.Aggregations.Max<DateTime>("max_createdUtc").Value);
-        Assert.Equal(19.27, percentiles.GetPercentile(1).Value);
-        Assert.Equal(20.35, percentiles.GetPercentile(5).Value);
-        Assert.Equal(26d, percentiles.GetPercentile(25).Value);
-        Assert.Equal(30.5, percentiles.GetPercentile(50).Value);
-        Assert.Equal(42.5, percentiles.GetPercentile(75).Value);
-        Assert.Equal(55.95d, Math.Round((double)percentiles.GetPercentile(95).Value, 2));
-        Assert.Equal(59.19, percentiles.GetPercentile(99).Value);
+        Assert.NotNull(percentiles);
+        var minCreatedUtc = result.Aggregations.Min<DateTime>("min_createdUtc");
+        Assert.NotNull(minCreatedUtc);
+        Assert.Equal(DateTime.UtcNow.Date.SubtractYears(10), minCreatedUtc.Value);
+        var maxCreatedUtc = result.Aggregations.Max<DateTime>("max_createdUtc");
+        Assert.NotNull(maxCreatedUtc);
+        Assert.Equal(DateTime.UtcNow.Date.SubtractYears(1), maxCreatedUtc.Value);
+        var p1 = percentiles.GetPercentile(1);
+        Assert.NotNull(p1);
+        Assert.Equal(19.27, p1.Value);
+        var p5 = percentiles.GetPercentile(5);
+        Assert.NotNull(p5);
+        Assert.Equal(20.35, p5.Value);
+        var p25 = percentiles.GetPercentile(25);
+        Assert.NotNull(p25);
+        Assert.Equal(26d, p25.Value);
+        var p50 = percentiles.GetPercentile(50);
+        Assert.NotNull(p50);
+        Assert.Equal(30.5, p50.Value);
+        var p75 = percentiles.GetPercentile(75);
+        Assert.NotNull(p75);
+        Assert.Equal(42.5, p75.Value);
+        var p95 = percentiles.GetPercentile(95);
+        Assert.NotNull(p95);
+        Assert.Equal(55.95d, Math.Round((double)p95.Value!, 2));
+        var p99 = percentiles.GetPercentile(99);
+        Assert.NotNull(p99);
+        Assert.Equal(59.19, p99.Value);
     }
 
     [Fact]
@@ -63,10 +90,18 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.FilterExpression("age: <40").AggregationsExpression(aggregations));
         Assert.Equal(7, result.Total);
         Assert.Equal(4, result.Aggregations.Count);
-        Assert.Equal(19, result.Aggregations.Min("min_age").Value);
-        Assert.Equal(35, result.Aggregations.Min("max_age").Value);
-        Assert.Equal(Math.Round(27.2857142857143, 5), Math.Round(result.Aggregations.Average("avg_age").Value.GetValueOrDefault(), 5));
-        Assert.Equal(191, result.Aggregations.Sum("sum_age").Value);
+        var minAge = result.Aggregations.Min("min_age");
+        Assert.NotNull(minAge);
+        Assert.Equal(19, minAge.Value);
+        var maxAge = result.Aggregations.Min("max_age");
+        Assert.NotNull(maxAge);
+        Assert.Equal(35, maxAge.Value);
+        var avgAge = result.Aggregations.Average("avg_age");
+        Assert.NotNull(avgAge);
+        Assert.Equal(Math.Round(27.2857142857143, 5), Math.Round(avgAge.Value.GetValueOrDefault(), 5));
+        var sumAge = result.Aggregations.Sum("sum_age");
+        Assert.NotNull(sumAge);
+        Assert.Equal(191, sumAge.Value);
     }
 
     [Fact]
@@ -78,10 +113,18 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.FilterExpression("aliasedage: <40").AggregationsExpression(aggregations));
         Assert.Equal(7, result.Total);
         Assert.Equal(4, result.Aggregations.Count);
-        Assert.Equal(19, result.Aggregations.Min("min_aliasedage").Value);
-        Assert.Equal(35, result.Aggregations.Min("max_aliasedage").Value);
-        Assert.Equal(Math.Round(27.2857142857143, 5), Math.Round(result.Aggregations.Average("avg_aliasedage").Value.GetValueOrDefault(), 5));
-        Assert.Equal(191, result.Aggregations.Sum("sum_aliasedage").Value);
+        var minAliasedAge = result.Aggregations.Min("min_aliasedage");
+        Assert.NotNull(minAliasedAge);
+        Assert.Equal(19, minAliasedAge.Value);
+        var maxAliasedAge = result.Aggregations.Min("max_aliasedage");
+        Assert.NotNull(maxAliasedAge);
+        Assert.Equal(35, maxAliasedAge.Value);
+        var avgAliasedAge = result.Aggregations.Average("avg_aliasedage");
+        Assert.NotNull(avgAliasedAge);
+        Assert.Equal(Math.Round(27.2857142857143, 5), Math.Round(avgAliasedAge.Value.GetValueOrDefault(), 5));
+        var sumAliasedAge = result.Aggregations.Sum("sum_aliasedage");
+        Assert.NotNull(sumAliasedAge);
+        Assert.Equal(191, sumAliasedAge.Value);
     }
 
     [Fact]
@@ -98,11 +141,21 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression(aggregations));
         Assert.Equal(1, result.Total);
         Assert.Equal(5, result.Aggregations.Count);
-        Assert.Equal(1000, result.Aggregations.Min("min_followers").Value);
-        Assert.Equal(1000, result.Aggregations.Min("max_followers").Value);
-        Assert.Equal(1000, result.Aggregations.Average("avg_followers").Value.GetValueOrDefault());
-        Assert.Equal(1000, result.Aggregations.Sum("sum_followers").Value);
-        Assert.Equal(1, result.Aggregations.Cardinality("cardinality_twitter").Value);
+        var minFollowers = result.Aggregations.Min("min_followers");
+        Assert.NotNull(minFollowers);
+        Assert.Equal(1000, minFollowers.Value);
+        var maxFollowers = result.Aggregations.Min("max_followers");
+        Assert.NotNull(maxFollowers);
+        Assert.Equal(1000, maxFollowers.Value);
+        var avgFollowers = result.Aggregations.Average("avg_followers");
+        Assert.NotNull(avgFollowers);
+        Assert.Equal(1000, avgFollowers.Value.GetValueOrDefault());
+        var sumFollowers = result.Aggregations.Sum("sum_followers");
+        Assert.NotNull(sumFollowers);
+        Assert.Equal(1000, sumFollowers.Value);
+        var cardinalityTwitter = result.Aggregations.Cardinality("cardinality_twitter");
+        Assert.NotNull(cardinalityTwitter);
+        Assert.Equal(1, cardinalityTwitter.Value);
     }
 
     [Fact]
@@ -129,7 +182,7 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
             ), cancellationToken: TestCancellationToken);
 
         // Assert
-        var result = nestedAggQuery.Aggregations.ToAggregations(_serializer);
+        var result = nestedAggQuery.Aggregations!.ToAggregations(_serializer)!;
         Assert.Single(result);
         Assert.Equal(2, ((Foundatio.Repositories.Models.BucketAggregate)((Foundatio.Repositories.Models.SingleBucketAggregate)result["nested_reviewRating"]).Aggregations["terms_rating"]).Items.Count);
 
@@ -144,15 +197,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
             ))), cancellationToken: TestCancellationToken);
 
         // Assert (with filter)
-        result = nestedAggQueryWithFilter.Aggregations.ToAggregations(_serializer);
+        result = nestedAggQueryWithFilter.Aggregations!.ToAggregations(_serializer)!;
         Assert.Single(result);
 
         var nestedAgg = (Foundatio.Repositories.Models.SingleBucketAggregate)result["nested_reviewRating"];
         var filteredAgg = (Foundatio.Repositories.Models.SingleBucketAggregate)nestedAgg.Aggregations[$"user_{employees[0].Id}"];
         Assert.NotNull(filteredAgg);
-        Assert.Single(filteredAgg.Aggregations.Terms("terms_rating").Buckets);
-        Assert.Equal("5", filteredAgg.Aggregations.Terms("terms_rating").Buckets.First().Key);
-        Assert.Equal(1, filteredAgg.Aggregations.Terms("terms_rating").Buckets.First().Total);
+        Assert.Single(filteredAgg.Aggregations.Terms("terms_rating")!.Buckets);
+        Assert.Equal("5", filteredAgg.Aggregations.Terms("terms_rating")!.Buckets.First().Key);
+        Assert.Equal(1, filteredAgg.Aggregations.Terms("terms_rating")!.Buckets.First().Total);
     }
 
     [Fact]
@@ -172,7 +225,9 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression("cardinality:twitter"));
         Assert.Equal(1, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Equal(1, result.Aggregations.Cardinality("cardinality_twitter").Value);
+        var cardinalityTwitter = result.Aggregations.Cardinality("cardinality_twitter");
+        Assert.NotNull(cardinalityTwitter);
+        Assert.Equal(1, cardinalityTwitter.Value);
     }
 
     [Fact]
@@ -184,7 +239,9 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression(aggregations));
         Assert.Equal(10, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Equal(2, result.Aggregations.Cardinality("cardinality_location").Value);
+        var cardinalityLocation = result.Aggregations.Cardinality("cardinality_location");
+        Assert.NotNull(cardinalityLocation);
+        Assert.Equal(2, cardinalityLocation.Value);
     }
 
     [Fact]
@@ -196,7 +253,9 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression(aggregations));
         Assert.Equal(10, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Equal(10, result.Aggregations.Missing("missing_companyName").Total);
+        var missingCompanyName = result.Aggregations.Missing("missing_companyName");
+        Assert.NotNull(missingCompanyName);
+        Assert.Equal(10, missingCompanyName.Total);
     }
 
     [Fact]
@@ -214,10 +273,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(3, result.Total);
         Assert.Equal(3, result.Aggregations.Count);
 
-        AssertEqual(utcToday.SubtractDays(2), result.Aggregations.Min<DateTime>("min_nextReview")?.Value);
-        AssertEqual(utcToday, result.Aggregations.Max<DateTime>("max_nextReview")?.Value);
+        var minNextReview = result.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(minNextReview);
+        AssertEqual(utcToday.SubtractDays(2), minNextReview.Value);
+        var maxNextReview = result.Aggregations.Max<DateTime>("max_nextReview");
+        Assert.NotNull(maxNextReview);
+        AssertEqual(utcToday, maxNextReview.Value);
 
         var dateHistogramAgg = result.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         var oldestDate = utcToday.Date.SubtractDays(2);
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -243,10 +307,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(3, result.Total);
         Assert.Equal(3, result.Aggregations.Count);
 
-        AssertEqual(DateTime.SpecifyKind(utcToday.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified), result.Aggregations.Min<DateTime>("min_nextReview")?.Value);
-        AssertEqual(DateTime.SpecifyKind(utcToday.SubtractHours(1), DateTimeKind.Unspecified), result.Aggregations.Max<DateTime>("max_nextReview")?.Value);
+        var minNextReview = result.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(minNextReview);
+        AssertEqual(DateTime.SpecifyKind(utcToday.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified), minNextReview.Value);
+        var maxNextReview = result.Aggregations.Max<DateTime>("max_nextReview");
+        Assert.NotNull(maxNextReview);
+        AssertEqual(DateTime.SpecifyKind(utcToday.SubtractHours(1), DateTimeKind.Unspecified), maxNextReview.Value);
 
         var dateHistogramAgg = result.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         var oldestDate = DateTime.SpecifyKind(utcToday.Date.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified);
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -273,10 +342,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(3, result.Total);
         Assert.Equal(3, result.Aggregations.Count);
 
-        AssertEqual(DateTime.SpecifyKind(utcToday.SubtractDays(2).AddMinutes(offsetInMinutes), DateTimeKind.Unspecified), result.Aggregations.Min<DateTime>("min_nextReview")?.Value);
-        AssertEqual(DateTime.SpecifyKind(utcToday.AddMinutes(offsetInMinutes), DateTimeKind.Unspecified), result.Aggregations.Max<DateTime>("max_nextReview")?.Value);
+        var minNextReview = result.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(minNextReview);
+        AssertEqual(DateTime.SpecifyKind(utcToday.SubtractDays(2).AddMinutes(offsetInMinutes), DateTimeKind.Unspecified), minNextReview.Value);
+        var maxNextReview = result.Aggregations.Max<DateTime>("max_nextReview");
+        Assert.NotNull(maxNextReview);
+        AssertEqual(DateTime.SpecifyKind(utcToday.AddMinutes(offsetInMinutes), DateTimeKind.Unspecified), maxNextReview.Value);
 
         var dateHistogramAgg = result.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         var oldestDate = DateTime.SpecifyKind(utcToday.SubtractDays(3).AddMinutes(offsetInMinutes), DateTimeKind.Unspecified); // it's minus 3 days because the offset puts it a day back.
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -317,11 +391,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(3, result.Total);
         Assert.Equal(3, result.Aggregations.Count);
 
-        // Dates are always returned in utc.
-        Assert.Equal(DateTime.SpecifyKind(today.SubtractDays(2), DateTimeKind.Utc), result.Aggregations.Min<DateTime>("min_nextReview")?.Value);
-        Assert.Equal(DateTime.SpecifyKind(today, DateTimeKind.Utc), result.Aggregations.Max<DateTime>("max_nextReview")?.Value);
+        var minNextReview = result.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(minNextReview);
+        Assert.Equal(DateTime.SpecifyKind(today.SubtractDays(2), DateTimeKind.Utc), minNextReview.Value);
+        var maxNextReview = result.Aggregations.Max<DateTime>("max_nextReview");
+        Assert.NotNull(maxNextReview);
+        Assert.Equal(DateTime.SpecifyKind(today, DateTimeKind.Utc), maxNextReview.Value);
 
         var dateHistogramAgg = result.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         var oldestDate = DateTime.SpecifyKind(today.Date.SubtractDays(2), DateTimeKind.Utc);
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -347,11 +425,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(3, result.Total);
         Assert.Equal(3, result.Aggregations.Count);
 
-        // Dates are always returned in utc.
-        AssertEqual(DateTime.SpecifyKind(today.UtcDateTime.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified), result.Aggregations.Min<DateTime>("min_nextReview")?.Value);
-        AssertEqual(DateTime.SpecifyKind(today.UtcDateTime.SubtractHours(1), DateTimeKind.Unspecified), result.Aggregations.Max<DateTime>("max_nextReview")?.Value);
+        var minNextReview = result.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(minNextReview);
+        AssertEqual(DateTime.SpecifyKind(today.UtcDateTime.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified), minNextReview.Value);
+        var maxNextReview = result.Aggregations.Max<DateTime>("max_nextReview");
+        Assert.NotNull(maxNextReview);
+        AssertEqual(DateTime.SpecifyKind(today.UtcDateTime.SubtractHours(1), DateTimeKind.Unspecified), maxNextReview.Value);
 
         var dateHistogramAgg = result.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         var oldestDate = DateTime.SpecifyKind(today.UtcDateTime.SubtractDays(2).AddHours(1).Date.SubtractHours(1), DateTimeKind.Unspecified);
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -379,11 +461,17 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(10, result.Total);
         Assert.Single(result.Aggregations);
 
-        var bucket = result.Aggregations.GeoHash("geogrid_location").Buckets.Single();
+        var geoHashAgg = result.Aggregations.GeoHash("geogrid_location");
+        Assert.NotNull(geoHashAgg);
+        var bucket = geoHashAgg.Buckets.Single();
         Assert.Equal("s", bucket.Key);
         Assert.Equal(10, bucket.Total);
-        Assert.Equal(Math.Round(14.9999999860302, 5), Math.Round(bucket.Aggregations.Average("avg_lat").Value.GetValueOrDefault(), 5));
-        Assert.Equal(Math.Round(14.9999999860302, 5), Math.Round(bucket.Aggregations.Average("avg_lon").Value.GetValueOrDefault(), 5));
+        var avgLat = bucket.Aggregations.Average("avg_lat");
+        Assert.NotNull(avgLat);
+        Assert.Equal(Math.Round(14.9999999860302, 5), Math.Round(avgLat.Value.GetValueOrDefault(), 5));
+        var avgLon = bucket.Aggregations.Average("avg_lon");
+        Assert.NotNull(avgLon);
+        Assert.Equal(Math.Round(14.9999999860302, 5), Math.Round(avgLon.Value.GetValueOrDefault(), 5));
     }
 
     [Fact]
@@ -394,36 +482,46 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression("terms:age"));
         Assert.Equal(10, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Equal(10, result.Aggregations.Terms<int>("terms_age").Buckets.Count);
-        Assert.Equal(1, result.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19).Total);
+        var termsAge = result.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(termsAge);
+        Assert.Equal(10, termsAge.Buckets.Count);
+        Assert.Equal(1, termsAge.Buckets.First(f => f.Key == 19).Total);
 
         string json = JsonConvert.SerializeObject(result);
         var roundTripped = JsonConvert.DeserializeObject<CountResult>(json);
+        Assert.NotNull(roundTripped);
         Assert.Equal(10, roundTripped.Total);
         Assert.Single(roundTripped.Aggregations);
-        Assert.Equal(10, roundTripped.Aggregations.Terms<int>("terms_age").Buckets.Count);
-        Assert.Equal(1, roundTripped.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19).Total);
+        var roundTrippedTermsAge = roundTripped.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(roundTrippedTermsAge);
+        Assert.Equal(10, roundTrippedTermsAge.Buckets.Count);
+        Assert.Equal(1, roundTrippedTermsAge.Buckets.First(f => f.Key == 19).Total);
 
         result = await _employeeRepository.CountAsync(q => q.AggregationsExpression("terms:(age~2 @missing:0 terms:(years~2 @missing:0))"));
         Assert.Equal(10, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Equal(2, result.Aggregations.Terms<int>("terms_age").Buckets.Count);
-        var bucket = result.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19);
+        termsAge = result.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(termsAge);
+        Assert.Equal(2, termsAge.Buckets.Count);
+        var bucket = termsAge.Buckets.First(f => f.Key == 19);
         Assert.Equal(1, bucket.Total);
         Assert.Single(bucket.Aggregations);
-        Assert.Single(bucket.Aggregations.Terms<int>("terms_years").Buckets);
+        var termsYears = bucket.Aggregations.Terms<int>("terms_years");
+        Assert.NotNull(termsYears);
+        Assert.Single(termsYears.Buckets);
 
         json = JsonConvert.SerializeObject(result, Formatting.Indented);
         roundTripped = JsonConvert.DeserializeObject<CountResult>(json);
+        Assert.NotNull(roundTripped);
         string roundTrippedJson = JsonConvert.SerializeObject(roundTripped, Formatting.Indented);
         Assert.Equal(json, roundTrippedJson);
         Assert.Equal(10, roundTripped.Total);
         Assert.Single(roundTripped.Aggregations);
-        Assert.Equal(2, roundTripped.Aggregations.Terms<int>("terms_age").Buckets.Count);
-        bucket = roundTripped.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19);
+        Assert.Equal(2, roundTripped.Aggregations.Terms<int>("terms_age")!.Buckets.Count);
+        bucket = roundTripped.Aggregations.Terms<int>("terms_age")!.Buckets.First(f => f.Key == 19);
         Assert.Equal(1, bucket.Total);
         Assert.Single(bucket.Aggregations);
-        Assert.Single(bucket.Aggregations.Terms<int>("terms_years").Buckets);
+        Assert.Single(bucket.Aggregations.Terms<int>("terms_years")!.Buckets);
     }
 
     [Fact]
@@ -442,6 +540,7 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Single(result.Aggregations);
 
         var dateHistogramAgg = result.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         var oldestDate = DateTime.SpecifyKind(utcToday.UtcDateTime.Date.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified);
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -453,8 +552,10 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
 
         string json = JsonConvert.SerializeObject(result);
         var roundTripped = JsonConvert.DeserializeObject<CountResult>(json);
+        Assert.NotNull(roundTripped);
 
         dateHistogramAgg = roundTripped.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         oldestDate = DateTime.SpecifyKind(utcToday.UtcDateTime.Date.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified);
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -481,12 +582,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Single(result.Aggregations);
 
         var dateTermsAgg = result.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(dateTermsAgg);
         Assert.Equal(utcToday.SubtractDays(2), dateTermsAgg.Value);
 
         string json = JsonConvert.SerializeObject(result);
         var roundTripped = JsonConvert.DeserializeObject<CountResult>(json);
+        Assert.NotNull(roundTripped);
 
         dateTermsAgg = roundTripped.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(dateTermsAgg);
         Assert.Equal(utcToday.SubtractDays(2), dateTermsAgg.Value);
     }
 
@@ -499,8 +603,10 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression(aggregations));
         Assert.Equal(10, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Equal(10, result.Aggregations.Terms<int>("terms_age").Buckets.Count);
-        var bucket = result.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19);
+        var termsAge = result.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(termsAge);
+        Assert.Equal(10, termsAge.Buckets.Count);
+        var bucket = termsAge.Buckets.First(f => f.Key == 19);
         Assert.Equal(1, bucket.Total);
 
         var tophits = bucket.Aggregations.TopHits();
@@ -512,10 +618,13 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
 
         string json = JsonConvert.SerializeObject(result);
         var roundTripped = JsonConvert.DeserializeObject<CountResult>(json);
+        Assert.NotNull(roundTripped);
         Assert.Equal(10, roundTripped.Total);
         Assert.Single(roundTripped.Aggregations);
-        Assert.Equal(10, roundTripped.Aggregations.Terms<int>("terms_age").Buckets.Count);
-        bucket = roundTripped.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19);
+        var roundTrippedTermsAge = roundTripped.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(roundTrippedTermsAge);
+        Assert.Equal(10, roundTrippedTermsAge.Buckets.Count);
+        bucket = roundTrippedTermsAge.Buckets.First(f => f.Key == 19);
         Assert.Equal(1, bucket.Total);
 
         string systemTextJson = System.Text.Json.JsonSerializer.Serialize(result);
@@ -524,10 +633,11 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
             System.Text.Json.Nodes.JsonNode.Parse(systemTextJson)),
             "Newtonsoft and System.Text.Json serialization should produce semantically equivalent JSON");
         roundTripped = System.Text.Json.JsonSerializer.Deserialize<CountResult>(systemTextJson);
+        Assert.NotNull(roundTripped);
         Assert.Equal(10, roundTripped.Total);
         Assert.Single(roundTripped.Aggregations);
-        Assert.Equal(10, roundTripped.Aggregations.Terms<int>("terms_age").Buckets.Count);
-        bucket = roundTripped.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19);
+        Assert.Equal(10, roundTripped.Aggregations.Terms<int>("terms_age")!.Buckets.Count);
+        bucket = roundTripped.Aggregations.Terms<int>("terms_age")!.Buckets.First(f => f.Key == 19);
         Assert.Equal(1, bucket.Total);
 
         tophits = bucket.Aggregations.TopHits();
@@ -574,7 +684,7 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         using var hitStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
         var employeeHit = _configuration.Client.ElasticsearchClientSettings.RequestResponseSerializer.Deserialize<Hit<Employee>>(hitStream);
         Assert.Equal("employees", employeeHit.Index);
-        Assert.Equal("62d982efd3e0d1fed81452f3", employeeHit.Source.CompanyId);
+        Assert.Equal("62d982efd3e0d1fed81452f3", employeeHit.Source!.CompanyId);
     }
 
     [Fact]
@@ -587,8 +697,10 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression(aggregations));
         Assert.Equal(11, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Single(result.Aggregations.Terms<int>("terms_age").Buckets);
-        var bucket = result.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 45);
+        var termsAge = result.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(termsAge);
+        Assert.Single(termsAge.Buckets);
+        var bucket = termsAge.Buckets.First(f => f.Key == 45);
         Assert.Equal(2, bucket.Total);
 
         var tophits = bucket.Aggregations.TopHits();

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/AggregationQueryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/AggregationQueryTests.cs
@@ -391,6 +391,7 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(3, result.Total);
         Assert.Equal(3, result.Aggregations.Count);
 
+        // Dates are always returned in utc.
         var minNextReview = result.Aggregations.Min<DateTime>("min_nextReview");
         Assert.NotNull(minNextReview);
         Assert.Equal(DateTime.SpecifyKind(today.SubtractDays(2), DateTimeKind.Utc), minNextReview.Value);
@@ -425,6 +426,7 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(3, result.Total);
         Assert.Equal(3, result.Aggregations.Count);
 
+        // Dates are always returned in utc.
         var minNextReview = result.Aggregations.Min<DateTime>("min_nextReview");
         Assert.NotNull(minNextReview);
         AssertEqual(DateTime.SpecifyKind(today.UtcDateTime.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified), minNextReview.Value);

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/AggregationQueryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/AggregationQueryTests.cs
@@ -75,7 +75,8 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(42.5, p75.Value);
         var p95 = percentiles.GetPercentile(95);
         Assert.NotNull(p95);
-        Assert.Equal(55.95d, Math.Round((double)p95.Value!, 2));
+        Assert.NotNull(p95.Value);
+        Assert.Equal(55.95d, Math.Round((double)p95.Value, 2));
         var p99 = percentiles.GetPercentile(99);
         Assert.NotNull(p99);
         Assert.Equal(59.19, p99.Value);
@@ -182,7 +183,10 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
             ), cancellationToken: TestCancellationToken);
 
         // Assert
-        var result = nestedAggQuery.Aggregations!.ToAggregations(_serializer)!;
+        var aggs = nestedAggQuery.Aggregations;
+        Assert.NotNull(aggs);
+        var result = aggs.ToAggregations(_serializer);
+        Assert.NotNull(result);
         Assert.Single(result);
         Assert.Equal(2, ((Foundatio.Repositories.Models.BucketAggregate)((Foundatio.Repositories.Models.SingleBucketAggregate)result["nested_reviewRating"]).Aggregations["terms_rating"]).Items.Count);
 
@@ -197,15 +201,20 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
             ))), cancellationToken: TestCancellationToken);
 
         // Assert (with filter)
-        result = nestedAggQueryWithFilter.Aggregations!.ToAggregations(_serializer)!;
+        var aggsWithFilter = nestedAggQueryWithFilter.Aggregations;
+        Assert.NotNull(aggsWithFilter);
+        result = aggsWithFilter.ToAggregations(_serializer);
+        Assert.NotNull(result);
         Assert.Single(result);
 
         var nestedAgg = (Foundatio.Repositories.Models.SingleBucketAggregate)result["nested_reviewRating"];
         var filteredAgg = (Foundatio.Repositories.Models.SingleBucketAggregate)nestedAgg.Aggregations[$"user_{employees[0].Id}"];
         Assert.NotNull(filteredAgg);
-        Assert.Single(filteredAgg.Aggregations.Terms("terms_rating")!.Buckets);
-        Assert.Equal("5", filteredAgg.Aggregations.Terms("terms_rating")!.Buckets.First().Key);
-        Assert.Equal(1, filteredAgg.Aggregations.Terms("terms_rating")!.Buckets.First().Total);
+        var termsRating = filteredAgg.Aggregations.Terms("terms_rating");
+        Assert.NotNull(termsRating);
+        Assert.Single(termsRating.Buckets);
+        Assert.Equal("5", termsRating.Buckets.First().Key);
+        Assert.Equal(1, termsRating.Buckets.First().Total);
     }
 
     [Fact]
@@ -519,11 +528,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(json, roundTrippedJson);
         Assert.Equal(10, roundTripped.Total);
         Assert.Single(roundTripped.Aggregations);
-        Assert.Equal(2, roundTripped.Aggregations.Terms<int>("terms_age")!.Buckets.Count);
-        bucket = roundTripped.Aggregations.Terms<int>("terms_age")!.Buckets.First(f => f.Key == 19);
+        var roundTrippedTermsAge2 = roundTripped.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(roundTrippedTermsAge2);
+        Assert.Equal(2, roundTrippedTermsAge2.Buckets.Count);
+        bucket = roundTrippedTermsAge2.Buckets.First(f => f.Key == 19);
         Assert.Equal(1, bucket.Total);
         Assert.Single(bucket.Aggregations);
-        Assert.Single(bucket.Aggregations.Terms<int>("terms_years")!.Buckets);
+        var roundTrippedTermsYears = bucket.Aggregations.Terms<int>("terms_years");
+        Assert.NotNull(roundTrippedTermsYears);
+        Assert.Single(roundTrippedTermsYears.Buckets);
     }
 
     [Fact]
@@ -638,8 +651,10 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.NotNull(roundTripped);
         Assert.Equal(10, roundTripped.Total);
         Assert.Single(roundTripped.Aggregations);
-        Assert.Equal(10, roundTripped.Aggregations.Terms<int>("terms_age")!.Buckets.Count);
-        bucket = roundTripped.Aggregations.Terms<int>("terms_age")!.Buckets.First(f => f.Key == 19);
+        var sysTermsAge = roundTripped.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(sysTermsAge);
+        Assert.Equal(10, sysTermsAge.Buckets.Count);
+        bucket = sysTermsAge.Buckets.First(f => f.Key == 19);
         Assert.Equal(1, bucket.Total);
 
         tophits = bucket.Aggregations.TopHits();
@@ -686,7 +701,8 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         using var hitStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
         var employeeHit = _configuration.Client.ElasticsearchClientSettings.RequestResponseSerializer.Deserialize<Hit<Employee>>(hitStream);
         Assert.Equal("employees", employeeHit.Index);
-        Assert.Equal("62d982efd3e0d1fed81452f3", employeeHit.Source!.CompanyId);
+        Assert.NotNull(employeeHit.Source);
+        Assert.Equal("62d982efd3e0d1fed81452f3", employeeHit.Source.CompanyId);
     }
 
     [Fact]

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/AggregationQueryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/AggregationQueryTests.cs
@@ -39,20 +39,47 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression(aggregations));
         Assert.Equal(10, result.Total);
         Assert.Equal(7, result.Aggregations.Count);
-        Assert.Equal(19, result.Aggregations.Min("min_age").Value);
-        Assert.Equal(60, result.Aggregations.Max("max_age").Value);
-        Assert.Equal(34.7, result.Aggregations.Average("avg_age").Value);
-        Assert.Equal(347, result.Aggregations.Sum("sum_age").Value);
+        var minAge = result.Aggregations.Min("min_age");
+        Assert.NotNull(minAge);
+        Assert.Equal(19, minAge.Value);
+        var maxAge = result.Aggregations.Max("max_age");
+        Assert.NotNull(maxAge);
+        Assert.Equal(60, maxAge.Value);
+        var avgAge = result.Aggregations.Average("avg_age");
+        Assert.NotNull(avgAge);
+        Assert.Equal(34.7, avgAge.Value);
+        var sumAge = result.Aggregations.Sum("sum_age");
+        Assert.NotNull(sumAge);
+        Assert.Equal(347, sumAge.Value);
         var percentiles = result.Aggregations.Percentiles("percentiles_age");
-        Assert.Equal(DateTime.UtcNow.Date.SubtractYears(10), result.Aggregations.Min<DateTime>("min_createdUtc").Value);
-        Assert.Equal(DateTime.UtcNow.Date.SubtractYears(1), result.Aggregations.Max<DateTime>("max_createdUtc").Value);
-        Assert.Equal(19.27, percentiles.GetPercentile(1).Value);
-        Assert.Equal(20.35, percentiles.GetPercentile(5).Value);
-        Assert.Equal(26d, percentiles.GetPercentile(25).Value);
-        Assert.Equal(30.5, percentiles.GetPercentile(50).Value);
-        Assert.Equal(42.5, percentiles.GetPercentile(75).Value);
-        Assert.Equal(55.95d, Math.Round((double)percentiles.GetPercentile(95).Value, 2));
-        Assert.Equal(59.19, percentiles.GetPercentile(99).Value);
+        Assert.NotNull(percentiles);
+        var minCreatedUtc = result.Aggregations.Min<DateTime>("min_createdUtc");
+        Assert.NotNull(minCreatedUtc);
+        Assert.Equal(DateTime.UtcNow.Date.SubtractYears(10), minCreatedUtc.Value);
+        var maxCreatedUtc = result.Aggregations.Max<DateTime>("max_createdUtc");
+        Assert.NotNull(maxCreatedUtc);
+        Assert.Equal(DateTime.UtcNow.Date.SubtractYears(1), maxCreatedUtc.Value);
+        var p1 = percentiles.GetPercentile(1);
+        Assert.NotNull(p1);
+        Assert.Equal(19.27, p1.Value);
+        var p5 = percentiles.GetPercentile(5);
+        Assert.NotNull(p5);
+        Assert.Equal(20.35, p5.Value);
+        var p25 = percentiles.GetPercentile(25);
+        Assert.NotNull(p25);
+        Assert.Equal(26d, p25.Value);
+        var p50 = percentiles.GetPercentile(50);
+        Assert.NotNull(p50);
+        Assert.Equal(30.5, p50.Value);
+        var p75 = percentiles.GetPercentile(75);
+        Assert.NotNull(p75);
+        Assert.Equal(42.5, p75.Value);
+        var p95 = percentiles.GetPercentile(95);
+        Assert.NotNull(p95);
+        Assert.Equal(55.95d, Math.Round((double)p95.Value!, 2));
+        var p99 = percentiles.GetPercentile(99);
+        Assert.NotNull(p99);
+        Assert.Equal(59.19, p99.Value);
     }
 
     [Fact]
@@ -64,10 +91,18 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.FilterExpression("age: <40").AggregationsExpression(aggregations));
         Assert.Equal(7, result.Total);
         Assert.Equal(4, result.Aggregations.Count);
-        Assert.Equal(19, result.Aggregations.Min("min_age").Value);
-        Assert.Equal(35, result.Aggregations.Min("max_age").Value);
-        Assert.Equal(Math.Round(27.2857142857143, 5), Math.Round(result.Aggregations.Average("avg_age").Value.GetValueOrDefault(), 5));
-        Assert.Equal(191, result.Aggregations.Sum("sum_age").Value);
+        var minAge = result.Aggregations.Min("min_age");
+        Assert.NotNull(minAge);
+        Assert.Equal(19, minAge.Value);
+        var maxAge = result.Aggregations.Min("max_age");
+        Assert.NotNull(maxAge);
+        Assert.Equal(35, maxAge.Value);
+        var avgAge = result.Aggregations.Average("avg_age");
+        Assert.NotNull(avgAge);
+        Assert.Equal(Math.Round(27.2857142857143, 5), Math.Round(avgAge.Value.GetValueOrDefault(), 5));
+        var sumAge = result.Aggregations.Sum("sum_age");
+        Assert.NotNull(sumAge);
+        Assert.Equal(191, sumAge.Value);
     }
 
     [Fact]
@@ -79,10 +114,18 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.FilterExpression("aliasedage: <40").AggregationsExpression(aggregations));
         Assert.Equal(7, result.Total);
         Assert.Equal(4, result.Aggregations.Count);
-        Assert.Equal(19, result.Aggregations.Min("min_aliasedage").Value);
-        Assert.Equal(35, result.Aggregations.Min("max_aliasedage").Value);
-        Assert.Equal(Math.Round(27.2857142857143, 5), Math.Round(result.Aggregations.Average("avg_aliasedage").Value.GetValueOrDefault(), 5));
-        Assert.Equal(191, result.Aggregations.Sum("sum_aliasedage").Value);
+        var minAliasedAge = result.Aggregations.Min("min_aliasedage");
+        Assert.NotNull(minAliasedAge);
+        Assert.Equal(19, minAliasedAge.Value);
+        var maxAliasedAge = result.Aggregations.Min("max_aliasedage");
+        Assert.NotNull(maxAliasedAge);
+        Assert.Equal(35, maxAliasedAge.Value);
+        var avgAliasedAge = result.Aggregations.Average("avg_aliasedage");
+        Assert.NotNull(avgAliasedAge);
+        Assert.Equal(Math.Round(27.2857142857143, 5), Math.Round(avgAliasedAge.Value.GetValueOrDefault(), 5));
+        var sumAliasedAge = result.Aggregations.Sum("sum_aliasedage");
+        Assert.NotNull(sumAliasedAge);
+        Assert.Equal(191, sumAliasedAge.Value);
     }
 
     [Fact]
@@ -99,11 +142,21 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression(aggregations));
         Assert.Equal(1, result.Total);
         Assert.Equal(5, result.Aggregations.Count);
-        Assert.Equal(1000, result.Aggregations.Min("min_followers").Value);
-        Assert.Equal(1000, result.Aggregations.Min("max_followers").Value);
-        Assert.Equal(1000, result.Aggregations.Average("avg_followers").Value.GetValueOrDefault());
-        Assert.Equal(1000, result.Aggregations.Sum("sum_followers").Value);
-        Assert.Equal(1, result.Aggregations.Cardinality("cardinality_twitter").Value);
+        var minFollowers = result.Aggregations.Min("min_followers");
+        Assert.NotNull(minFollowers);
+        Assert.Equal(1000, minFollowers.Value);
+        var maxFollowers = result.Aggregations.Min("max_followers");
+        Assert.NotNull(maxFollowers);
+        Assert.Equal(1000, maxFollowers.Value);
+        var avgFollowers = result.Aggregations.Average("avg_followers");
+        Assert.NotNull(avgFollowers);
+        Assert.Equal(1000, avgFollowers.Value.GetValueOrDefault());
+        var sumFollowers = result.Aggregations.Sum("sum_followers");
+        Assert.NotNull(sumFollowers);
+        Assert.Equal(1000, sumFollowers.Value);
+        var cardinalityTwitter = result.Aggregations.Cardinality("cardinality_twitter");
+        Assert.NotNull(cardinalityTwitter);
+        Assert.Equal(1, cardinalityTwitter.Value);
     }
 
     [Fact]
@@ -123,7 +176,9 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression("cardinality:twitter"));
         Assert.Equal(1, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Equal(1, result.Aggregations.Cardinality("cardinality_twitter").Value);
+        var cardinalityTwitter = result.Aggregations.Cardinality("cardinality_twitter");
+        Assert.NotNull(cardinalityTwitter);
+        Assert.Equal(1, cardinalityTwitter.Value);
     }
 
     [Fact]
@@ -135,7 +190,9 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression(aggregations));
         Assert.Equal(10, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Equal(2, result.Aggregations.Cardinality("cardinality_location").Value);
+        var cardinalityLocation = result.Aggregations.Cardinality("cardinality_location");
+        Assert.NotNull(cardinalityLocation);
+        Assert.Equal(2, cardinalityLocation.Value);
     }
 
     [Fact]
@@ -147,7 +204,9 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression(aggregations));
         Assert.Equal(10, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Equal(10, result.Aggregations.Missing("missing_companyName").Total);
+        var missingCompanyName = result.Aggregations.Missing("missing_companyName");
+        Assert.NotNull(missingCompanyName);
+        Assert.Equal(10, missingCompanyName.Total);
     }
 
     [Fact]
@@ -165,10 +224,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(3, result.Total);
         Assert.Equal(3, result.Aggregations.Count);
 
-        AssertEqual(utcToday.SubtractDays(2), result.Aggregations.Min<DateTime>("min_nextReview")?.Value);
-        AssertEqual(utcToday, result.Aggregations.Max<DateTime>("max_nextReview")?.Value);
+        var minNextReview = result.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(minNextReview);
+        AssertEqual(utcToday.SubtractDays(2), minNextReview.Value);
+        var maxNextReview = result.Aggregations.Max<DateTime>("max_nextReview");
+        Assert.NotNull(maxNextReview);
+        AssertEqual(utcToday, maxNextReview.Value);
 
         var dateHistogramAgg = result.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         var oldestDate = utcToday.Date.SubtractDays(2);
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -194,10 +258,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(3, result.Total);
         Assert.Equal(3, result.Aggregations.Count);
 
-        AssertEqual(DateTime.SpecifyKind(utcToday.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified), result.Aggregations.Min<DateTime>("min_nextReview")?.Value);
-        AssertEqual(DateTime.SpecifyKind(utcToday.SubtractHours(1), DateTimeKind.Unspecified), result.Aggregations.Max<DateTime>("max_nextReview")?.Value);
+        var minNextReview = result.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(minNextReview);
+        AssertEqual(DateTime.SpecifyKind(utcToday.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified), minNextReview.Value);
+        var maxNextReview = result.Aggregations.Max<DateTime>("max_nextReview");
+        Assert.NotNull(maxNextReview);
+        AssertEqual(DateTime.SpecifyKind(utcToday.SubtractHours(1), DateTimeKind.Unspecified), maxNextReview.Value);
 
         var dateHistogramAgg = result.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         var oldestDate = DateTime.SpecifyKind(utcToday.Date.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified);
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -224,10 +293,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(3, result.Total);
         Assert.Equal(3, result.Aggregations.Count);
 
-        AssertEqual(DateTime.SpecifyKind(utcToday.SubtractDays(2).AddMinutes(offsetInMinutes), DateTimeKind.Unspecified), result.Aggregations.Min<DateTime>("min_nextReview")?.Value);
-        AssertEqual(DateTime.SpecifyKind(utcToday.AddMinutes(offsetInMinutes), DateTimeKind.Unspecified), result.Aggregations.Max<DateTime>("max_nextReview")?.Value);
+        var minNextReview = result.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(minNextReview);
+        AssertEqual(DateTime.SpecifyKind(utcToday.SubtractDays(2).AddMinutes(offsetInMinutes), DateTimeKind.Unspecified), minNextReview.Value);
+        var maxNextReview = result.Aggregations.Max<DateTime>("max_nextReview");
+        Assert.NotNull(maxNextReview);
+        AssertEqual(DateTime.SpecifyKind(utcToday.AddMinutes(offsetInMinutes), DateTimeKind.Unspecified), maxNextReview.Value);
 
         var dateHistogramAgg = result.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         var oldestDate = DateTime.SpecifyKind(utcToday.SubtractDays(3).AddMinutes(offsetInMinutes), DateTimeKind.Unspecified); // it's minus 3 days because the offset puts it a day back.
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -268,11 +342,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(3, result.Total);
         Assert.Equal(3, result.Aggregations.Count);
 
-        // Dates are always returned in utc.
-        Assert.Equal(DateTime.SpecifyKind(today.SubtractDays(2), DateTimeKind.Utc), result.Aggregations.Min<DateTime>("min_nextReview")?.Value);
-        Assert.Equal(DateTime.SpecifyKind(today, DateTimeKind.Utc), result.Aggregations.Max<DateTime>("max_nextReview")?.Value);
+        var minNextReview = result.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(minNextReview);
+        Assert.Equal(DateTime.SpecifyKind(today.SubtractDays(2), DateTimeKind.Utc), minNextReview.Value);
+        var maxNextReview = result.Aggregations.Max<DateTime>("max_nextReview");
+        Assert.NotNull(maxNextReview);
+        Assert.Equal(DateTime.SpecifyKind(today, DateTimeKind.Utc), maxNextReview.Value);
 
         var dateHistogramAgg = result.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         var oldestDate = DateTime.SpecifyKind(today.Date.SubtractDays(2), DateTimeKind.Utc);
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -298,11 +376,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(3, result.Total);
         Assert.Equal(3, result.Aggregations.Count);
 
-        // Dates are always returned in utc.
-        AssertEqual(DateTime.SpecifyKind(today.UtcDateTime.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified), result.Aggregations.Min<DateTime>("min_nextReview")?.Value);
-        AssertEqual(DateTime.SpecifyKind(today.UtcDateTime.SubtractHours(1), DateTimeKind.Unspecified), result.Aggregations.Max<DateTime>("max_nextReview")?.Value);
+        var minNextReview = result.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(minNextReview);
+        AssertEqual(DateTime.SpecifyKind(today.UtcDateTime.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified), minNextReview.Value);
+        var maxNextReview = result.Aggregations.Max<DateTime>("max_nextReview");
+        Assert.NotNull(maxNextReview);
+        AssertEqual(DateTime.SpecifyKind(today.UtcDateTime.SubtractHours(1), DateTimeKind.Unspecified), maxNextReview.Value);
 
         var dateHistogramAgg = result.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         var oldestDate = DateTime.SpecifyKind(today.UtcDateTime.Date.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified);
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -330,11 +412,17 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Equal(10, result.Total);
         Assert.Single(result.Aggregations);
 
-        var bucket = result.Aggregations.GeoHash("geogrid_location").Buckets.Single();
+        var geoHashAgg = result.Aggregations.GeoHash("geogrid_location");
+        Assert.NotNull(geoHashAgg);
+        var bucket = geoHashAgg.Buckets.Single();
         Assert.Equal("s", bucket.Key);
         Assert.Equal(10, bucket.Total);
-        Assert.Equal(Math.Round(14.9999999860302, 5), Math.Round(bucket.Aggregations.Average("avg_lat").Value.GetValueOrDefault(), 5));
-        Assert.Equal(Math.Round(14.9999999860302, 5), Math.Round(bucket.Aggregations.Average("avg_lon").Value.GetValueOrDefault(), 5));
+        var avgLat = bucket.Aggregations.Average("avg_lat");
+        Assert.NotNull(avgLat);
+        Assert.Equal(Math.Round(14.9999999860302, 5), Math.Round(avgLat.Value.GetValueOrDefault(), 5));
+        var avgLon = bucket.Aggregations.Average("avg_lon");
+        Assert.NotNull(avgLon);
+        Assert.Equal(Math.Round(14.9999999860302, 5), Math.Round(avgLon.Value.GetValueOrDefault(), 5));
     }
 
     [Fact]
@@ -345,48 +433,65 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression("terms:age"));
         Assert.Equal(10, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Equal(10, result.Aggregations.Terms<int>("terms_age").Buckets.Count);
-        Assert.Equal(1, result.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19).Total);
+        var termsAge = result.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(termsAge);
+        Assert.Equal(10, termsAge.Buckets.Count);
+        Assert.Equal(1, termsAge.Buckets.First(f => f.Key == 19).Total);
 
         string json = JsonConvert.SerializeObject(result);
         var roundTripped = JsonConvert.DeserializeObject<CountResult>(json);
+        Assert.NotNull(roundTripped);
         Assert.Equal(10, roundTripped.Total);
         Assert.Single(roundTripped.Aggregations);
-        Assert.Equal(10, roundTripped.Aggregations.Terms<int>("terms_age").Buckets.Count);
-        Assert.Equal(1, roundTripped.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19).Total);
+        var roundTrippedTermsAge = roundTripped.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(roundTrippedTermsAge);
+        Assert.Equal(10, roundTrippedTermsAge.Buckets.Count);
+        Assert.Equal(1, roundTrippedTermsAge.Buckets.First(f => f.Key == 19).Total);
 
         // Test with all serializers
         foreach (var serializer in SerializerTestHelper.GetTextSerializers())
         {
             json = serializer.SerializeToString(result);
             roundTripped = serializer.Deserialize<CountResult>(json);
+            Assert.NotNull(roundTripped);
             Assert.Equal(10, roundTripped.Total);
             Assert.Single(roundTripped.Aggregations);
-            Assert.Equal(10, roundTripped.Aggregations.Terms<int>("terms_age").Buckets.Count);
-            Assert.Equal(1, roundTripped.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19).Total);
+            var serializerTermsAge = roundTripped.Aggregations.Terms<int>("terms_age");
+            Assert.NotNull(serializerTermsAge);
+            Assert.Equal(10, serializerTermsAge.Buckets.Count);
+            Assert.Equal(1, serializerTermsAge.Buckets.First(f => f.Key == 19).Total);
         }
 
         result = await _employeeRepository.CountAsync(q => q.AggregationsExpression("terms:(age~2 @missing:0 terms:(years~2 @missing:0))"));
         Assert.Equal(10, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Equal(2, result.Aggregations.Terms<int>("terms_age").Buckets.Count);
-        var bucket = result.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19);
+        termsAge = result.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(termsAge);
+        Assert.Equal(2, termsAge.Buckets.Count);
+        var bucket = termsAge.Buckets.First(f => f.Key == 19);
         Assert.Equal(1, bucket.Total);
         Assert.Single(bucket.Aggregations);
-        Assert.Single(bucket.Aggregations.Terms<int>("terms_years").Buckets);
+        var termsYears = bucket.Aggregations.Terms<int>("terms_years");
+        Assert.NotNull(termsYears);
+        Assert.Single(termsYears.Buckets);
 
         // Test nested aggregations with all serializers
         foreach (var serializer in SerializerTestHelper.GetTextSerializers())
         {
             json = serializer.SerializeToString(result);
             roundTripped = serializer.Deserialize<CountResult>(json);
+            Assert.NotNull(roundTripped);
             Assert.Equal(10, roundTripped.Total);
             Assert.Single(roundTripped.Aggregations);
-            Assert.Equal(2, roundTripped.Aggregations.Terms<int>("terms_age").Buckets.Count);
-            bucket = roundTripped.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19);
+            var nestedTermsAge = roundTripped.Aggregations.Terms<int>("terms_age");
+            Assert.NotNull(nestedTermsAge);
+            Assert.Equal(2, nestedTermsAge.Buckets.Count);
+            bucket = nestedTermsAge.Buckets.First(f => f.Key == 19);
             Assert.Equal(1, bucket.Total);
             Assert.Single(bucket.Aggregations);
-            Assert.Single(bucket.Aggregations.Terms<int>("terms_years").Buckets);
+            var nestedTermsYears = bucket.Aggregations.Terms<int>("terms_years");
+            Assert.NotNull(nestedTermsYears);
+            Assert.Single(nestedTermsYears.Buckets);
         }
     }
 
@@ -406,6 +511,7 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Single(result.Aggregations);
 
         var dateHistogramAgg = result.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         var oldestDate = DateTime.SpecifyKind(utcToday.UtcDateTime.Date.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified);
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -417,8 +523,10 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
 
         string json = JsonConvert.SerializeObject(result);
         var roundTripped = JsonConvert.DeserializeObject<CountResult>(json);
+        Assert.NotNull(roundTripped);
 
         dateHistogramAgg = roundTripped.Aggregations.DateHistogram("date_nextReview");
+        Assert.NotNull(dateHistogramAgg);
         Assert.Equal(3, dateHistogramAgg.Buckets.Count);
         oldestDate = DateTime.SpecifyKind(utcToday.UtcDateTime.Date.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified);
         foreach (var bucket in dateHistogramAgg.Buckets)
@@ -433,8 +541,10 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         {
             json = serializer.SerializeToString(result);
             roundTripped = serializer.Deserialize<CountResult>(json);
+            Assert.NotNull(roundTripped);
 
             dateHistogramAgg = roundTripped.Aggregations.DateHistogram("date_nextReview");
+            Assert.NotNull(dateHistogramAgg);
             Assert.Equal(3, dateHistogramAgg.Buckets.Count);
             oldestDate = DateTime.SpecifyKind(utcToday.UtcDateTime.Date.SubtractDays(2).SubtractHours(1), DateTimeKind.Unspecified);
             foreach (var bucket in dateHistogramAgg.Buckets)
@@ -462,12 +572,15 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         Assert.Single(result.Aggregations);
 
         var dateTermsAgg = result.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(dateTermsAgg);
         Assert.Equal(utcToday.SubtractDays(2), dateTermsAgg.Value);
 
         string json = JsonConvert.SerializeObject(result);
         var roundTripped = JsonConvert.DeserializeObject<CountResult>(json);
+        Assert.NotNull(roundTripped);
 
         dateTermsAgg = roundTripped.Aggregations.Min<DateTime>("min_nextReview");
+        Assert.NotNull(dateTermsAgg);
         Assert.Equal(utcToday.SubtractDays(2), dateTermsAgg.Value);
 
         // Test with all serializers
@@ -475,8 +588,10 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         {
             json = serializer.SerializeToString(result);
             roundTripped = serializer.Deserialize<CountResult>(json);
+            Assert.NotNull(roundTripped);
 
             dateTermsAgg = roundTripped.Aggregations.Min<DateTime>("min_nextReview");
+            Assert.NotNull(dateTermsAgg);
             Assert.Equal(utcToday.SubtractDays(2), dateTermsAgg.Value);
         }
     }
@@ -490,8 +605,10 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression(aggregations));
         Assert.Equal(10, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Equal(10, result.Aggregations.Terms<int>("terms_age").Buckets.Count);
-        var bucket = result.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19);
+        var termsAge = result.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(termsAge);
+        Assert.Equal(10, termsAge.Buckets.Count);
+        var bucket = termsAge.Buckets.First(f => f.Key == 19);
         Assert.Equal(1, bucket.Total);
 
         var tophits = bucket.Aggregations.TopHits();
@@ -503,10 +620,13 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
 
         string json = JsonConvert.SerializeObject(result);
         var roundTripped = JsonConvert.DeserializeObject<CountResult>(json);
+        Assert.NotNull(roundTripped);
         Assert.Equal(10, roundTripped.Total);
         Assert.Single(roundTripped.Aggregations);
-        Assert.Equal(10, roundTripped.Aggregations.Terms<int>("terms_age").Buckets.Count);
-        bucket = roundTripped.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19);
+        var roundTrippedTermsAge = roundTripped.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(roundTrippedTermsAge);
+        Assert.Equal(10, roundTrippedTermsAge.Buckets.Count);
+        bucket = roundTrippedTermsAge.Buckets.First(f => f.Key == 19);
         Assert.Equal(1, bucket.Total);
 
         // Test with all serializers
@@ -514,10 +634,13 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         {
             json = serializer.SerializeToString(result);
             roundTripped = serializer.Deserialize<CountResult>(json);
+            Assert.NotNull(roundTripped);
             Assert.Equal(10, roundTripped.Total);
             Assert.Single(roundTripped.Aggregations);
-            Assert.Equal(10, roundTripped.Aggregations.Terms<int>("terms_age").Buckets.Count);
-            bucket = roundTripped.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 19);
+            var serializerTermsAge = roundTripped.Aggregations.Terms<int>("terms_age");
+            Assert.NotNull(serializerTermsAge);
+            Assert.Equal(10, serializerTermsAge.Buckets.Count);
+            bucket = serializerTermsAge.Buckets.First(f => f.Key == 19);
             Assert.Equal(1, bucket.Total);
         }
 
@@ -577,8 +700,10 @@ public sealed class AggregationQueryTests : ElasticRepositoryTestBase
         var result = await _employeeRepository.CountAsync(q => q.AggregationsExpression(aggregations));
         Assert.Equal(11, result.Total);
         Assert.Single(result.Aggregations);
-        Assert.Single(result.Aggregations.Terms<int>("terms_age").Buckets);
-        var bucket = result.Aggregations.Terms<int>("terms_age").Buckets.First(f => f.Key == 45);
+        var termsAge = result.Aggregations.Terms<int>("terms_age");
+        Assert.NotNull(termsAge);
+        Assert.Single(termsAge.Buckets);
+        var bucket = termsAge.Buckets.First(f => f.Key == 45);
         Assert.Equal(2, bucket.Total);
 
         var tophits = bucket.Aggregations.TopHits();

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/CustomFieldTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/CustomFieldTests.cs
@@ -19,9 +19,10 @@ public sealed class CustomFieldTests : ElasticRepositoryTestBase
 
     public CustomFieldTests(ITestOutputHelper output) : base(output)
     {
+        Assert.NotNull(_configuration.CustomFieldDefinitionRepository);
         _customFieldDefinitionRepository = _configuration.CustomFieldDefinitionRepository;
         _employeeRepository = new EmployeeWithCustomFieldsRepository(_configuration);
-        _repocache = _configuration.Cache as InMemoryCacheClient;
+        _repocache = Assert.IsType<InMemoryCacheClient>(_configuration.Cache);
     }
 
     public override async ValueTask InitializeAsync()

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Extensions/ElasticsearchExtensions.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Extensions/ElasticsearchExtensions.cs
@@ -41,9 +41,11 @@ public static class ElasticsearchExtensions
         }
 
 #if ELASTICSEARCH9
-        return (response.Aliases ?? throw new InvalidOperationException("Aliases response was null")).Count;
+        Assert.NotNull(response.Aliases);
+        return response.Aliases.Count;
 #else
-        return (response.Values ?? throw new InvalidOperationException("Values response was null")).Count;
+        Assert.NotNull(response.Values);
+        return response.Values.Count;
 #endif
     }
 
@@ -60,9 +62,11 @@ public static class ElasticsearchExtensions
         }
 
 #if ELASTICSEARCH9
-        return (response.Aliases ?? throw new InvalidOperationException("Aliases response was null")).Keys.ToList();
+        Assert.NotNull(response.Aliases);
+        return response.Aliases.Keys.ToList();
 #else
-        return (response.Values ?? throw new InvalidOperationException("Values response was null")).Keys.ToList();
+        Assert.NotNull(response.Values);
+        return response.Values.Keys.ToList();
 #endif
     }
 
@@ -79,9 +83,11 @@ public static class ElasticsearchExtensions
         }
 
 #if ELASTICSEARCH9
-        return (response.Aliases ?? throw new InvalidOperationException("Aliases response was null")).Keys.ToList();
+        Assert.NotNull(response.Aliases);
+        return response.Aliases.Keys.ToList();
 #else
-        return (response.Values ?? throw new InvalidOperationException("Values response was null")).Keys.ToList();
+        Assert.NotNull(response.Values);
+        return response.Values.Keys.ToList();
 #endif
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Extensions/ElasticsearchExtensions.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Extensions/ElasticsearchExtensions.cs
@@ -14,9 +14,11 @@ public static class ElasticsearchExtensions
         var aliasResponse = await client.Indices.GetAliasAsync((Indices)aliasName, a => a.IgnoreUnavailable());
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        var indices = aliasResponse.Aliases;
 #else
-        var indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        var indices = aliasResponse.Values;
 #endif
         Assert.Contains(indexName, indices.Keys);
         Assert.Single(indices);
@@ -39,9 +41,9 @@ public static class ElasticsearchExtensions
         }
 
 #if ELASTICSEARCH9
-        return response.Aliases!.Count;
+        return (response.Aliases ?? throw new InvalidOperationException("Aliases response was null")).Count;
 #else
-        return response.Values!.Count;
+        return (response.Values ?? throw new InvalidOperationException("Values response was null")).Count;
 #endif
     }
 
@@ -58,9 +60,9 @@ public static class ElasticsearchExtensions
         }
 
 #if ELASTICSEARCH9
-        return response.Aliases!.Keys.ToList();
+        return (response.Aliases ?? throw new InvalidOperationException("Aliases response was null")).Keys.ToList();
 #else
-        return response.Values!.Keys.ToList();
+        return (response.Values ?? throw new InvalidOperationException("Values response was null")).Keys.ToList();
 #endif
     }
 
@@ -77,9 +79,9 @@ public static class ElasticsearchExtensions
         }
 
 #if ELASTICSEARCH9
-        return response.Aliases!.Keys.ToList();
+        return (response.Aliases ?? throw new InvalidOperationException("Aliases response was null")).Keys.ToList();
 #else
-        return response.Values!.Keys.ToList();
+        return (response.Values ?? throw new InvalidOperationException("Values response was null")).Keys.ToList();
 #endif
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Extensions/ElasticsearchExtensions.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Extensions/ElasticsearchExtensions.cs
@@ -14,9 +14,9 @@ public static class ElasticsearchExtensions
         var aliasResponse = await client.Indices.GetAliasAsync((Indices)aliasName, a => a.IgnoreUnavailable());
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases;
+        var indices = aliasResponse.Aliases!;
 #else
-        var indices = aliasResponse.Values;
+        var indices = aliasResponse.Values!;
 #endif
         Assert.Contains(indexName, indices.Keys);
         Assert.Single(indices);
@@ -39,9 +39,9 @@ public static class ElasticsearchExtensions
         }
 
 #if ELASTICSEARCH9
-        return response.Aliases.Count;
+        return response.Aliases!.Count;
 #else
-        return response.Values.Count;
+        return response.Values!.Count;
 #endif
     }
 
@@ -58,9 +58,9 @@ public static class ElasticsearchExtensions
         }
 
 #if ELASTICSEARCH9
-        return response.Aliases.Keys.ToList();
+        return response.Aliases!.Keys.ToList();
 #else
-        return response.Values.Keys.ToList();
+        return response.Values!.Keys.ToList();
 #endif
     }
 
@@ -77,9 +77,9 @@ public static class ElasticsearchExtensions
         }
 
 #if ELASTICSEARCH9
-        return response.Aliases.Keys.ToList();
+        return response.Aliases!.Keys.ToList();
 #else
-        return response.Values.Keys.ToList();
+        return response.Values!.Keys.ToList();
 #endif
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Foundatio.Repositories.Elasticsearch.Tests.csproj
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Foundatio.Repositories.Elasticsearch.Tests.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Exceptionless.RandomData" Version="2.0.1" />
-    <PackageReference Include="Jint" Version="4.6.4" />
+    <PackageReference Include="Jint" Version="4.8.0" />
     <PackageReference Include="TimeZoneConverter" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Foundatio.Repositories.Elasticsearch.Tests.csproj
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Foundatio.Repositories.Elasticsearch.Tests.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Exceptionless.RandomData" Version="2.0.1" />
-    <PackageReference Include="Jint" Version="4.6.4" />
+    <PackageReference Include="Jint" Version="4.8.0" />
     <PackageReference Include="NEST.JsonNetSerializer" Version="7.17.5" />
     <PackageReference Include="TimeZoneConverter" Version="7.2.0" />
   </ItemGroup>

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/IndexTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/IndexTests.cs
@@ -60,9 +60,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
             _logger.LogRequest(aliasesResponse);
             Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-            var indices = aliasesResponse.Aliases;
+            var indices = aliasesResponse.Aliases!;
 #else
-            var indices = aliasesResponse.Values;
+            var indices = aliasesResponse.Values!;
 #endif
             Assert.Single(indices);
 
@@ -101,9 +101,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
             _logger.LogRequest(aliasesResponse);
             Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-            var indices = aliasesResponse.Aliases;
+            var indices = aliasesResponse.Aliases!;
 #else
-            var indices = aliasesResponse.Values;
+            var indices = aliasesResponse.Values!;
 #endif
             Assert.Single(indices);
 
@@ -150,9 +150,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(alias);
         Assert.True(alias.IsValidResponse);
 #if ELASTICSEARCH9
-        var aliasIndices = alias.Aliases;
+        var aliasIndices = alias.Aliases!;
 #else
-        var aliasIndices = alias.Values;
+        var aliasIndices = alias.Values!;
 #endif
         Assert.Equal(2, aliasIndices.Count);
 
@@ -195,9 +195,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         await _client.Indices.RefreshAsync(Elastic.Clients.Elasticsearch.Indices.All, cancellationToken: TestCancellationToken);
         var aliasesResponse = await _client.Indices.GetAliasAsync((Indices)$"{version1Index.VersionedName},{version2Index.VersionedName}", cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        var indices = aliasesResponse.Aliases;
+        var indices = aliasesResponse.Aliases!;
 #else
-        var indices = aliasesResponse.Values;
+        var indices = aliasesResponse.Values!;
 #endif
         Assert.Empty(indices.Values.SelectMany(i => i.Aliases));
 
@@ -208,16 +208,16 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         await version1Index.MaintainAsync();
         aliasesResponse = await _client.Indices.GetAliasAsync((Indices)version1Index.VersionedName, cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases;
+        indices = aliasesResponse.Aliases!;
 #else
-        indices = aliasesResponse.Values;
+        indices = aliasesResponse.Values!;
 #endif
         Assert.Single(indices.Single().Value.Aliases);
         aliasesResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.VersionedName, cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases;
+        indices = aliasesResponse.Aliases!;
 #else
-        indices = aliasesResponse.Values;
+        indices = aliasesResponse.Values!;
 #endif
         Assert.Empty(indices.Single().Value.Aliases);
 
@@ -263,9 +263,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         await _client.Indices.RefreshAsync(Elastic.Clients.Elasticsearch.Indices.All, cancellationToken: TestCancellationToken);
         var aliasesResponse = await _client.Indices.GetAliasAsync((Indices)$"{version1Index.GetVersionedIndex(utcNow.UtcDateTime)},{version2Index.GetVersionedIndex(utcNow.UtcDateTime)}", cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        var indices = aliasesResponse.Aliases;
+        var indices = aliasesResponse.Aliases!;
 #else
-        var indices = aliasesResponse.Values;
+        var indices = aliasesResponse.Values!;
 #endif
         Assert.Empty(indices.Values.SelectMany(i => i.Aliases));
 
@@ -276,16 +276,16 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         await version1Index.MaintainAsync();
         aliasesResponse = await _client.Indices.GetAliasAsync((Indices)version1Index.GetVersionedIndex(utcNow.UtcDateTime), cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases;
+        indices = aliasesResponse.Aliases!;
 #else
-        indices = aliasesResponse.Values;
+        indices = aliasesResponse.Values!;
 #endif
         Assert.Equal(version1Index.Aliases.Count + 1, indices.Single().Value.Aliases.Count);
         aliasesResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.GetVersionedIndex(utcNow.UtcDateTime), cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases;
+        indices = aliasesResponse.Aliases!;
 #else
-        indices = aliasesResponse.Values;
+        indices = aliasesResponse.Values!;
 #endif
         Assert.Empty(indices.Single().Value.Aliases);
 
@@ -297,9 +297,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
     {
         var aliasesResponse = await _client.Indices.GetAliasAsync((Indices)index, cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        var indices = aliasesResponse.Aliases;
+        var indices = aliasesResponse.Aliases!;
 #else
-        var indices = aliasesResponse.Values;
+        var indices = aliasesResponse.Values!;
 #endif
         var aliases = indices.Single(a => a.Key == index).Value.Aliases.Select(s => s.Key).ToList();
         foreach (string alias in aliases)
@@ -335,9 +335,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasesResponse.Aliases;
+        var indices = aliasesResponse.Aliases!;
 #else
-        var indices = aliasesResponse.Values;
+        var indices = aliasesResponse.Values!;
 #endif
         Assert.Single(indices);
         var aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -356,9 +356,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases;
+        indices = aliasesResponse.Aliases!;
 #else
-        indices = aliasesResponse.Values;
+        indices = aliasesResponse.Values!;
 #endif
         Assert.Single(indices);
         aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -410,9 +410,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
             _logger.LogRequest(aliasesResponse);
             Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-            var indices = aliasesResponse.Aliases;
+            var indices = aliasesResponse.Aliases!;
 #else
-            var indices = aliasesResponse.Values;
+            var indices = aliasesResponse.Values!;
 #endif
             Assert.Single(indices);
 
@@ -441,9 +441,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
             _logger.LogRequest(aliasesResponse);
             Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-            var indices = aliasesResponse.Aliases;
+            var indices = aliasesResponse.Aliases!;
 #else
-            var indices = aliasesResponse.Values;
+            var indices = aliasesResponse.Values!;
 #endif
             Assert.Single(indices);
 
@@ -510,16 +510,16 @@ public sealed class IndexTests : ElasticRepositoryTestBase
 
         await index1.ConfigureAsync();
         var settings = await _client.Indices.GetSettingsAsync((Indices)index1.VersionedName, cancellationToken: TestCancellationToken);
-        var indexSettings = settings.Settings[index1.VersionedName].Settings;
+        var indexSettings = settings.Settings![index1.VersionedName].Settings!;
         // NumberOfReplicas is Union<int, string> - need to extract the actual value
         var replicas = indexSettings.Index?.NumberOfReplicas ?? indexSettings.NumberOfReplicas;
         Assert.NotNull(replicas);
         // Match returns the value from either side of the union
-        var replicaCount = replicas.Match(i => i, s => int.Parse(s));
+        var replicaCount = replicas!.Match(i => i, s => int.Parse(s!));
         Assert.Equal(0, replicaCount);
         Assert.NotNull(indexSettings.Index);
-        Assert.NotNull(indexSettings.Index.Analysis);
-        Assert.NotNull(indexSettings.Index.Analysis.Analyzers["custom1"]);
+        Assert.NotNull(indexSettings.Index!.Analysis);
+        Assert.NotNull(indexSettings.Index!.Analysis!.Analyzers!["custom1"]);
 
         var index2 = new VersionedEmployeeIndex(_configuration, 1, i => i.Settings(s => s
             .NumberOfReplicas(1)
@@ -529,15 +529,15 @@ public sealed class IndexTests : ElasticRepositoryTestBase
 
         await index2.ConfigureAsync();
         settings = await _client.Indices.GetSettingsAsync((Indices)index1.VersionedName, cancellationToken: TestCancellationToken);
-        indexSettings = settings.Settings[index1.VersionedName].Settings;
+        indexSettings = settings.Settings![index1.VersionedName].Settings!;
         replicas = indexSettings.Index?.NumberOfReplicas ?? indexSettings.NumberOfReplicas;
         Assert.NotNull(replicas);
-        replicaCount = replicas.Match(i => i, s => int.Parse(s));
+        replicaCount = replicas!.Match(i => i, s => int.Parse(s!));
         Assert.Equal(1, replicaCount);
         Assert.NotNull(indexSettings.Index);
-        Assert.NotNull(indexSettings.Index.Analysis);
-        Assert.NotNull(indexSettings.Index.Analysis.Analyzers["custom1"]);
-        Assert.NotNull(indexSettings.Index.Analysis.Analyzers["custom2"]);
+        Assert.NotNull(indexSettings.Index!.Analysis);
+        Assert.NotNull(indexSettings.Index!.Analysis!.Analyzers!["custom1"]);
+        Assert.NotNull(indexSettings.Index!.Analysis!.Analyzers!["custom2"]);
     }
 
     [Fact]
@@ -723,9 +723,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasesResponse.Aliases;
+        var indices = aliasesResponse.Aliases!;
 #else
-        var indices = aliasesResponse.Values;
+        var indices = aliasesResponse.Values!;
 #endif
         Assert.Single(indices);
         var aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -745,9 +745,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases;
+        indices = aliasesResponse.Aliases!;
 #else
-        indices = aliasesResponse.Values;
+        indices = aliasesResponse.Values!;
 #endif
         Assert.Single(indices);
         aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -767,9 +767,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases;
+        indices = aliasesResponse.Aliases!;
 #else
-        indices = aliasesResponse.Values;
+        indices = aliasesResponse.Values!;
 #endif
         Assert.Single(indices);
         aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -806,9 +806,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasesResponse.Aliases;
+        var indices = aliasesResponse.Aliases!;
 #else
-        var indices = aliasesResponse.Values;
+        var indices = aliasesResponse.Values!;
 #endif
         Assert.Single(indices);
         var aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -828,9 +828,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases;
+        indices = aliasesResponse.Aliases!;
 #else
-        indices = aliasesResponse.Values;
+        indices = aliasesResponse.Values!;
 #endif
         Assert.Single(indices);
         aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -850,9 +850,9 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases;
+        indices = aliasesResponse.Aliases!;
 #else
-        indices = aliasesResponse.Values;
+        indices = aliasesResponse.Values!;
 #endif
         Assert.Single(indices);
         aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/IndexTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/IndexTests.cs
@@ -544,7 +544,7 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         var indexSettings = indexSettingsEntry.Settings;
         var replicas = indexSettings.Index?.NumberOfReplicas ?? indexSettings.NumberOfReplicas;
         Assert.NotNull(replicas);
-        var replicaCount = replicas.Match(i => i, s => int.Parse(s));
+        var replicaCount = replicas.Match(i => i, s => int.Parse(s!));
         Assert.Equal(0, replicaCount);
         Assert.NotNull(indexSettings.Index);
         var indexSection = indexSettings.Index;
@@ -566,7 +566,7 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         indexSettings = indexSettingsEntry.Settings;
         replicas = indexSettings.Index?.NumberOfReplicas ?? indexSettings.NumberOfReplicas;
         Assert.NotNull(replicas);
-        replicaCount = replicas.Match(i => i, s => int.Parse(s));
+        replicaCount = replicas.Match(i => i, s => int.Parse(s!));
         Assert.Equal(1, replicaCount);
         Assert.NotNull(indexSettings.Index);
         indexSection = indexSettings.Index;

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/IndexTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/IndexTests.cs
@@ -60,9 +60,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
             _logger.LogRequest(aliasesResponse);
             Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-            var indices = aliasesResponse.Aliases!;
+            Assert.NotNull(aliasesResponse.Aliases);
+            var indices = aliasesResponse.Aliases;
 #else
-            var indices = aliasesResponse.Values!;
+            Assert.NotNull(aliasesResponse.Values);
+            var indices = aliasesResponse.Values;
 #endif
             Assert.Single(indices);
 
@@ -101,9 +103,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
             _logger.LogRequest(aliasesResponse);
             Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-            var indices = aliasesResponse.Aliases!;
+            Assert.NotNull(aliasesResponse.Aliases);
+            var indices = aliasesResponse.Aliases;
 #else
-            var indices = aliasesResponse.Values!;
+            Assert.NotNull(aliasesResponse.Values);
+            var indices = aliasesResponse.Values;
 #endif
             Assert.Single(indices);
 
@@ -150,9 +154,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(alias);
         Assert.True(alias.IsValidResponse);
 #if ELASTICSEARCH9
-        var aliasIndices = alias.Aliases!;
+        Assert.NotNull(alias.Aliases);
+        var aliasIndices = alias.Aliases;
 #else
-        var aliasIndices = alias.Values!;
+        Assert.NotNull(alias.Values);
+        var aliasIndices = alias.Values;
 #endif
         Assert.Equal(2, aliasIndices.Count);
 
@@ -195,9 +201,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         await _client.Indices.RefreshAsync(Elastic.Clients.Elasticsearch.Indices.All, cancellationToken: TestCancellationToken);
         var aliasesResponse = await _client.Indices.GetAliasAsync((Indices)$"{version1Index.VersionedName},{version2Index.VersionedName}", cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        var indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        var indices = aliasesResponse.Aliases;
 #else
-        var indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        var indices = aliasesResponse.Values;
 #endif
         Assert.Empty(indices.Values.SelectMany(i => i.Aliases));
 
@@ -208,16 +216,20 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         await version1Index.MaintainAsync();
         aliasesResponse = await _client.Indices.GetAliasAsync((Indices)version1Index.VersionedName, cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        indices = aliasesResponse.Aliases;
 #else
-        indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        indices = aliasesResponse.Values;
 #endif
         Assert.Single(indices.Single().Value.Aliases);
         aliasesResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.VersionedName, cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        indices = aliasesResponse.Aliases;
 #else
-        indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        indices = aliasesResponse.Values;
 #endif
         Assert.Empty(indices.Single().Value.Aliases);
 
@@ -263,9 +275,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         await _client.Indices.RefreshAsync(Elastic.Clients.Elasticsearch.Indices.All, cancellationToken: TestCancellationToken);
         var aliasesResponse = await _client.Indices.GetAliasAsync((Indices)$"{version1Index.GetVersionedIndex(utcNow.UtcDateTime)},{version2Index.GetVersionedIndex(utcNow.UtcDateTime)}", cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        var indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        var indices = aliasesResponse.Aliases;
 #else
-        var indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        var indices = aliasesResponse.Values;
 #endif
         Assert.Empty(indices.Values.SelectMany(i => i.Aliases));
 
@@ -276,16 +290,20 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         await version1Index.MaintainAsync();
         aliasesResponse = await _client.Indices.GetAliasAsync((Indices)version1Index.GetVersionedIndex(utcNow.UtcDateTime), cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        indices = aliasesResponse.Aliases;
 #else
-        indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        indices = aliasesResponse.Values;
 #endif
         Assert.Equal(version1Index.Aliases.Count + 1, indices.Single().Value.Aliases.Count);
         aliasesResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.GetVersionedIndex(utcNow.UtcDateTime), cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        indices = aliasesResponse.Aliases;
 #else
-        indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        indices = aliasesResponse.Values;
 #endif
         Assert.Empty(indices.Single().Value.Aliases);
 
@@ -297,9 +315,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
     {
         var aliasesResponse = await _client.Indices.GetAliasAsync((Indices)index, cancellationToken: TestCancellationToken);
 #if ELASTICSEARCH9
-        var indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        var indices = aliasesResponse.Aliases;
 #else
-        var indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        var indices = aliasesResponse.Values;
 #endif
         var aliases = indices.Single(a => a.Key == index).Value.Aliases.Select(s => s.Key).ToList();
         foreach (string alias in aliases)
@@ -335,9 +355,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        var indices = aliasesResponse.Aliases;
 #else
-        var indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        var indices = aliasesResponse.Values;
 #endif
         Assert.Single(indices);
         var aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -356,9 +378,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        indices = aliasesResponse.Aliases;
 #else
-        indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        indices = aliasesResponse.Values;
 #endif
         Assert.Single(indices);
         aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -410,9 +434,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
             _logger.LogRequest(aliasesResponse);
             Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-            var indices = aliasesResponse.Aliases!;
+            Assert.NotNull(aliasesResponse.Aliases);
+            var indices = aliasesResponse.Aliases;
 #else
-            var indices = aliasesResponse.Values!;
+            Assert.NotNull(aliasesResponse.Values);
+            var indices = aliasesResponse.Values;
 #endif
             Assert.Single(indices);
 
@@ -441,9 +467,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
             _logger.LogRequest(aliasesResponse);
             Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-            var indices = aliasesResponse.Aliases!;
+            Assert.NotNull(aliasesResponse.Aliases);
+            var indices = aliasesResponse.Aliases;
 #else
-            var indices = aliasesResponse.Values!;
+            Assert.NotNull(aliasesResponse.Values);
+            var indices = aliasesResponse.Values;
 #endif
             Assert.Single(indices);
 
@@ -510,16 +538,19 @@ public sealed class IndexTests : ElasticRepositoryTestBase
 
         await index1.ConfigureAsync();
         var settings = await _client.Indices.GetSettingsAsync((Indices)index1.VersionedName, cancellationToken: TestCancellationToken);
-        var indexSettings = settings.Settings![index1.VersionedName].Settings!;
-        // NumberOfReplicas is Union<int, string> - need to extract the actual value
+        Assert.NotNull(settings.Settings);
+        var indexSettingsEntry = settings.Settings[index1.VersionedName];
+        Assert.NotNull(indexSettingsEntry.Settings);
+        var indexSettings = indexSettingsEntry.Settings;
         var replicas = indexSettings.Index?.NumberOfReplicas ?? indexSettings.NumberOfReplicas;
         Assert.NotNull(replicas);
-        // Match returns the value from either side of the union
-        var replicaCount = replicas!.Match(i => i, s => int.Parse(s!));
+        var replicaCount = replicas.Match(i => i, s => int.Parse(s));
         Assert.Equal(0, replicaCount);
         Assert.NotNull(indexSettings.Index);
-        Assert.NotNull(indexSettings.Index!.Analysis);
-        Assert.NotNull(indexSettings.Index!.Analysis!.Analyzers!["custom1"]);
+        var indexSection = indexSettings.Index;
+        Assert.NotNull(indexSection.Analysis);
+        Assert.NotNull(indexSection.Analysis.Analyzers);
+        Assert.NotNull(indexSection.Analysis.Analyzers["custom1"]);
 
         var index2 = new VersionedEmployeeIndex(_configuration, 1, i => i.Settings(s => s
             .NumberOfReplicas(1)
@@ -529,15 +560,20 @@ public sealed class IndexTests : ElasticRepositoryTestBase
 
         await index2.ConfigureAsync();
         settings = await _client.Indices.GetSettingsAsync((Indices)index1.VersionedName, cancellationToken: TestCancellationToken);
-        indexSettings = settings.Settings![index1.VersionedName].Settings!;
+        Assert.NotNull(settings.Settings);
+        indexSettingsEntry = settings.Settings[index1.VersionedName];
+        Assert.NotNull(indexSettingsEntry.Settings);
+        indexSettings = indexSettingsEntry.Settings;
         replicas = indexSettings.Index?.NumberOfReplicas ?? indexSettings.NumberOfReplicas;
         Assert.NotNull(replicas);
-        replicaCount = replicas!.Match(i => i, s => int.Parse(s!));
+        replicaCount = replicas.Match(i => i, s => int.Parse(s));
         Assert.Equal(1, replicaCount);
         Assert.NotNull(indexSettings.Index);
-        Assert.NotNull(indexSettings.Index!.Analysis);
-        Assert.NotNull(indexSettings.Index!.Analysis!.Analyzers!["custom1"]);
-        Assert.NotNull(indexSettings.Index!.Analysis!.Analyzers!["custom2"]);
+        indexSection = indexSettings.Index;
+        Assert.NotNull(indexSection.Analysis);
+        Assert.NotNull(indexSection.Analysis.Analyzers);
+        Assert.NotNull(indexSection.Analysis.Analyzers["custom1"]);
+        Assert.NotNull(indexSection.Analysis.Analyzers["custom2"]);
     }
 
     [Fact]
@@ -723,9 +759,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        var indices = aliasesResponse.Aliases;
 #else
-        var indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        var indices = aliasesResponse.Values;
 #endif
         Assert.Single(indices);
         var aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -745,9 +783,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        indices = aliasesResponse.Aliases;
 #else
-        indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        indices = aliasesResponse.Values;
 #endif
         Assert.Single(indices);
         aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -767,9 +807,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        indices = aliasesResponse.Aliases;
 #else
-        indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        indices = aliasesResponse.Values;
 #endif
         Assert.Single(indices);
         aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -806,9 +848,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        var indices = aliasesResponse.Aliases;
 #else
-        var indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        var indices = aliasesResponse.Values;
 #endif
         Assert.Single(indices);
         var aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -828,9 +872,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        indices = aliasesResponse.Aliases;
 #else
-        indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        indices = aliasesResponse.Values;
 #endif
         Assert.Single(indices);
         aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -850,9 +896,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        indices = aliasesResponse.Aliases;
 #else
-        indices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        indices = aliasesResponse.Values;
 #endif
         Assert.Single(indices);
         aliases = indices.Values.Single().Aliases.Select(s => s.Key).ToList();
@@ -1080,7 +1128,7 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         var baseDate = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         // Act
-        Employee lastEmployee = null!;
+        Employee? lastEmployee = null;
         for (int i = 0; i < UNIQUE_DATES; i++)
         {
             var testDate = baseDate.AddDays(i);
@@ -1088,7 +1136,6 @@ public sealed class IndexTests : ElasticRepositoryTestBase
             lastEmployee = await repository.AddAsync(employee);
         }
 
-        // Assert
         Assert.NotNull(lastEmployee);
         Assert.NotNull(lastEmployee.Id);
         var retrieved = await repository.GetByIdAsync(lastEmployee.Id);

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/MigrationTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/MigrationTests.cs
@@ -13,11 +13,11 @@ namespace Foundatio.Repositories.Elasticsearch.Tests;
 
 public sealed class MigrationTests : ElasticRepositoryTestBase
 {
-    private MigrationIndex _migrationIndex;
-    private MigrationManager _migrationManager;
-    private MigrationStateRepository _migrationStateRepository;
-    private ILockProvider _lockProvider;
-    private IServiceProvider _serviceProvider;
+    private MigrationIndex _migrationIndex = null!;
+    private MigrationManager _migrationManager = null!;
+    private MigrationStateRepository _migrationStateRepository = null!;
+    private ILockProvider _lockProvider = null!;
+    private IServiceProvider _serviceProvider = null!;
 
     public MigrationTests(ITestOutputHelper output) : base(output)
     {

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/NestedFieldTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/NestedFieldTests.cs
@@ -152,6 +152,7 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
 
         // Assert
         var result = nestedAggQuery.Aggregations.ToAggregations();
+        Assert.NotNull(result);
         Assert.Single(result);
 
         var nestedReviewRatingAgg = result["nested_reviewRating"] as SingleBucketAggregate;
@@ -171,6 +172,7 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
 
         // Assert - Verify filtered aggregation
         result = nestedAggQueryWithFilter.Aggregations.ToAggregations();
+        Assert.NotNull(result);
         Assert.Single(result);
 
         var nestedReviewRatingFilteredAgg = result["nested_reviewRating"] as SingleBucketAggregate;
@@ -178,9 +180,11 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
 
         var userFilteredAgg = nestedReviewRatingFilteredAgg.Aggregations["user_" + employees[0].Id] as SingleBucketAggregate;
         Assert.NotNull(userFilteredAgg);
-        Assert.Single(userFilteredAgg.Aggregations.Terms("terms_rating").Buckets);
-        Assert.Equal("5", userFilteredAgg.Aggregations.Terms("terms_rating").Buckets.First().Key);
-        Assert.Equal(1, userFilteredAgg.Aggregations.Terms("terms_rating").Buckets.First().Total);
+        var userTermsRating = userFilteredAgg.Aggregations.Terms("terms_rating");
+        Assert.NotNull(userTermsRating);
+        Assert.Single(userTermsRating.Buckets);
+        Assert.Equal("5", userTermsRating.Buckets.First().Key);
+        Assert.Equal(1, userTermsRating.Buckets.First().Total);
     }
 
     [Fact]
@@ -221,14 +225,22 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         Assert.NotNull(nestedPeerReviewsAgg);
 
         var reviewerTermsAgg = nestedPeerReviewsAgg.Aggregations.Terms<string>("terms_peerReviews.reviewerEmployeeId");
+        Assert.NotNull(reviewerTermsAgg);
         Assert.Equal(3, reviewerTermsAgg.Buckets.Count);
 
         var ratingTermsAgg = nestedPeerReviewsAgg.Aggregations.Terms<int>("terms_peerReviews.rating");
+        Assert.NotNull(ratingTermsAgg);
         Assert.Equal(3, ratingTermsAgg.Buckets.Count);
 
-        Assert.Equal(3, nestedPeerReviewsAgg.Aggregations.Min("min_peerReviews.rating").Value);
-        Assert.Equal(5, nestedPeerReviewsAgg.Aggregations.Max("max_peerReviews.rating").Value);
-        Assert.Equal(3, nestedPeerReviewsAgg.Aggregations.Cardinality("cardinality_peerReviews.reviewerEmployeeId").Value);
+        var minAgg = nestedPeerReviewsAgg.Aggregations.Min("min_peerReviews.rating");
+        Assert.NotNull(minAgg);
+        Assert.Equal(3, minAgg.Value);
+        var maxAgg = nestedPeerReviewsAgg.Aggregations.Max("max_peerReviews.rating");
+        Assert.NotNull(maxAgg);
+        Assert.Equal(5, maxAgg.Value);
+        var cardinalityAgg = nestedPeerReviewsAgg.Aggregations.Cardinality("cardinality_peerReviews.reviewerEmployeeId");
+        Assert.NotNull(cardinalityAgg);
+        Assert.Equal(3, cardinalityAgg.Value);
     }
 
     [Fact]
@@ -269,12 +281,14 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         Assert.NotNull(nestedPeerReviewsAggWithInclude);
 
         var reviewerTermsAggWithInclude = nestedPeerReviewsAggWithInclude.Aggregations.Terms<string>("terms_peerReviews.reviewerEmployeeId");
-        Assert.Equal(2, reviewerTermsAggWithInclude.Buckets.Count); // Only employee1 and employee2 should be included
+        Assert.NotNull(reviewerTermsAggWithInclude);
+        Assert.Equal(2, reviewerTermsAggWithInclude.Buckets.Count);
         Assert.Contains(reviewerTermsAggWithInclude.Buckets, b => String.Equals(b.Key, "employee1"));
         Assert.Contains(reviewerTermsAggWithInclude.Buckets, b => String.Equals(b.Key, "employee2"));
         Assert.DoesNotContain(reviewerTermsAggWithInclude.Buckets, b => String.Equals(b.Key, "employee3"));
 
         var ratingTermsAggWithInclude = nestedPeerReviewsAggWithInclude.Aggregations.Terms<int>("terms_peerReviews.rating");
+        Assert.NotNull(ratingTermsAggWithInclude);
         Assert.Equal(2, ratingTermsAggWithInclude.Buckets.Count); // Only ratings 4 and 5 should be included
         Assert.Contains(ratingTermsAggWithInclude.Buckets, b => b.Key == 4);
         Assert.Contains(ratingTermsAggWithInclude.Buckets, b => b.Key == 5);
@@ -319,13 +333,15 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         Assert.NotNull(nestedPeerReviewsAggWithExclude);
 
         var reviewerTermsAggWithExclude = nestedPeerReviewsAggWithExclude.Aggregations.Terms<string>("terms_peerReviews.reviewerEmployeeId");
-        Assert.Equal(2, reviewerTermsAggWithExclude.Buckets.Count); // employee3 should be excluded
+        Assert.NotNull(reviewerTermsAggWithExclude);
+        Assert.Equal(2, reviewerTermsAggWithExclude.Buckets.Count);
         Assert.Contains(reviewerTermsAggWithExclude.Buckets, b => String.Equals(b.Key, "employee1"));
         Assert.Contains(reviewerTermsAggWithExclude.Buckets, b => String.Equals(b.Key, "employee2"));
         Assert.DoesNotContain(reviewerTermsAggWithExclude.Buckets, b => String.Equals(b.Key, "employee3"));
 
         var ratingTermsAggWithExclude = nestedPeerReviewsAggWithExclude.Aggregations.Terms<int>("terms_peerReviews.rating");
-        Assert.Equal(2, ratingTermsAggWithExclude.Buckets.Count); // rating 3 should be excluded
+        Assert.NotNull(ratingTermsAggWithExclude);
+        Assert.Equal(2, ratingTermsAggWithExclude.Buckets.Count);
         Assert.Contains(ratingTermsAggWithExclude.Buckets, b => b.Key == 4);
         Assert.Contains(ratingTermsAggWithExclude.Buckets, b => b.Key == 5);
         Assert.DoesNotContain(ratingTermsAggWithExclude.Buckets, b => b.Key == 3);
@@ -367,6 +383,7 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         Assert.NotNull(nestedPeerReviewsAgg);
 
         var ratingTermsAgg = nestedPeerReviewsAgg.Aggregations.Terms<int>("terms_peerReviews.rating");
+        Assert.NotNull(ratingTermsAgg);
         Assert.Equal(4, ratingTermsAgg.Buckets.Count);
         var bucket = ratingTermsAgg.Buckets.First(f => f.Key == 5);
         Assert.Equal(2, bucket.Total);
@@ -374,6 +391,7 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         // Test Newtonsoft.Json serialization
         string json = JsonConvert.SerializeObject(result);
         var roundTripped = JsonConvert.DeserializeObject<CountResult>(json);
+        Assert.NotNull(roundTripped);
         Assert.Equal(3, roundTripped.Total);
         Assert.Single(roundTripped.Aggregations);
 
@@ -390,6 +408,7 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         string systemTextJson = System.Text.Json.JsonSerializer.Serialize(result);
         Assert.Equal(json, systemTextJson);
         roundTripped = System.Text.Json.JsonSerializer.Deserialize<CountResult>(systemTextJson);
+        Assert.NotNull(roundTripped);
         Assert.Equal(3, roundTripped.Total);
         Assert.Single(roundTripped.Aggregations);
 
@@ -397,6 +416,7 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         Assert.NotNull(roundTrippedNestedAgg);
 
         roundTrippedRatingTermsAgg = roundTrippedNestedAgg.Aggregations.Terms<int>("terms_peerReviews.rating");
+        Assert.NotNull(roundTrippedRatingTermsAgg);
         Assert.Equal(4, roundTrippedRatingTermsAgg.Buckets.Count);
         bucket = roundTrippedRatingTermsAgg.Buckets.First(f => f.Key == 5);
         Assert.Equal(2, bucket.Total);
@@ -662,6 +682,7 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         Assert.Contains("terms_peerReviews.rating", result.Aggregations.Keys);
 
         var ratingTermsAgg = result.Aggregations.Terms<int>("terms_peerReviews.rating");
+        Assert.NotNull(ratingTermsAgg);
         Assert.Equal(4, ratingTermsAgg.Buckets.Count);
         Assert.Equal(2, ratingTermsAgg.Buckets.First(b => b.Key == 5).Total);
         Assert.Equal(2, ratingTermsAgg.Buckets.First(b => b.Key == 4).Total);

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/NestedFieldTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/NestedFieldTests.cs
@@ -152,6 +152,7 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
 
         // Assert
         var result = nestedAggQuery.Aggregations.ToAggregations(_serializer);
+        Assert.NotNull(result);
         Assert.Single(result);
 
         var nestedReviewRatingAgg = Assert.IsType<SingleBucketAggregate>(result["nested_reviewRating"]);
@@ -171,14 +172,17 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
 
         // Assert - Verify filtered aggregation
         result = nestedAggQueryWithFilter.Aggregations.ToAggregations(_serializer);
+        Assert.NotNull(result);
         Assert.Single(result);
 
         var nestedReviewRatingFilteredAgg = Assert.IsType<SingleBucketAggregate>(result["nested_reviewRating"]);
 
         var userFilteredAgg = Assert.IsType<SingleBucketAggregate>(nestedReviewRatingFilteredAgg.Aggregations[$"user_{employees[0].Id}"]);
-        Assert.Single(userFilteredAgg.Aggregations.Terms("terms_rating").Buckets);
-        Assert.Equal("5", userFilteredAgg.Aggregations.Terms("terms_rating").Buckets.First().Key);
-        Assert.Equal(1, userFilteredAgg.Aggregations.Terms("terms_rating").Buckets.First().Total);
+        var userTermsRating = userFilteredAgg.Aggregations.Terms("terms_rating");
+        Assert.NotNull(userTermsRating);
+        Assert.Single(userTermsRating.Buckets);
+        Assert.Equal("5", userTermsRating.Buckets.First().Key);
+        Assert.Equal(1, userTermsRating.Buckets.First().Total);
     }
 
     [Fact]
@@ -218,14 +222,22 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         var nestedPeerReviewsAgg = Assert.IsType<SingleBucketAggregate>(result.Aggregations["nested_peerReviews"]);
 
         var reviewerTermsAgg = nestedPeerReviewsAgg.Aggregations.Terms<string>("terms_peerReviews.reviewerEmployeeId");
+        Assert.NotNull(reviewerTermsAgg);
         Assert.Equal(3, reviewerTermsAgg.Buckets.Count);
 
         var ratingTermsAgg = nestedPeerReviewsAgg.Aggregations.Terms<int>("terms_peerReviews.rating");
+        Assert.NotNull(ratingTermsAgg);
         Assert.Equal(3, ratingTermsAgg.Buckets.Count);
 
-        Assert.Equal(3, nestedPeerReviewsAgg.Aggregations.Min("min_peerReviews.rating").Value);
-        Assert.Equal(5, nestedPeerReviewsAgg.Aggregations.Max("max_peerReviews.rating").Value);
-        Assert.Equal(3, nestedPeerReviewsAgg.Aggregations.Cardinality("cardinality_peerReviews.reviewerEmployeeId").Value);
+        var minAgg = nestedPeerReviewsAgg.Aggregations.Min("min_peerReviews.rating");
+        Assert.NotNull(minAgg);
+        Assert.Equal(3, minAgg.Value);
+        var maxAgg = nestedPeerReviewsAgg.Aggregations.Max("max_peerReviews.rating");
+        Assert.NotNull(maxAgg);
+        Assert.Equal(5, maxAgg.Value);
+        var cardinalityAgg = nestedPeerReviewsAgg.Aggregations.Cardinality("cardinality_peerReviews.reviewerEmployeeId");
+        Assert.NotNull(cardinalityAgg);
+        Assert.Equal(3, cardinalityAgg.Value);
     }
 
     [Fact]
@@ -265,12 +277,14 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         var nestedPeerReviewsAggWithInclude = Assert.IsType<SingleBucketAggregate>(resultWithInclude.Aggregations["nested_peerReviews"]);
 
         var reviewerTermsAggWithInclude = nestedPeerReviewsAggWithInclude.Aggregations.Terms<string>("terms_peerReviews.reviewerEmployeeId");
-        Assert.Equal(2, reviewerTermsAggWithInclude.Buckets.Count); // Only employee1 and employee2 should be included
+        Assert.NotNull(reviewerTermsAggWithInclude);
+        Assert.Equal(2, reviewerTermsAggWithInclude.Buckets.Count);
         Assert.Contains(reviewerTermsAggWithInclude.Buckets, b => String.Equals(b.Key, "employee1"));
         Assert.Contains(reviewerTermsAggWithInclude.Buckets, b => String.Equals(b.Key, "employee2"));
         Assert.DoesNotContain(reviewerTermsAggWithInclude.Buckets, b => String.Equals(b.Key, "employee3"));
 
         var ratingTermsAggWithInclude = nestedPeerReviewsAggWithInclude.Aggregations.Terms<int>("terms_peerReviews.rating");
+        Assert.NotNull(ratingTermsAggWithInclude);
         Assert.Equal(2, ratingTermsAggWithInclude.Buckets.Count); // Only ratings 4 and 5 should be included
         Assert.Contains(ratingTermsAggWithInclude.Buckets, b => b.Key == 4);
         Assert.Contains(ratingTermsAggWithInclude.Buckets, b => b.Key == 5);
@@ -314,13 +328,15 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         var nestedPeerReviewsAggWithExclude = Assert.IsType<SingleBucketAggregate>(resultWithExclude.Aggregations["nested_peerReviews"]);
 
         var reviewerTermsAggWithExclude = nestedPeerReviewsAggWithExclude.Aggregations.Terms<string>("terms_peerReviews.reviewerEmployeeId");
-        Assert.Equal(2, reviewerTermsAggWithExclude.Buckets.Count); // employee3 should be excluded
+        Assert.NotNull(reviewerTermsAggWithExclude);
+        Assert.Equal(2, reviewerTermsAggWithExclude.Buckets.Count);
         Assert.Contains(reviewerTermsAggWithExclude.Buckets, b => String.Equals(b.Key, "employee1"));
         Assert.Contains(reviewerTermsAggWithExclude.Buckets, b => String.Equals(b.Key, "employee2"));
         Assert.DoesNotContain(reviewerTermsAggWithExclude.Buckets, b => String.Equals(b.Key, "employee3"));
 
         var ratingTermsAggWithExclude = nestedPeerReviewsAggWithExclude.Aggregations.Terms<int>("terms_peerReviews.rating");
-        Assert.Equal(2, ratingTermsAggWithExclude.Buckets.Count); // rating 3 should be excluded
+        Assert.NotNull(ratingTermsAggWithExclude);
+        Assert.Equal(2, ratingTermsAggWithExclude.Buckets.Count);
         Assert.Contains(ratingTermsAggWithExclude.Buckets, b => b.Key == 4);
         Assert.Contains(ratingTermsAggWithExclude.Buckets, b => b.Key == 5);
         Assert.DoesNotContain(ratingTermsAggWithExclude.Buckets, b => b.Key == 3);
@@ -361,6 +377,7 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         var nestedPeerReviewsAgg = Assert.IsType<SingleBucketAggregate>(result.Aggregations["nested_peerReviews"]);
 
         var ratingTermsAgg = nestedPeerReviewsAgg.Aggregations.Terms<int>("terms_peerReviews.rating");
+        Assert.NotNull(ratingTermsAgg);
         Assert.Equal(4, ratingTermsAgg.Buckets.Count);
         var bucket = ratingTermsAgg.Buckets.First(f => f.Key == 5);
         Assert.Equal(2, bucket.Total);
@@ -368,6 +385,7 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         // Test Newtonsoft.Json serialization
         string json = JsonConvert.SerializeObject(result);
         var roundTripped = JsonConvert.DeserializeObject<CountResult>(json);
+        Assert.NotNull(roundTripped);
         Assert.Equal(3, roundTripped.Total);
         Assert.Single(roundTripped.Aggregations);
 
@@ -386,12 +404,14 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
             System.Text.Json.Nodes.JsonNode.Parse(systemTextJson)),
             "Newtonsoft and System.Text.Json serialization should produce semantically equivalent JSON");
         roundTripped = System.Text.Json.JsonSerializer.Deserialize<CountResult>(systemTextJson);
+        Assert.NotNull(roundTripped);
         Assert.Equal(3, roundTripped.Total);
         Assert.Single(roundTripped.Aggregations);
 
         roundTrippedNestedAgg = Assert.IsType<SingleBucketAggregate>(roundTripped.Aggregations["nested_peerReviews"]);
 
         roundTrippedRatingTermsAgg = roundTrippedNestedAgg.Aggregations.Terms<int>("terms_peerReviews.rating");
+        Assert.NotNull(roundTrippedRatingTermsAgg);
         Assert.Equal(4, roundTrippedRatingTermsAgg.Buckets.Count);
         bucket = roundTrippedRatingTermsAgg.Buckets.First(f => f.Key == 5);
         Assert.Equal(2, bucket.Total);
@@ -657,6 +677,7 @@ public sealed class NestedFieldTests : ElasticRepositoryTestBase
         Assert.Contains("terms_peerReviews.rating", result.Aggregations.Keys);
 
         var ratingTermsAgg = result.Aggregations.Terms<int>("terms_peerReviews.rating");
+        Assert.NotNull(ratingTermsAgg);
         Assert.Equal(4, ratingTermsAgg.Buckets.Count);
         Assert.Equal(2, ratingTermsAgg.Buckets.First(b => b.Key == 5).Total);
         Assert.Equal(2, ratingTermsAgg.Buckets.First(b => b.Key == 4).Total);

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/QueryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/QueryTests.cs
@@ -103,7 +103,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         employee1 = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(age: 19, companyId: EmployeeGenerator.DefaultCompanyId), o => o.ImmediateConsistency());
 
         query = new RepositoryQuery<Employee>();
-        query.FieldEquals(e => e.Name, null);
+        query.FieldEquals(e => e.Name, (object?)null);
         result = await _employeeRepository.FindAsync(q => query);
         Assert.Single(result.Documents);
         Assert.Null(result.Documents.Single().Name);
@@ -115,7 +115,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.Null(result.Documents.Single().Name);
 
         query = new RepositoryQuery<Employee>();
-        query.FieldNotEquals(e => e.Name, null);
+        query.FieldNotEquals(e => e.Name, (object?)null);
         result = await _employeeRepository.FindAsync(q => query);
         Assert.Single(result.Documents);
         Assert.NotNull(result.Documents.Single().Name);
@@ -137,7 +137,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         ], o => o.ImmediateConsistency());
 
         // Act
-        var result = await _employeeRepository.FindAsync(q => q.FieldCondition(e => e.Name, ComparisonOperator.Contains, (object)null));
+        var result = await _employeeRepository.FindAsync(q => q.FieldCondition(e => e.Name, ComparisonOperator.Contains, (object?)null));
 
         // Assert — null Contains rewrites to IsEmpty, so finds the employee without a name
         Assert.Single(result.Documents);
@@ -154,7 +154,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         ], o => o.ImmediateConsistency());
 
         // Act
-        var result = await _employeeRepository.FindAsync(q => q.FieldCondition(e => e.Name, ComparisonOperator.NotContains, (object)null));
+        var result = await _employeeRepository.FindAsync(q => q.FieldCondition(e => e.Name, ComparisonOperator.NotContains, (object?)null));
 
         // Assert — null NotContains rewrites to HasValue, so finds the employee with a name
         Assert.Single(result.Documents);
@@ -290,7 +290,8 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.NotNull(log);
         Assert.NotNull(log.Id);
 
-        var companyLog = await _dailyRepository.GetByIdAsync(log!.Id, o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc"));
+        var companyLog = await _dailyRepository.GetByIdAsync(log.Id, o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc"));
+        Assert.NotNull(companyLog);
         Assert.Equal(log.Id, companyLog.Id);
         Assert.Equal(log.CreatedUtc, companyLog.CreatedUtc);
         Assert.Equal(default, companyLog.Date);
@@ -312,7 +313,8 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.Collection(_cache.Items, c => Assert.StartsWith("alias:daily-logevents-", c.Key));
 
         const string cacheKey = "company:1234567890";
-        var companyLog = await _dailyRepository.GetByIdAsync(log!.Id, o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
+        var companyLog = await _dailyRepository.GetByIdAsync(log.Id, o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
+        Assert.NotNull(companyLog);
         Assert.Equal(log.Id, companyLog.Id);
         Assert.Equal(log.CreatedUtc, companyLog.CreatedUtc);
         Assert.Equal(default, companyLog.Date);
@@ -326,7 +328,8 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.Collection(_cache.Items, c => Assert.StartsWith("alias:daily-logevents-", c.Key), c => Assert.Equal($"LogEvent:{cacheKey}", c.Key));
 
         // Ensure cache hit by cache key.
-        companyLog = await _dailyRepository.GetByIdAsync(log!.Id, o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
+        companyLog = await _dailyRepository.GetByIdAsync(log.Id, o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
+        Assert.NotNull(companyLog);
         Assert.Equal(log.Id, companyLog.Id);
         Assert.Equal(log.CreatedUtc, companyLog.CreatedUtc);
         Assert.Equal(default, companyLog.Date);
@@ -347,7 +350,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.NotNull(log);
         Assert.NotNull(log.Id);
 
-        var results = await _dailyRepository.GetByIdsAsync([log!.Id], o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc"));
+        var results = await _dailyRepository.GetByIdsAsync([log.Id], o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc"));
         Assert.Single(results);
         var companyLog = results.First();
         Assert.Equal(log.Id, companyLog.Id);
@@ -371,7 +374,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.Collection(_cache.Items, c => Assert.StartsWith("alias:daily-logevents-", c.Key));
 
         const string cacheKey = "company:1234567890";
-        var results = await _dailyRepository.GetByIdsAsync([log!.Id], o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
+        var results = await _dailyRepository.GetByIdsAsync([log.Id], o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
         Assert.Single(results);
         var companyLog = results.First();
         Assert.Equal(log.Id, companyLog.Id);
@@ -387,7 +390,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.Collection(_cache.Items, c => Assert.StartsWith("alias:daily-logevents-", c.Key), c => Assert.Equal($"LogEvent:{cacheKey}", c.Key));
 
         // Ensure cache hit by cache key.
-        results = await _dailyRepository.GetByIdsAsync([log!.Id], o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
+        results = await _dailyRepository.GetByIdsAsync([log.Id], o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
         Assert.Single(results);
         companyLog = results.First();
         Assert.Equal(log.Id, companyLog.Id);
@@ -965,7 +968,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         ], o => o.ImmediateConsistency());
 
         // Act
-        string nullValue = null;
+        string? nullValue = null;
         var result = await _employeeRepository.FindAsync(q => q
             .FieldEqualsIf(e => e.CompanyName, nullValue, condition: v => v is not null));
 
@@ -1748,7 +1751,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         {
             await _employeeRepository.FindAsync(q => q.FieldOr(g => g
                 .FieldEquals(f => f.CompanyName, "Acme")
-                .FieldCondition(f => f.Age, ComparisonOperator.GreaterThan, (object)null)
+                .FieldCondition(f => f.Age, ComparisonOperator.GreaterThan, (object?)null)
             ));
         });
 
@@ -1840,7 +1843,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         // Act & Assert
         var ex = await Assert.ThrowsAsync<FieldQueryValidationException>(async () =>
         {
-            await _employeeRepository.FindAsync(q => q.FieldGreaterThan(e => e.Age, null));
+            await _employeeRepository.FindAsync(q => q.FieldGreaterThan(e => e.Age, (object?)null));
         });
 
         Assert.Contains("null value", ex.Message);

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/QueryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/QueryTests.cs
@@ -580,7 +580,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
     [Fact]
     public async Task GetByEmailAddressFilter()
     {
-        var findResult = await _employeeRepository.GetByEmailAddressAsync(EmployeeGenerator.Default.EmailAddress);
+        var findResult = await _employeeRepository.GetByEmailAddressAsync(EmployeeGenerator.Default.EmailAddress!);
         Assert.Null(findResult);
         Assert.Equal(1, _cache.Writes);
         Assert.Equal(1, _cache.Count);
@@ -588,7 +588,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.Equal(2, _cache.Misses); // one for soft deleted ids
 
         // missing value should be cached
-        findResult = await _employeeRepository.GetByEmailAddressAsync(EmployeeGenerator.Default.EmailAddress);
+        findResult = await _employeeRepository.GetByEmailAddressAsync(EmployeeGenerator.Default.EmailAddress!);
         Assert.DoesNotContain(Log.LogEntries, l => l.LogLevel == LogLevel.Error);
         Assert.Null(findResult);
         Assert.Equal(1, _cache.Writes);

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/QueryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/QueryTests.cs
@@ -103,7 +103,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         employee1 = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(age: 19, companyId: EmployeeGenerator.DefaultCompanyId), o => o.ImmediateConsistency());
 
         query = new RepositoryQuery<Employee>();
-        query.FieldEquals(e => e.Name, null);
+        query.FieldEquals(e => e.Name, (object?)null);
         result = await _employeeRepository.FindAsync(q => query);
         Assert.Single(result.Documents);
         Assert.Null(result.Documents.Single().Name);
@@ -115,7 +115,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.Null(result.Documents.Single().Name);
 
         query = new RepositoryQuery<Employee>();
-        query.FieldNotEquals(e => e.Name, null);
+        query.FieldNotEquals(e => e.Name, (object?)null);
         result = await _employeeRepository.FindAsync(q => query);
         Assert.Single(result.Documents);
         Assert.NotNull(result.Documents.Single().Name);
@@ -137,7 +137,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         ], o => o.ImmediateConsistency());
 
         // Act
-        var result = await _employeeRepository.FindAsync(q => q.FieldCondition(e => e.Name, ComparisonOperator.Contains, (object)null));
+        var result = await _employeeRepository.FindAsync(q => q.FieldCondition(e => e.Name, ComparisonOperator.Contains, (object?)null));
 
         // Assert — null Contains rewrites to IsEmpty, so finds the employee without a name
         Assert.Single(result.Documents);
@@ -154,7 +154,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         ], o => o.ImmediateConsistency());
 
         // Act
-        var result = await _employeeRepository.FindAsync(q => q.FieldCondition(e => e.Name, ComparisonOperator.NotContains, (object)null));
+        var result = await _employeeRepository.FindAsync(q => q.FieldCondition(e => e.Name, ComparisonOperator.NotContains, (object?)null));
 
         // Assert — null NotContains rewrites to HasValue, so finds the employee with a name
         Assert.Single(result.Documents);
@@ -289,7 +289,8 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.NotNull(log);
         Assert.NotNull(log.Id);
 
-        var companyLog = await _dailyRepository.GetByIdAsync(log!.Id, o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc"));
+        var companyLog = await _dailyRepository.GetByIdAsync(log.Id, o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc"));
+        Assert.NotNull(companyLog);
         Assert.Equal(log.Id, companyLog.Id);
         Assert.Equal(log.CreatedUtc, companyLog.CreatedUtc);
         Assert.Equal(default, companyLog.Date);
@@ -311,7 +312,8 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.Collection(_cache.Items, c => Assert.StartsWith("alias:daily-logevents-", c.Key));
 
         const string cacheKey = "company:1234567890";
-        var companyLog = await _dailyRepository.GetByIdAsync(log!.Id, o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
+        var companyLog = await _dailyRepository.GetByIdAsync(log.Id, o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
+        Assert.NotNull(companyLog);
         Assert.Equal(log.Id, companyLog.Id);
         Assert.Equal(log.CreatedUtc, companyLog.CreatedUtc);
         Assert.Equal(default, companyLog.Date);
@@ -325,7 +327,8 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.Collection(_cache.Items, c => Assert.StartsWith("alias:daily-logevents-", c.Key), c => Assert.Equal($"LogEvent:{cacheKey}", c.Key));
 
         // Ensure cache hit by cache key.
-        companyLog = await _dailyRepository.GetByIdAsync(log!.Id, o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
+        companyLog = await _dailyRepository.GetByIdAsync(log.Id, o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
+        Assert.NotNull(companyLog);
         Assert.Equal(log.Id, companyLog.Id);
         Assert.Equal(log.CreatedUtc, companyLog.CreatedUtc);
         Assert.Equal(default, companyLog.Date);
@@ -346,7 +349,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.NotNull(log);
         Assert.NotNull(log.Id);
 
-        var results = await _dailyRepository.GetByIdsAsync([log!.Id], o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc"));
+        var results = await _dailyRepository.GetByIdsAsync([log.Id], o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc"));
         Assert.Single(results);
         var companyLog = results.First();
         Assert.Equal(log.Id, companyLog.Id);
@@ -370,7 +373,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.Collection(_cache.Items, c => Assert.StartsWith("alias:daily-logevents-", c.Key));
 
         const string cacheKey = "company:1234567890";
-        var results = await _dailyRepository.GetByIdsAsync([log!.Id], o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
+        var results = await _dailyRepository.GetByIdsAsync([log.Id], o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
         Assert.Single(results);
         var companyLog = results.First();
         Assert.Equal(log.Id, companyLog.Id);
@@ -386,7 +389,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         Assert.Collection(_cache.Items, c => Assert.StartsWith("alias:daily-logevents-", c.Key), c => Assert.Equal($"LogEvent:{cacheKey}", c.Key));
 
         // Ensure cache hit by cache key.
-        results = await _dailyRepository.GetByIdsAsync([log!.Id], o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
+        results = await _dailyRepository.GetByIdsAsync([log.Id], o => o.QueryLogLevel(LogLevel.Warning).Exclude(e => e.Date).Include(e => e.Id).Include("createdUtc").Cache(cacheKey));
         Assert.Single(results);
         companyLog = results.First();
         Assert.Equal(log.Id, companyLog.Id);
@@ -964,7 +967,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         ], o => o.ImmediateConsistency());
 
         // Act
-        string nullValue = null;
+        string? nullValue = null;
         var result = await _employeeRepository.FindAsync(q => q
             .FieldEqualsIf(e => e.CompanyName, nullValue, condition: v => v is not null));
 
@@ -1747,7 +1750,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         {
             await _employeeRepository.FindAsync(q => q.FieldOr(g => g
                 .FieldEquals(f => f.CompanyName, "Acme")
-                .FieldCondition(f => f.Age, ComparisonOperator.GreaterThan, (object)null)
+                .FieldCondition(f => f.Age, ComparisonOperator.GreaterThan, (object?)null)
             ));
         });
 
@@ -1839,7 +1842,7 @@ public sealed class QueryTests : ElasticRepositoryTestBase
         // Act & Assert
         var ex = await Assert.ThrowsAsync<FieldQueryValidationException>(async () =>
         {
-            await _employeeRepository.FindAsync(q => q.FieldGreaterThan(e => e.Age, null));
+            await _employeeRepository.FindAsync(q => q.FieldGreaterThan(e => e.Age, (object?)null));
         });
 
         Assert.Contains("null value", ex.Message);

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
@@ -167,11 +167,11 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
     [Fact]
     public async Task InvalidateCacheWithInvalidArgumentsAsync()
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await _identityRepository.InvalidateCacheAsync((Identity)null));
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await _identityRepository.InvalidateCacheAsync((IReadOnlyCollection<Identity>)null));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await _identityRepository.InvalidateCacheAsync((Identity)null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await _identityRepository.InvalidateCacheAsync((IReadOnlyCollection<Identity>)null!));
         await _identityRepository.InvalidateCacheAsync(new List<Identity>());
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await _identityRepository.InvalidateCacheAsync(new List<Identity> {
-            null
+            null!
         }));
     }
 
@@ -268,34 +268,34 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(0, _cache.Hits);
         Assert.Equal(0, _cache.Misses);
 
-        Assert.Equal(identity, await _identityRepository.GetByIdAsync(identity.Id, o => o.Cache(null)));
+        Assert.Equal(identity, await _identityRepository.GetByIdAsync(identity.Id, o => o.Cache(null!)));
         Assert.Equal(1, _cache.Count);
         Assert.Equal(0, _cache.Hits);
         Assert.Equal(1, _cache.Misses);
 
-        Assert.Equal(identity, await _identityRepository.GetByIdAsync(identity.Id, o => o.Cache(null)));
+        Assert.Equal(identity, await _identityRepository.GetByIdAsync(identity.Id, o => o.Cache(null!)));
         Assert.Equal(1, _cache.Count);
         Assert.Equal(1, _cache.Hits);
         Assert.Equal(1, _cache.Misses);
 
-        Assert.Null(await _identityRepository.GetByIdAsync("not-yet", o => o.Cache(null)));
+        Assert.Null(await _identityRepository.GetByIdAsync("not-yet", o => o.Cache(null!)));
         Assert.Equal(2, _cache.Count);
         Assert.Equal(1, _cache.Hits);
         Assert.Equal(2, _cache.Misses);
 
-        Assert.Null(await _identityRepository.GetByIdAsync("not-yet", o => o.Cache(null)));
+        Assert.Null(await _identityRepository.GetByIdAsync("not-yet", o => o.Cache(null!)));
         Assert.Equal(2, _cache.Count);
         Assert.Equal(2, _cache.Hits);
         Assert.Equal(2, _cache.Misses);
 
-        var newIdentity = await _identityRepository.AddAsync(IdentityGenerator.Generate("not-yet"), o => o.Cache(null));
+        var newIdentity = await _identityRepository.AddAsync(IdentityGenerator.Generate("not-yet"), o => o.Cache(null!));
         Assert.NotNull(newIdentity);
         Assert.NotNull(newIdentity.Id);
         Assert.Equal(2, _cache.Count);
         Assert.Equal(2, _cache.Hits);
         Assert.Equal(2, _cache.Misses);
 
-        Assert.Equal(newIdentity, await _identityRepository.GetByIdAsync("not-yet", o => o.Cache(null)));
+        Assert.Equal(newIdentity, await _identityRepository.GetByIdAsync("not-yet", o => o.Cache(null!)));
         Assert.Equal(2, _cache.Count);
         Assert.Equal(3, _cache.Hits);
         Assert.Equal(2, _cache.Misses);
@@ -406,10 +406,10 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.NotNull(identity);
         Assert.NotNull(identity.Id);
 
-        var result = await _identityRepository.GetByIdsAsync((Ids)null);
+        var result = await _identityRepository.GetByIdsAsync((Ids)null!);
         Assert.Empty(result);
 
-        result = await _identityRepository.GetByIdsAsync(new string[] { null });
+        result = await _identityRepository.GetByIdsAsync(new string[] { null! });
         Assert.Empty(result);
 
         result = await _identityRepository.GetByIdsAsync(new[] { IdentityGenerator.Default.Id, identity.Id });
@@ -481,19 +481,19 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.NotNull(identity);
         Assert.NotNull(identity.Id);
 
-        var result = await _identityRepository.GetByIdsAsync((Ids)null, o => o.Cache());
+        var result = await _identityRepository.GetByIdsAsync((Ids)null!, o => o.Cache());
         Assert.Empty(result);
         Assert.Equal(0, _cache.Count);
         Assert.Equal(0, _cache.Hits);
         Assert.Equal(0, _cache.Misses);
 
-        result = await _identityRepository.GetByIdsAsync(new Ids((string)null), o => o.Cache());
+        result = await _identityRepository.GetByIdsAsync(new Ids((string)null!), o => o.Cache());
         Assert.Empty(result);
         Assert.Equal(0, _cache.Count);
         Assert.Equal(0, _cache.Hits);
         Assert.Equal(0, _cache.Misses);
 
-        result = await _identityRepository.GetByIdsAsync(new Ids(IdentityGenerator.Default.Id, identity.Id, null), o => o.Cache());
+        result = await _identityRepository.GetByIdsAsync(new Ids(IdentityGenerator.Default.Id, identity.Id, null!), o => o.Cache());
         Assert.Single(result);
         Assert.Equal(2, _cache.Count);
         Assert.Equal(0, _cache.Hits);
@@ -708,12 +708,12 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(identity1.Id, results.Documents.First().Id);
         Assert.Equal(2, results.Total);
 
-        string asyncQueryId = results.GetAsyncQueryId();
+        string? asyncQueryId = results.GetAsyncQueryId();
         Assert.Null(asyncQueryId);
         Assert.False(results.IsAsyncQueryPartial());
         Assert.False(results.IsAsyncQueryRunning());
 
-        results = await _identityRepository.GetAllAsync(o => o.AsyncQueryId(asyncQueryId, TimeSpan.FromMinutes(1)));
+        results = await _identityRepository.GetAllAsync(o => o.AsyncQueryId(asyncQueryId!, TimeSpan.FromMinutes(1)));
         Assert.NotNull(results);
         Assert.Equal(2, results.Documents.Count);
         Assert.Equal(1, results.Page);
@@ -725,7 +725,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.False(results.IsAsyncQueryPartial());
         Assert.False(results.IsAsyncQueryRunning());
 
-        results = await _identityRepository.GetAllAsync(o => o.AsyncQueryId(asyncQueryId, TimeSpan.FromMinutes(1), autoDelete: true));
+        results = await _identityRepository.GetAllAsync(o => o.AsyncQueryId(asyncQueryId!, TimeSpan.FromMinutes(1), autoDelete: true));
         Assert.NotNull(results);
         Assert.Equal(2, results.Documents.Count);
         Assert.Equal(1, results.Page);
@@ -755,13 +755,13 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         await _identityRepository.RemoveQueryAsync(asyncQueryId);
 
         // getting query that doesn't exist returns empty (don't love it, but other things are doing similar)
-        await Assert.ThrowsAsync<AsyncQueryNotFoundException>(() => _identityRepository.GetAllAsync(o => o.AsyncQueryId(asyncQueryId)));
+        await Assert.ThrowsAsync<AsyncQueryNotFoundException>(() => _identityRepository.GetAllAsync(o => o.AsyncQueryId(asyncQueryId!)));
 
         // removing query that does not exist to make sure it doesn't throw
         await _identityRepository.RemoveQueryAsync(asyncQueryId);
 
         // setting to null is ignored
-        await _identityRepository.GetAllAsync(o => o.AsyncQueryId(null));
+        await _identityRepository.GetAllAsync(o => o.AsyncQueryId(null!));
     }
 
     [Fact]
@@ -779,12 +779,12 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.NotNull(results);
         Assert.Equal(2, results);
 
-        string asyncQueryId = results.GetAsyncQueryId();
+        string? asyncQueryId = results.GetAsyncQueryId();
         Assert.Null(asyncQueryId);
         Assert.False(results.IsAsyncQueryPartial());
         Assert.False(results.IsAsyncQueryRunning());
 
-        results = await _identityRepository.CountAsync(o => o.AsyncQueryId(asyncQueryId, TimeSpan.FromMinutes(1)));
+        results = await _identityRepository.CountAsync(o => o.AsyncQueryId(asyncQueryId!, TimeSpan.FromMinutes(1)));
         Assert.NotNull(results);
         Assert.Equal(2, results);
         Assert.Equal(2, results.Total);
@@ -793,7 +793,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.False(results.IsAsyncQueryPartial());
         Assert.False(results.IsAsyncQueryRunning());
 
-        results = await _identityRepository.CountAsync(o => o.AsyncQueryId(asyncQueryId, TimeSpan.FromMinutes(1), autoDelete: true));
+        results = await _identityRepository.CountAsync(o => o.AsyncQueryId(asyncQueryId!, TimeSpan.FromMinutes(1), autoDelete: true));
         Assert.NotNull(results);
         Assert.Equal(2, results);
         Assert.Equal(2, results.Total);
@@ -817,13 +817,13 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         await _identityRepository.RemoveQueryAsync(asyncQueryId);
 
         // getting query that doesn't exist returns empty (don't love it, but other things are doing similar)
-        results = await _identityRepository.CountAsync(o => o.AsyncQueryId(asyncQueryId));
+        await _identityRepository.CountAsync(o => o.AsyncQueryId(asyncQueryId!));
 
         // removing query that does not exist to make sure it doesn't throw
         await _identityRepository.RemoveQueryAsync(asyncQueryId);
 
         // setting to null is ignored
-        await _identityRepository.GetAllAsync(o => o.AsyncQueryId(null));
+        await _identityRepository.GetAllAsync(o => o.AsyncQueryId(null!));
     }
 
     [Fact]
@@ -853,7 +853,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.NotNull(employee2);
         Assert.NotNull(employee2.Id);
 
-        var results = await _employeeRepository.FindAsync(q => q.FilterExpression("unmappedcompanyname:" + employee1.CompanyName), o => o.RuntimeFieldResolver(f => String.Equals(f, "unmappedCompanyName", StringComparison.OrdinalIgnoreCase) ? Task.FromResult(new ElasticRuntimeField { Name = "unmappedCompanyName", FieldType = ElasticRuntimeFieldType.Keyword }) : Task.FromResult<ElasticRuntimeField>(null)));
+        var results = await _employeeRepository.FindAsync(q => q.FilterExpression("unmappedcompanyname:" + employee1.CompanyName), o => o.RuntimeFieldResolver(f => String.Equals(f, "unmappedCompanyName", StringComparison.OrdinalIgnoreCase) ? Task.FromResult(new ElasticRuntimeField { Name = "unmappedCompanyName", FieldType = ElasticRuntimeFieldType.Keyword }) : Task.FromResult<ElasticRuntimeField>(null!)));
         Assert.NotNull(results);
         Assert.Single(results.Documents);
     }
@@ -901,7 +901,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(employee1.Id, results.Documents.First().Id);
         Assert.Equal(2, results.Total);
         Assert.Null(results.GetSearchBeforeToken());
-        Assert.NotEmpty(results.GetSearchAfterToken());
+        Assert.NotEmpty(results.GetSearchAfterToken()!);
 
         Assert.True(await results.NextPageAsync());
         Assert.Single(results.Documents);
@@ -909,8 +909,8 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(2, results.Total);
         Assert.Equal(employee2.Id, results.Documents.First().Id);
         Assert.False(results.HasMore);
-        string searchBeforeToken = results.GetSearchBeforeToken();
-        Assert.NotEmpty(searchBeforeToken);
+        string? searchBeforeToken = results.GetSearchBeforeToken();
+        Assert.NotEmpty(searchBeforeToken!);
         Assert.Null(results.GetSearchAfterToken());
 
         Assert.False(await results.NextPageAsync());
@@ -928,10 +928,10 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(employee1.Id, results.Documents.First().Id);
         Assert.Equal(2, results.Total);
         Assert.Null(results.GetSearchBeforeToken());
-        Assert.NotEmpty(results.GetSearchAfterToken());
+        Assert.NotEmpty(results.GetSearchAfterToken()!);
 
         // try search before
-        results = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(1).SearchBeforeToken(searchBeforeToken));
+        results = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(1).SearchBeforeToken(searchBeforeToken!));
         Assert.NotNull(results);
         Assert.Single(results.Documents);
         Assert.Equal(1, results.Page);
@@ -939,7 +939,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(employee1.Id, results.Documents.First().Id);
         Assert.Equal(2, results.Total);
         Assert.Null(results.GetSearchBeforeToken());
-        Assert.NotEmpty(results.GetSearchAfterToken());
+        Assert.NotEmpty(results.GetSearchAfterToken()!);
 
         results = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(5).SearchAfterPaging());
         Assert.NotNull(results);
@@ -1013,7 +1013,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
 
         // Act
         var results = await _identityRepository.GetAllAsync(o => o.PageLimit(10));
-        var viewedIds = new HashSet<string>();
+        var viewedIds = new HashSet<string?>();
         int pagedRecords = 0;
         do
         {
@@ -1052,7 +1052,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
 
         // Act
         var results = await _identityRepository.FindAsync(q => q, o => o.PageLimit(10));
-        var viewedIds = new HashSet<string>();
+        var viewedIds = new HashSet<string?>();
         int pagedRecords = 0;
         do
         {
@@ -1085,13 +1085,13 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(identity2.Id, results.Documents.First().Id);
         Assert.Equal(2, results.Total);
 
-        results = await _identityRepository.FindAsync(q => q.SortDescending(d => d.Id), o => o.PageLimit(1).SearchAfter(results.Hits.First().GetSorts()));
+        results = await _identityRepository.FindAsync(q => q.SortDescending(d => d.Id), o => o.PageLimit(1).SearchAfter(results.Hits.First().GetSorts()!));
         Assert.Single(results.Documents);
         Assert.Equal(2, results.Total);
         Assert.Equal(identity1.Id, results.Documents.First().Id);
         Assert.False(results.HasMore);
 
-        results = await _identityRepository.FindAsync(q => q.SortDescending(d => d.Id), o => o.PageLimit(1).SearchAfter(results.Hits.First().GetSorts()));
+        results = await _identityRepository.FindAsync(q => q.SortDescending(d => d.Id), o => o.PageLimit(1).SearchAfter(results.Hits.First().GetSorts()!));
         Assert.Empty(results.Documents);
         Assert.Equal(1, results.Page);
         Assert.False(results.HasMore);
@@ -1299,13 +1299,13 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         int pageSize = 10;
 
         var employeePages = new List<FindResults<Employee>>();
-        string searchAfterToken = null;
-        string searchBeforeToken = null;
+        string? searchAfterToken = null;
+        string? searchBeforeToken = null;
         int page = 0;
         do
         {
             page++;
-            var employees = await _employeeRepository.FindAsync(q => q.Sort(e => e.Name).Sort(e => e.CompanyName).SortDescending(secondarySort), o => o.SearchAfterToken(searchAfterToken).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
+            var employees = await _employeeRepository.FindAsync(q => q.Sort(e => e.Name).Sort(e => e.CompanyName).SortDescending(secondarySort), o => o.SearchAfterToken(searchAfterToken!).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
             searchBeforeToken = employees.GetSearchBeforeToken();
             searchAfterToken = employees.GetSearchAfterToken();
             if (page == 1)
@@ -1345,7 +1345,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         do
         {
             page--;
-            var employees = await _employeeRepository.FindAsync(q => q.Sort(e => e.Name).Sort(e => e.CompanyName).SortDescending(e => e.Age), o => o.SearchBeforeToken(searchBeforeToken).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
+            var employees = await _employeeRepository.FindAsync(q => q.Sort(e => e.Name).Sort(e => e.CompanyName).SortDescending(e => e.Age), o => o.SearchBeforeToken(searchBeforeToken!).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
             searchBeforeToken = employees.GetSearchBeforeToken();
             searchAfterToken = employees.GetSearchAfterToken();
             if (page == 1)
@@ -1377,13 +1377,13 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         int pageSize = 10;
 
         var employeePages = new List<FindResults<Employee>>();
-        string searchAfterToken = null;
-        string searchBeforeToken = null;
+        string? searchAfterToken = null;
+        string? searchBeforeToken = null;
         int page = 0;
         do
         {
             page++;
-            var employees = await _employeeRepository.FindAsync(q => q.SortExpression("name companyname -age"), o => o.SearchAfterToken(searchAfterToken).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
+            var employees = await _employeeRepository.FindAsync(q => q.SortExpression("name companyname -age"), o => o.SearchAfterToken(searchAfterToken!).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
             searchBeforeToken = employees.GetSearchBeforeToken();
             searchAfterToken = employees.GetSearchAfterToken();
             if (page == 1)
@@ -1423,7 +1423,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         do
         {
             page--;
-            var employees = await _employeeRepository.FindAsync(q => q.SortExpression("name companyname -age"), o => o.SearchBeforeToken(searchBeforeToken).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
+            var employees = await _employeeRepository.FindAsync(q => q.SortExpression("name companyname -age"), o => o.SearchBeforeToken(searchBeforeToken!).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
             searchBeforeToken = employees.GetSearchBeforeToken();
             searchAfterToken = employees.GetSearchAfterToken();
             if (page == 1)

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
@@ -167,11 +167,11 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
     [Fact]
     public async Task InvalidateCacheWithInvalidArgumentsAsync()
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await _identityRepository.InvalidateCacheAsync((Identity)null));
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await _identityRepository.InvalidateCacheAsync((IReadOnlyCollection<Identity>)null));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await _identityRepository.InvalidateCacheAsync((Identity)null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await _identityRepository.InvalidateCacheAsync((IReadOnlyCollection<Identity>)null!));
         await _identityRepository.InvalidateCacheAsync(new List<Identity>());
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await _identityRepository.InvalidateCacheAsync(new List<Identity> {
-            null
+            null!
         }));
     }
 
@@ -268,34 +268,34 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(0, _cache.Hits);
         Assert.Equal(0, _cache.Misses);
 
-        Assert.Equal(identity, await _identityRepository.GetByIdAsync(identity.Id, o => o.Cache(null)));
+        Assert.Equal(identity, await _identityRepository.GetByIdAsync(identity.Id, o => o.Cache(null!)));
         Assert.Equal(1, _cache.Count);
         Assert.Equal(0, _cache.Hits);
         Assert.Equal(1, _cache.Misses);
 
-        Assert.Equal(identity, await _identityRepository.GetByIdAsync(identity.Id, o => o.Cache(null)));
+        Assert.Equal(identity, await _identityRepository.GetByIdAsync(identity.Id, o => o.Cache(null!)));
         Assert.Equal(1, _cache.Count);
         Assert.Equal(1, _cache.Hits);
         Assert.Equal(1, _cache.Misses);
 
-        Assert.Null(await _identityRepository.GetByIdAsync("not-yet", o => o.Cache(null)));
+        Assert.Null(await _identityRepository.GetByIdAsync("not-yet", o => o.Cache(null!)));
         Assert.Equal(2, _cache.Count);
         Assert.Equal(1, _cache.Hits);
         Assert.Equal(2, _cache.Misses);
 
-        Assert.Null(await _identityRepository.GetByIdAsync("not-yet", o => o.Cache(null)));
+        Assert.Null(await _identityRepository.GetByIdAsync("not-yet", o => o.Cache(null!)));
         Assert.Equal(2, _cache.Count);
         Assert.Equal(2, _cache.Hits);
         Assert.Equal(2, _cache.Misses);
 
-        var newIdentity = await _identityRepository.AddAsync(IdentityGenerator.Generate("not-yet"), o => o.Cache(null));
+        var newIdentity = await _identityRepository.AddAsync(IdentityGenerator.Generate("not-yet"), o => o.Cache(null!));
         Assert.NotNull(newIdentity);
         Assert.NotNull(newIdentity.Id);
         Assert.Equal(2, _cache.Count);
         Assert.Equal(2, _cache.Hits);
         Assert.Equal(2, _cache.Misses);
 
-        Assert.Equal(newIdentity, await _identityRepository.GetByIdAsync("not-yet", o => o.Cache(null)));
+        Assert.Equal(newIdentity, await _identityRepository.GetByIdAsync("not-yet", o => o.Cache(null!)));
         Assert.Equal(2, _cache.Count);
         Assert.Equal(3, _cache.Hits);
         Assert.Equal(2, _cache.Misses);
@@ -407,10 +407,10 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.NotNull(identity);
         Assert.NotNull(identity.Id);
 
-        var result = await _identityRepository.GetByIdsAsync((Ids)null);
+        var result = await _identityRepository.GetByIdsAsync((Ids)null!);
         Assert.Empty(result);
 
-        result = await _identityRepository.GetByIdsAsync(new string[] { null });
+        result = await _identityRepository.GetByIdsAsync(new string[] { null! });
         Assert.Empty(result);
 
         result = await _identityRepository.GetByIdsAsync(new[] { IdentityGenerator.Default.Id, identity.Id });
@@ -482,19 +482,19 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.NotNull(identity);
         Assert.NotNull(identity.Id);
 
-        var result = await _identityRepository.GetByIdsAsync((Ids)null, o => o.Cache());
+        var result = await _identityRepository.GetByIdsAsync((Ids)null!, o => o.Cache());
         Assert.Empty(result);
         Assert.Equal(0, _cache.Count);
         Assert.Equal(0, _cache.Hits);
         Assert.Equal(0, _cache.Misses);
 
-        result = await _identityRepository.GetByIdsAsync(new Ids((string)null), o => o.Cache());
+        result = await _identityRepository.GetByIdsAsync(new Ids((string)null!), o => o.Cache());
         Assert.Empty(result);
         Assert.Equal(0, _cache.Count);
         Assert.Equal(0, _cache.Hits);
         Assert.Equal(0, _cache.Misses);
 
-        result = await _identityRepository.GetByIdsAsync(new Ids(IdentityGenerator.Default.Id, identity.Id, null), o => o.Cache());
+        result = await _identityRepository.GetByIdsAsync(new Ids(IdentityGenerator.Default.Id, identity.Id, null!), o => o.Cache());
         Assert.Single(result);
         Assert.Equal(2, _cache.Count);
         Assert.Equal(0, _cache.Hits);
@@ -689,8 +689,8 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
     private async Task<long> GetCurrentScrollCountAsync()
     {
         var stats = await _client.Nodes.StatsAsync();
-        var nodeStats = stats.Nodes.First().Value;
-        return nodeStats.Indices.Search.ScrollCurrent;
+        var nodeStats = stats.Nodes!.First().Value;
+        return nodeStats.Indices!.Search!.ScrollCurrent;
     }
 
     [Fact]
@@ -712,12 +712,12 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(identity1.Id, results.Documents.First().Id);
         Assert.Equal(2, results.Total);
 
-        string asyncQueryId = results.GetAsyncQueryId();
+        string? asyncQueryId = results.GetAsyncQueryId();
         Assert.Null(asyncQueryId);
         Assert.False(results.IsAsyncQueryPartial());
         Assert.False(results.IsAsyncQueryRunning());
 
-        results = await _identityRepository.GetAllAsync(o => o.AsyncQueryId(asyncQueryId, TimeSpan.FromMinutes(1)));
+        results = await _identityRepository.GetAllAsync(o => o.AsyncQueryId(asyncQueryId!, TimeSpan.FromMinutes(1)));
         Assert.NotNull(results);
         Assert.Equal(2, results.Documents.Count);
         Assert.Equal(1, results.Page);
@@ -729,7 +729,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.False(results.IsAsyncQueryPartial());
         Assert.False(results.IsAsyncQueryRunning());
 
-        results = await _identityRepository.GetAllAsync(o => o.AsyncQueryId(asyncQueryId, TimeSpan.FromMinutes(1), autoDelete: true));
+        results = await _identityRepository.GetAllAsync(o => o.AsyncQueryId(asyncQueryId!, TimeSpan.FromMinutes(1), autoDelete: true));
         Assert.NotNull(results);
         Assert.Equal(2, results.Documents.Count);
         Assert.Equal(1, results.Page);
@@ -759,13 +759,13 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         await _identityRepository.RemoveQueryAsync(asyncQueryId);
 
         // getting query that doesn't exist returns empty (don't love it, but other things are doing similar)
-        await Assert.ThrowsAsync<AsyncQueryNotFoundException>(() => _identityRepository.GetAllAsync(o => o.AsyncQueryId(asyncQueryId)));
+        await Assert.ThrowsAsync<AsyncQueryNotFoundException>(() => _identityRepository.GetAllAsync(o => o.AsyncQueryId(asyncQueryId!)));
 
         // removing query that does not exist to make sure it doesn't throw
         await _identityRepository.RemoveQueryAsync(asyncQueryId);
 
         // setting to null is ignored
-        await _identityRepository.GetAllAsync(o => o.AsyncQueryId(null));
+        await _identityRepository.GetAllAsync(o => o.AsyncQueryId(null!));
     }
 
     [Fact]
@@ -783,12 +783,12 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.NotNull(results);
         Assert.Equal(2, results);
 
-        string asyncQueryId = results.GetAsyncQueryId();
+        string? asyncQueryId = results.GetAsyncQueryId();
         Assert.Null(asyncQueryId);
         Assert.False(results.IsAsyncQueryPartial());
         Assert.False(results.IsAsyncQueryRunning());
 
-        results = await _identityRepository.CountAsync(o => o.AsyncQueryId(asyncQueryId, TimeSpan.FromMinutes(1)));
+        results = await _identityRepository.CountAsync(o => o.AsyncQueryId(asyncQueryId!, TimeSpan.FromMinutes(1)));
         Assert.NotNull(results);
         Assert.Equal(2, results);
         Assert.Equal(2, results.Total);
@@ -797,7 +797,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.False(results.IsAsyncQueryPartial());
         Assert.False(results.IsAsyncQueryRunning());
 
-        results = await _identityRepository.CountAsync(o => o.AsyncQueryId(asyncQueryId, TimeSpan.FromMinutes(1), autoDelete: true));
+        results = await _identityRepository.CountAsync(o => o.AsyncQueryId(asyncQueryId!, TimeSpan.FromMinutes(1), autoDelete: true));
         Assert.NotNull(results);
         Assert.Equal(2, results);
         Assert.Equal(2, results.Total);
@@ -821,13 +821,13 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         await _identityRepository.RemoveQueryAsync(asyncQueryId);
 
         // getting query that doesn't exist returns empty (don't love it, but other things are doing similar)
-        results = await _identityRepository.CountAsync(o => o.AsyncQueryId(asyncQueryId));
+        await _identityRepository.CountAsync(o => o.AsyncQueryId(asyncQueryId!));
 
         // removing query that does not exist to make sure it doesn't throw
         await _identityRepository.RemoveQueryAsync(asyncQueryId);
 
         // setting to null is ignored
-        await _identityRepository.GetAllAsync(o => o.AsyncQueryId(null));
+        await _identityRepository.GetAllAsync(o => o.AsyncQueryId(null!));
     }
 
     [Fact]
@@ -857,7 +857,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.NotNull(employee2);
         Assert.NotNull(employee2.Id);
 
-        var results = await _employeeRepository.FindAsync(q => q.FilterExpression($"unmappedcompanyname:{employee1.CompanyName}"), o => o.RuntimeFieldResolver(f => String.Equals(f, "unmappedCompanyName", StringComparison.OrdinalIgnoreCase) ? Task.FromResult(new ElasticRuntimeField { Name = "unmappedCompanyName", FieldType = ElasticRuntimeFieldType.Keyword }) : Task.FromResult<ElasticRuntimeField>(null)));
+        var results = await _employeeRepository.FindAsync(q => q.FilterExpression($"unmappedcompanyname:{employee1.CompanyName}"), o => o.RuntimeFieldResolver(f => String.Equals(f, "unmappedCompanyName", StringComparison.OrdinalIgnoreCase) ? Task.FromResult(new ElasticRuntimeField { Name = "unmappedCompanyName", FieldType = ElasticRuntimeFieldType.Keyword }) : Task.FromResult<ElasticRuntimeField>(null!)));
         Assert.NotNull(results);
         Assert.Single(results.Documents);
     }
@@ -905,7 +905,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(employee1.Id, results.Documents.First().Id);
         Assert.Equal(2, results.Total);
         Assert.Null(results.GetSearchBeforeToken());
-        Assert.NotEmpty(results.GetSearchAfterToken());
+        Assert.NotEmpty(results.GetSearchAfterToken()!);
 
         Assert.True(await results.NextPageAsync());
         Assert.Single(results.Documents);
@@ -913,8 +913,8 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(2, results.Total);
         Assert.Equal(employee2.Id, results.Documents.First().Id);
         Assert.False(results.HasMore);
-        string searchBeforeToken = results.GetSearchBeforeToken();
-        Assert.NotEmpty(searchBeforeToken);
+        string? searchBeforeToken = results.GetSearchBeforeToken();
+        Assert.NotEmpty(searchBeforeToken!);
         Assert.Null(results.GetSearchAfterToken());
 
         Assert.False(await results.NextPageAsync());
@@ -932,10 +932,10 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(employee1.Id, results.Documents.First().Id);
         Assert.Equal(2, results.Total);
         Assert.Null(results.GetSearchBeforeToken());
-        Assert.NotEmpty(results.GetSearchAfterToken());
+        Assert.NotEmpty(results.GetSearchAfterToken()!);
 
         // try search before
-        results = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(1).SearchBeforeToken(searchBeforeToken, _serializer));
+        results = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(1).SearchBeforeToken(searchBeforeToken!, _serializer));
         Assert.NotNull(results);
         Assert.Single(results.Documents);
         Assert.Equal(1, results.Page);
@@ -943,7 +943,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(employee1.Id, results.Documents.First().Id);
         Assert.Equal(2, results.Total);
         Assert.Null(results.GetSearchBeforeToken());
-        Assert.NotEmpty(results.GetSearchAfterToken());
+        Assert.NotEmpty(results.GetSearchAfterToken()!);
 
         results = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(5).SearchAfterPaging());
         Assert.NotNull(results);
@@ -1012,7 +1012,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         await _identityRepository.AddAsync(identities, o => o.ImmediateConsistency());
 
         var results = await _identityRepository.GetAllAsync(o => o.PageLimit(10));
-        var viewedIds = new HashSet<string>();
+        var viewedIds = new HashSet<string?>();
         int pagedRecords = 0;
         do
         {
@@ -1045,7 +1045,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         await _identityRepository.AddAsync(identities, o => o.ImmediateConsistency());
 
         var results = await _identityRepository.FindAsync(q => q, o => o.PageLimit(10));
-        var viewedIds = new HashSet<string>();
+        var viewedIds = new HashSet<string?>();
         int pagedRecords = 0;
         do
         {
@@ -1077,13 +1077,13 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(identity2.Id, results.Documents.First().Id);
         Assert.Equal(2, results.Total);
 
-        results = await _identityRepository.FindAsync(q => q.SortDescending(d => d.Id), o => o.PageLimit(1).SearchAfter(results.Hits.First().GetSorts()));
+        results = await _identityRepository.FindAsync(q => q.SortDescending(d => d.Id), o => o.PageLimit(1).SearchAfter(results.Hits.First().GetSorts()!));
         Assert.Single(results.Documents);
         Assert.Equal(2, results.Total);
         Assert.Equal(identity1.Id, results.Documents.First().Id);
         Assert.False(results.HasMore);
 
-        results = await _identityRepository.FindAsync(q => q.SortDescending(d => d.Id), o => o.PageLimit(1).SearchAfter(results.Hits.First().GetSorts()));
+        results = await _identityRepository.FindAsync(q => q.SortDescending(d => d.Id), o => o.PageLimit(1).SearchAfter(results.Hits.First().GetSorts()!));
         Assert.Empty(results.Documents);
         Assert.Equal(1, results.Page);
         Assert.False(results.HasMore);
@@ -1290,13 +1290,13 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         int pageSize = 10;
 
         var employeePages = new List<FindResults<Employee>>();
-        string searchAfterToken = null;
-        string searchBeforeToken = null;
+        string? searchAfterToken = null;
+        string? searchBeforeToken = null;
         int page = 0;
         do
         {
             page++;
-            var employees = await _employeeRepository.FindAsync(q => q.Sort(e => e.Name).Sort(e => e.CompanyName).SortDescending(secondarySort), o => o.SearchAfterToken(searchAfterToken, _serializer).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
+            var employees = await _employeeRepository.FindAsync(q => q.Sort(e => e.Name).Sort(e => e.CompanyName).SortDescending(secondarySort), o => o.SearchAfterToken(searchAfterToken!, _serializer).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
             searchBeforeToken = employees.GetSearchBeforeToken();
             searchAfterToken = employees.GetSearchAfterToken();
             if (page == 1)
@@ -1336,7 +1336,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         do
         {
             page--;
-            var employees = await _employeeRepository.FindAsync(q => q.Sort(e => e.Name).Sort(e => e.CompanyName).SortDescending(e => e.Age), o => o.SearchBeforeToken(searchBeforeToken, _serializer).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
+            var employees = await _employeeRepository.FindAsync(q => q.Sort(e => e.Name).Sort(e => e.CompanyName).SortDescending(e => e.Age), o => o.SearchBeforeToken(searchBeforeToken!, _serializer).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
             searchBeforeToken = employees.GetSearchBeforeToken();
             searchAfterToken = employees.GetSearchAfterToken();
             if (page == 1)
@@ -1368,13 +1368,13 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         int pageSize = 10;
 
         var employeePages = new List<FindResults<Employee>>();
-        string searchAfterToken = null;
-        string searchBeforeToken = null;
+        string? searchAfterToken = null;
+        string? searchBeforeToken = null;
         int page = 0;
         do
         {
             page++;
-            var employees = await _employeeRepository.FindAsync(q => q.SortExpression("name companyname -age"), o => o.SearchAfterToken(searchAfterToken, _serializer).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
+            var employees = await _employeeRepository.FindAsync(q => q.SortExpression("name companyname -age"), o => o.SearchAfterToken(searchAfterToken!, _serializer).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
             searchBeforeToken = employees.GetSearchBeforeToken();
             searchAfterToken = employees.GetSearchAfterToken();
             if (page == 1)
@@ -1414,7 +1414,7 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         do
         {
             page--;
-            var employees = await _employeeRepository.FindAsync(q => q.SortExpression("name companyname -age"), o => o.SearchBeforeToken(searchBeforeToken, _serializer).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
+            var employees = await _employeeRepository.FindAsync(q => q.SortExpression("name companyname -age"), o => o.SearchBeforeToken(searchBeforeToken!, _serializer).PageLimit(pageSize).QueryLogLevel(LogLevel.Information));
             searchBeforeToken = employees.GetSearchBeforeToken();
             searchAfterToken = employees.GetSearchAfterToken();
             if (page == 1)

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReindexScriptTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReindexScriptTests.cs
@@ -14,7 +14,8 @@ public sealed class ReindexScriptTests
         index.TestRenameFieldScript(2, "companyName", "companyNameRenamed");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert -- produces 2 scripts (copy + remove), wrapped in functions
         Assert.Contains("void f000(def ctx) { if (ctx._source.containsKey('companyName')) { ctx._source.companyNameRenamed = ctx._source.companyName; } }", result);
@@ -30,7 +31,8 @@ public sealed class ReindexScriptTests
         index.TestRenameFieldScript(2, "oldName", "newName", remove: false);
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert -- single script returned directly (no function wrapping)
         Assert.Equal(
@@ -46,7 +48,8 @@ public sealed class ReindexScriptTests
         index.TestRenameFieldScript(2, "data.oldField", "data.newField");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert -- copy script with null-safety + remove script
         Assert.Contains(
@@ -66,7 +69,8 @@ public sealed class ReindexScriptTests
         index.TestRenameFieldScript(2, "data.oldField", "data.newField", remove: false);
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert -- single copy script with null-safety guards
         Assert.Equal(
@@ -82,7 +86,8 @@ public sealed class ReindexScriptTests
         index.TestRenameFieldScript(2, "metadata.author.name", "metadata.author.displayName");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert -- copy script with chained null-safety for each parent level
         Assert.Contains(
@@ -107,7 +112,8 @@ public sealed class ReindexScriptTests
         index.TestRenameFieldScript(2, "data.oldField", "meta.newField");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert -- copy guards data.oldField, assigns to meta.newField
         Assert.Contains(
@@ -130,7 +136,8 @@ public sealed class ReindexScriptTests
         index.TestRenameFieldScript(2, "data.oldField", "promoted");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert -- guard checks nested, assignment is top-level (no parent init needed)
         Assert.Contains(
@@ -151,7 +158,8 @@ public sealed class ReindexScriptTests
         index.TestRenameFieldScript(2, "companyName", "data.company");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert -- guard checks top-level, assignment creates nested parent
         Assert.Contains(
@@ -172,7 +180,8 @@ public sealed class ReindexScriptTests
         index.TestRemoveFieldScript(2, "companyName");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert -- single script, returned directly
         Assert.Equal(
@@ -188,7 +197,8 @@ public sealed class ReindexScriptTests
         index.TestRemoveFieldScript(2, "data.oldField");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert -- null guard on parent, parent-scoped remove
         Assert.Equal(
@@ -204,7 +214,8 @@ public sealed class ReindexScriptTests
         index.TestRemoveFieldScript(2, "metadata.author.name");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert -- chained null checks, parent-scoped remove
         Assert.Equal(
@@ -220,7 +231,7 @@ public sealed class ReindexScriptTests
         var index = new TestableVersionedIndex(5);
 
         // Act
-        string result = index.TestGetReindexScripts(0);
+        string? result = index.TestGetReindexScripts(0);
 
         // Assert
         Assert.Null(result);
@@ -234,7 +245,8 @@ public sealed class ReindexScriptTests
         index.TestAddReindexScript(2, "ctx._source.name = 'test';");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert
         Assert.Equal("ctx._source.name = 'test';", result);
@@ -249,7 +261,8 @@ public sealed class ReindexScriptTests
         index.TestAddReindexScript(3, "ctx._source.b = 2;");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert
         Assert.Contains("void f000(def ctx) { ctx._source.a = 1; }", result);
@@ -268,7 +281,8 @@ public sealed class ReindexScriptTests
         index.TestAddReindexScript(4, "ctx._source.v4 = true;");
 
         // Act -- upgrading from v1, index version is 3, so only v2 and v3 scripts apply
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert
         Assert.DoesNotContain("v1", result);
@@ -285,7 +299,8 @@ public sealed class ReindexScriptTests
         index.TestRenameFieldScript(2, "oldName", "newName");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert -- contains both the copy and the remove
         Assert.Contains("newName", result);
@@ -295,37 +310,37 @@ public sealed class ReindexScriptTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void RenameFieldScript_WithNullOrEmptyOriginalName_ThrowsArgumentException(string originalName)
+    public void RenameFieldScript_WithNullOrEmptyOriginalName_ThrowsArgumentException(string? originalName)
     {
         // Arrange
         var index = new TestableVersionedIndex(2);
 
         // Act / Assert
-        Assert.ThrowsAny<ArgumentException>(() => index.TestRenameFieldScript(2, originalName, "newName"));
+        Assert.ThrowsAny<ArgumentException>(() => index.TestRenameFieldScript(2, originalName!, "newName"));
     }
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void RenameFieldScript_WithNullOrEmptyCurrentName_ThrowsArgumentException(string currentName)
+    public void RenameFieldScript_WithNullOrEmptyCurrentName_ThrowsArgumentException(string? currentName)
     {
         // Arrange
         var index = new TestableVersionedIndex(2);
 
         // Act / Assert
-        Assert.ThrowsAny<ArgumentException>(() => index.TestRenameFieldScript(2, "oldName", currentName));
+        Assert.ThrowsAny<ArgumentException>(() => index.TestRenameFieldScript(2, "oldName", currentName!));
     }
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void RemoveFieldScript_WithNullOrEmptyFieldName_ThrowsArgumentException(string fieldName)
+    public void RemoveFieldScript_WithNullOrEmptyFieldName_ThrowsArgumentException(string? fieldName)
     {
         // Arrange
         var index = new TestableVersionedIndex(2);
 
         // Act / Assert
-        Assert.ThrowsAny<ArgumentException>(() => index.TestRemoveFieldScript(2, fieldName));
+        Assert.ThrowsAny<ArgumentException>(() => index.TestRemoveFieldScript(2, fieldName!));
     }
 
     [Theory]
@@ -419,7 +434,8 @@ public sealed class ReindexScriptTests
         index.TestRenameFieldScript(2, "a", "b");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert
         Assert.Contains("containsKey('a')", result);
@@ -435,7 +451,8 @@ public sealed class ReindexScriptTests
         index.TestRenameFieldScript(2, "a.b.c.d.e", "a.b.c.d.f", remove: false);
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert
         Assert.Contains("ctx._source.a != null", result);
@@ -456,7 +473,8 @@ public sealed class ReindexScriptTests
         index.TestAddReindexScript(4, "ctx._source.migrated = true;");
 
         // Act
-        string result = index.TestGetReindexScripts(1);
+        string? result = index.TestGetReindexScripts(1);
+        Assert.NotNull(result);
 
         // Assert
         Assert.Contains("newName", result);
@@ -483,7 +501,8 @@ public sealed class ReindexScriptTests
 
         // Act
         index.TestRenameFieldScript(2, fieldPath, "target");
-        string script = index.TestGetReindexScripts(1);
+        string? script = index.TestGetReindexScripts(1);
+        Assert.NotNull(script);
 
         // Assert
         Assert.Contains(expectedGuard, script);
@@ -500,7 +519,8 @@ public sealed class ReindexScriptTests
 
         // Act
         index.TestRenameFieldScript(2, fieldPath, "target");
-        string script = index.TestGetReindexScripts(1);
+        string? script = index.TestGetReindexScripts(1);
+        Assert.NotNull(script);
 
         // Assert
         Assert.Contains(expectedGuard, script);
@@ -530,7 +550,8 @@ public sealed class ReindexScriptTests
 
         // Act
         index.TestRenameFieldScript(2, fieldPath, "target");
-        string script = index.TestGetReindexScripts(1);
+        string? script = index.TestGetReindexScripts(1);
+        Assert.NotNull(script);
 
         // Assert
         Assert.Contains(expectedGuard, script);
@@ -548,7 +569,8 @@ public sealed class ReindexScriptTests
 
         // Act
         index.TestRemoveFieldScript(2, fieldPath);
-        string script = index.TestGetReindexScripts(1);
+        string? script = index.TestGetReindexScripts(1);
+        Assert.NotNull(script);
 
         // Assert
         Assert.Contains(expectedGuard, script);
@@ -566,7 +588,7 @@ public sealed class ReindexScriptTests
         public void TestRemoveFieldScript(int v, string field)
             => RemoveFieldScript(v, field);
 
-        public string TestGetReindexScripts(int currentVersion)
+        public string? TestGetReindexScripts(int currentVersion)
             => GetReindexScripts(currentVersion);
 
         public void TestAddReindexScript(int v, string script)

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReindexTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReindexTests.cs
@@ -113,9 +113,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        var indices = aliasResponse.Aliases;
 #else
-        var indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        var indices = aliasResponse.Values;
 #endif
         Assert.Single(indices);
         Assert.Equal(version2Index.VersionedName, indices.First().Key);
@@ -171,9 +173,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        var indices = aliasResponse.Aliases;
 #else
-        var indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        var indices = aliasResponse.Values;
 #endif
         Assert.Single(indices);
         Assert.True(indices.ContainsKey(version1Index.VersionedName));
@@ -225,9 +229,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasResponse);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        var indices = aliasResponse.Aliases;
 #else
-        var indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        var indices = aliasResponse.Values;
 #endif
         Assert.Single(indices);
         Assert.Equal(version1Index.VersionedName, indices.First().Key);
@@ -268,9 +274,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        indices = aliasResponse.Aliases;
 #else
-        indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        indices = aliasResponse.Values;
 #endif
         Assert.Single(indices);
         Assert.Equal(version1Index.VersionedName, indices.First().Key);
@@ -280,9 +288,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        indices = aliasResponse.Aliases;
 #else
-        indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        indices = aliasResponse.Values;
 #endif
         Assert.Single(indices);
         Assert.Equal(version2Index.VersionedName, indices.First().Key);
@@ -443,9 +453,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var aliasResponse = await _client.Indices.GetAliasAsync((Indices)version1Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        var indices = aliasResponse.Aliases;
 #else
-        var indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        var indices = aliasResponse.Values;
 #endif
         Assert.Single(indices);
         Assert.Equal(version1Index.VersionedName, indices.First().Key);
@@ -502,9 +514,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        var indices = aliasResponse.Aliases;
 #else
-        var indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        var indices = aliasResponse.Values;
 #endif
         Assert.Single(indices);
         Assert.Equal(version1Index.VersionedName, indices.First().Key);
@@ -514,9 +528,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        indices = aliasResponse.Aliases;
 #else
-        indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        indices = aliasResponse.Values;
 #endif
         Assert.Single(indices);
         Assert.Equal(version2Index.VersionedName, indices.First().Key);
@@ -561,9 +577,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasResponse);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        var indices = aliasResponse.Aliases;
 #else
-        var indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        var indices = aliasResponse.Values;
 #endif
         Assert.Single(indices);
         Assert.Equal(version1Index.VersionedName, indices.First().Key);
@@ -593,9 +611,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        indices = aliasResponse.Aliases;
 #else
-        indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        indices = aliasResponse.Values;
 #endif
         Assert.Single(indices);
         Assert.Equal(version2Index.VersionedName, indices.First().Key);
@@ -644,9 +664,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasResponse);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        var indices = aliasResponse.Aliases;
 #else
-        var indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        var indices = aliasResponse.Values;
 #endif
         Assert.Single(indices);
         Assert.Equal(version1Index.VersionedName, indices.First().Key);
@@ -675,9 +697,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasResponse);
         Assert.True(aliasResponse.IsValidResponse, aliasResponse.GetErrorMessage());
 #if ELASTICSEARCH9
-        indices = aliasResponse.Aliases!;
+        Assert.NotNull(aliasResponse.Aliases);
+        indices = aliasResponse.Aliases;
 #else
-        indices = aliasResponse.Values!;
+        Assert.NotNull(aliasResponse.Values);
+        indices = aliasResponse.Values;
 #endif
         Assert.Single(indices);
         Assert.Equal(version2Index.VersionedName, indices.First().Key);
@@ -765,9 +789,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var aliasIndices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        var aliasIndices = aliasesResponse.Aliases;
 #else
-        var aliasIndices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        var aliasIndices = aliasesResponse.Values;
 #endif
         Assert.Equal(version1Index.GetVersionedIndex(employee.CreatedUtc, 1), aliasIndices.Single().Key);
 
@@ -784,9 +810,11 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse, aliasesResponse.GetErrorMessage());
 #if ELASTICSEARCH9
-        aliasIndices = aliasesResponse.Aliases!;
+        Assert.NotNull(aliasesResponse.Aliases);
+        aliasIndices = aliasesResponse.Aliases;
 #else
-        aliasIndices = aliasesResponse.Values!;
+        Assert.NotNull(aliasesResponse.Values);
+        aliasIndices = aliasesResponse.Values;
 #endif
         Assert.Equal(version1Index.GetVersionedIndex(employee.CreatedUtc, 2), aliasIndices.Single().Key);
 
@@ -957,9 +985,10 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var request = new GetRequest(version2Index.VersionedName, employee.Id);
         var response = await _client.GetAsync<Dictionary<string, object>>(request, cancellationToken: TestCancellationToken);
         Assert.True(response.IsValidResponse);
-        Assert.True(response.Source!.TryGetValue("companyNameRenamed", out var companyNameRenamed));
+        Assert.NotNull(response.Source);
+        Assert.True(response.Source.TryGetValue("companyNameRenamed", out var companyNameRenamed));
         Assert.Equal("TestCompany", companyNameRenamed?.ToString());
-        Assert.False(response.Source!.ContainsKey("companyName"));
+        Assert.False(response.Source.ContainsKey("companyName"));
     }
 
     [Fact]
@@ -991,7 +1020,8 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var request = new GetRequest(version2Index.VersionedName, employee.Id);
         var response = await _client.GetAsync<Dictionary<string, object>>(request, cancellationToken: TestCancellationToken);
         Assert.True(response.IsValidResponse);
-        Assert.True(response.Source!.TryGetValue("data", out var data));
+        Assert.NotNull(response.Source);
+        Assert.True(response.Source.TryGetValue("data", out var data));
 
         string json = ToJson(data);
         Assert.Equal("{\"newField\":\"nestedValue\"}", json);
@@ -1026,7 +1056,8 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var request = new GetRequest(version2Index.VersionedName, employee.Id);
         var response = await _client.GetAsync<Dictionary<string, object>>(request, cancellationToken: TestCancellationToken);
         Assert.True(response.IsValidResponse);
-        Assert.False(response.Source!.ContainsKey("companyName"));
+        Assert.NotNull(response.Source);
+        Assert.False(response.Source.ContainsKey("companyName"));
     }
 
     [Fact]
@@ -1059,7 +1090,8 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var request = new GetRequest(version2Index.VersionedName, employee.Id);
         var response = await _client.GetAsync<Dictionary<string, object>>(request, cancellationToken: TestCancellationToken);
         Assert.True(response.IsValidResponse);
-        Assert.True(response.Source!.TryGetValue("data", out var data));
+        Assert.NotNull(response.Source);
+        Assert.True(response.Source.TryGetValue("data", out var data));
 
         string json = ToJson(data);
         Assert.Equal("{\"keepField\":\"keepValue\"}", json);

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReindexTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReindexTests.cs
@@ -611,6 +611,7 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
 
         var result = await repository.GetByIdAsync(employee.Id);
         Assert.NotNull(result);
+        employee.Version = result.Version; // SeqNo/PrimaryTerm is not preserved across reindex
         Assert.Equal(ToJson(employee), ToJson(result));
         Assert.False((await _client.Indices.ExistsAsync(version1Index.VersionedName, cancellationToken: TestCancellationToken)).Exists);
     }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReindexTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReindexTests.cs
@@ -113,9 +113,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases;
+        var indices = aliasResponse.Aliases!;
 #else
-        var indices = aliasResponse.Values;
+        var indices = aliasResponse.Values!;
 #endif
         Assert.Single(indices);
         Assert.Equal(version2Index.VersionedName, indices.First().Key);
@@ -171,9 +171,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases;
+        var indices = aliasResponse.Aliases!;
 #else
-        var indices = aliasResponse.Values;
+        var indices = aliasResponse.Values!;
 #endif
         Assert.Single(indices);
         Assert.True(indices.ContainsKey(version1Index.VersionedName));
@@ -225,9 +225,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasResponse);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases;
+        var indices = aliasResponse.Aliases!;
 #else
-        var indices = aliasResponse.Values;
+        var indices = aliasResponse.Values!;
 #endif
         Assert.Single(indices);
         Assert.Equal(version1Index.VersionedName, indices.First().Key);
@@ -268,9 +268,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasResponse.Aliases;
+        indices = aliasResponse.Aliases!;
 #else
-        indices = aliasResponse.Values;
+        indices = aliasResponse.Values!;
 #endif
         Assert.Single(indices);
         Assert.Equal(version1Index.VersionedName, indices.First().Key);
@@ -280,9 +280,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasResponse.Aliases;
+        indices = aliasResponse.Aliases!;
 #else
-        indices = aliasResponse.Values;
+        indices = aliasResponse.Values!;
 #endif
         Assert.Single(indices);
         Assert.Equal(version2Index.VersionedName, indices.First().Key);
@@ -384,6 +384,7 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
 
             IEmployeeRepository version20Repository = new EmployeeRepository(version20Index);
             var result = await version20Repository.GetByIdAsync(employee.Id);
+            Assert.NotNull(result);
             Assert.Equal("scripted", result.CompanyName);
 
             await using AsyncDisposableAction version21Scope = new(() => version21Index.DeleteAsync());
@@ -392,6 +393,7 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
 
             IEmployeeRepository version21Repository = new EmployeeRepository(version21Index);
             result = await version21Repository.GetByIdAsync(employee.Id);
+            Assert.NotNull(result);
             Assert.Equal("typed script", result.CompanyName);
         }
 
@@ -411,6 +413,7 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
 
             IEmployeeRepository version21Repository = new EmployeeRepository(version21Index);
             var result = await version21Repository.GetByIdAsync(employee.Id);
+            Assert.NotNull(result);
             Assert.Equal("typed script", result.CompanyName);
         }
     }
@@ -440,9 +443,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var aliasResponse = await _client.Indices.GetAliasAsync((Indices)version1Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases;
+        var indices = aliasResponse.Aliases!;
 #else
-        var indices = aliasResponse.Values;
+        var indices = aliasResponse.Values!;
 #endif
         Assert.Single(indices);
         Assert.Equal(version1Index.VersionedName, indices.First().Key);
@@ -499,9 +502,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases;
+        var indices = aliasResponse.Aliases!;
 #else
-        var indices = aliasResponse.Values;
+        var indices = aliasResponse.Values!;
 #endif
         Assert.Single(indices);
         Assert.Equal(version1Index.VersionedName, indices.First().Key);
@@ -511,9 +514,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasResponse.Aliases;
+        indices = aliasResponse.Aliases!;
 #else
-        indices = aliasResponse.Values;
+        indices = aliasResponse.Values!;
 #endif
         Assert.Single(indices);
         Assert.Equal(version2Index.VersionedName, indices.First().Key);
@@ -558,9 +561,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasResponse);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases;
+        var indices = aliasResponse.Aliases!;
 #else
-        var indices = aliasResponse.Values;
+        var indices = aliasResponse.Values!;
 #endif
         Assert.Single(indices);
         Assert.Equal(version1Index.VersionedName, indices.First().Key);
@@ -590,9 +593,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         aliasResponse = await _client.Indices.GetAliasAsync((Indices)version2Index.Name, cancellationToken: TestCancellationToken);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        indices = aliasResponse.Aliases;
+        indices = aliasResponse.Aliases!;
 #else
-        indices = aliasResponse.Values;
+        indices = aliasResponse.Values!;
 #endif
         Assert.Single(indices);
         Assert.Equal(version2Index.VersionedName, indices.First().Key);
@@ -608,7 +611,6 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
 
         var result = await repository.GetByIdAsync(employee.Id);
         Assert.NotNull(result);
-        employee.Version = result.Version; // SeqNo/PrimaryTerm is not preserved across reindex
         Assert.Equal(ToJson(employee), ToJson(result));
         Assert.False((await _client.Indices.ExistsAsync(version1Index.VersionedName, cancellationToken: TestCancellationToken)).Exists);
     }
@@ -641,9 +643,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasResponse);
         Assert.True(aliasResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var indices = aliasResponse.Aliases;
+        var indices = aliasResponse.Aliases!;
 #else
-        var indices = aliasResponse.Values;
+        var indices = aliasResponse.Values!;
 #endif
         Assert.Single(indices);
         Assert.Equal(version1Index.VersionedName, indices.First().Key);
@@ -672,9 +674,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasResponse);
         Assert.True(aliasResponse.IsValidResponse, aliasResponse.GetErrorMessage());
 #if ELASTICSEARCH9
-        indices = aliasResponse.Aliases;
+        indices = aliasResponse.Aliases!;
 #else
-        indices = aliasResponse.Values;
+        indices = aliasResponse.Values!;
 #endif
         Assert.Single(indices);
         Assert.Equal(version2Index.VersionedName, indices.First().Key);
@@ -762,9 +764,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse);
 #if ELASTICSEARCH9
-        var aliasIndices = aliasesResponse.Aliases;
+        var aliasIndices = aliasesResponse.Aliases!;
 #else
-        var aliasIndices = aliasesResponse.Values;
+        var aliasIndices = aliasesResponse.Values!;
 #endif
         Assert.Equal(version1Index.GetVersionedIndex(employee.CreatedUtc, 1), aliasIndices.Single().Key);
 
@@ -781,9 +783,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         _logger.LogRequest(aliasesResponse);
         Assert.True(aliasesResponse.IsValidResponse, aliasesResponse.GetErrorMessage());
 #if ELASTICSEARCH9
-        aliasIndices = aliasesResponse.Aliases;
+        aliasIndices = aliasesResponse.Aliases!;
 #else
-        aliasIndices = aliasesResponse.Values;
+        aliasIndices = aliasesResponse.Values!;
 #endif
         Assert.Equal(version1Index.GetVersionedIndex(employee.CreatedUtc, 2), aliasIndices.Single().Key);
 
@@ -954,9 +956,9 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var request = new GetRequest(version2Index.VersionedName, employee.Id);
         var response = await _client.GetAsync<Dictionary<string, object>>(request, cancellationToken: TestCancellationToken);
         Assert.True(response.IsValidResponse);
-        Assert.True(response.Source.TryGetValue("companyNameRenamed", out var companyNameRenamed));
+        Assert.True(response.Source!.TryGetValue("companyNameRenamed", out var companyNameRenamed));
         Assert.Equal("TestCompany", companyNameRenamed?.ToString());
-        Assert.False(response.Source.ContainsKey("companyName"));
+        Assert.False(response.Source!.ContainsKey("companyName"));
     }
 
     [Fact]
@@ -988,7 +990,7 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var request = new GetRequest(version2Index.VersionedName, employee.Id);
         var response = await _client.GetAsync<Dictionary<string, object>>(request, cancellationToken: TestCancellationToken);
         Assert.True(response.IsValidResponse);
-        Assert.True(response.Source.TryGetValue("data", out var data));
+        Assert.True(response.Source!.TryGetValue("data", out var data));
 
         string json = ToJson(data);
         Assert.Equal("{\"newField\":\"nestedValue\"}", json);
@@ -1023,7 +1025,7 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var request = new GetRequest(version2Index.VersionedName, employee.Id);
         var response = await _client.GetAsync<Dictionary<string, object>>(request, cancellationToken: TestCancellationToken);
         Assert.True(response.IsValidResponse);
-        Assert.False(response.Source.ContainsKey("companyName"));
+        Assert.False(response.Source!.ContainsKey("companyName"));
     }
 
     [Fact]
@@ -1056,7 +1058,7 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         var request = new GetRequest(version2Index.VersionedName, employee.Id);
         var response = await _client.GetAsync<Dictionary<string, object>>(request, cancellationToken: TestCancellationToken);
         Assert.True(response.IsValidResponse);
-        Assert.True(response.Source.TryGetValue("data", out var data));
+        Assert.True(response.Source!.TryGetValue("data", out var data));
 
         string json = ToJson(data);
         Assert.Equal("{\"keepField\":\"keepValue\"}", json);

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReindexTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReindexTests.cs
@@ -362,6 +362,7 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
 
             IEmployeeRepository version20Repository = new EmployeeRepository(version20Index);
             var result = await version20Repository.GetByIdAsync(employee.Id);
+            Assert.NotNull(result);
             Assert.Equal("scripted", result.CompanyName);
 
             await using AsyncDisposableAction version21Scope = new(() => version21Index.DeleteAsync());
@@ -370,6 +371,7 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
 
             IEmployeeRepository version21Repository = new EmployeeRepository(version21Index);
             result = await version21Repository.GetByIdAsync(employee.Id);
+            Assert.NotNull(result);
             Assert.Equal("typed script", result.CompanyName);
         }
 
@@ -389,6 +391,7 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
 
             IEmployeeRepository version21Repository = new EmployeeRepository(version21Index);
             var result = await version21Repository.GetByIdAsync(employee.Id);
+            Assert.NotNull(result);
             Assert.Equal("typed script", result.CompanyName);
         }
     }
@@ -558,6 +561,7 @@ public sealed class ReindexTests : ElasticRepositoryTestBase
         Assert.Equal(2, countResponse.Count);
 
         var result = await repository.GetByIdAsync(employee.Id);
+        Assert.NotNull(result);
         Assert.Equal(ToJson(employee), ToJson(result));
         Assert.False((await _client.Indices.ExistsAsync(version1Index.VersionedName, ct: TestCancellationToken)).Exists);
     }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/ChildRepository.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/ChildRepository.cs
@@ -33,7 +33,7 @@ public class ChildRepository : ElasticRepositoryBase<Child>, IChildRepository
         return Task.CompletedTask;
     }
 
-    protected override ICommandOptions<Child> ConfigureOptions(ICommandOptions<Child> options)
+    protected override ICommandOptions<Child> ConfigureOptions(ICommandOptions<Child>? options)
     {
         return base.ConfigureOptions(options).ParentDocumentType(typeof(Parent));
     }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/CalculatedIntegerFieldType.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/CalculatedIntegerFieldType.cs
@@ -24,16 +24,20 @@ public class CalculatedIntegerFieldType : IntegerFieldType
 
     public override async Task<ProcessFieldValueResult> ProcessValueAsync<T>(T document, object value, CustomFieldDefinition fieldDefinition) where T : class
     {
-        if (!fieldDefinition.Data.TryGetValue("Expression", out object expression))
+        if (!fieldDefinition.Data.TryGetValue("Expression", out object? expression) || expression is null)
             return await base.ProcessValueAsync(document, value, fieldDefinition);
 
-        var calculatedValue = await _scriptService.EvaluateForSourceAsync(document, expression.ToString());
+        string? expressionText = expression.ToString();
+        if (String.IsNullOrEmpty(expressionText))
+            return await base.ProcessValueAsync(document, value, fieldDefinition);
+
+        var calculatedValue = await _scriptService.EvaluateForSourceAsync(document, expressionText);
 
         // TODO: Implement a consecutive errors counter that disables badly behaving expressions
         if (calculatedValue.IsCancelled)
             return new ProcessFieldValueResult { Value = null };
 
-        if (calculatedValue.Value is Double.NaN)
+        if (calculatedValue.Value is double d && Double.IsNaN(d))
             return new ProcessFieldValueResult { Value = null };
 
         return new ProcessFieldValueResult { Value = calculatedValue.Value };
@@ -81,7 +85,7 @@ public class ScriptService : IDisposable
 
     private string EnsureExpressionFunctionInternal(string expression)
     {
-        if (_registeredExpressions.TryGetValue(expression, out string functionName))
+        if (_registeredExpressions.TryGetValue(expression, out string? functionName))
             return functionName;
 
         functionName = "_" + ComputeSha256Hash(expression);
@@ -187,7 +191,8 @@ public class ScriptService : IDisposable
 
         try
         {
-            return Engine.Evaluate(expression).ToObject();
+            return Engine.Evaluate(expression).ToObject()
+                ?? throw new InvalidOperationException("Expression evaluated to null");
         }
         finally
         {
@@ -247,13 +252,13 @@ public class ScriptService : IDisposable
 
 public class ScriptValueResult
 {
-    public ScriptValueResult(object value, bool isCancelled = false)
+    public ScriptValueResult(object? value, bool isCancelled = false)
     {
         Value = value;
         IsCancelled = isCancelled;
     }
 
-    public object Value { get; }
+    public object? Value { get; }
     public bool IsCancelled { get; }
 
     public static readonly ScriptValueResult Cancelled = new(null, true);
@@ -269,7 +274,7 @@ public class JintEnumConverter : IObjectConverter
             return true;
         }
 
-        result = null;
+        result = JsValue.Undefined;
         return false;
     }
 }
@@ -284,7 +289,7 @@ public class JintGuidConverter : IObjectConverter
             return true;
         }
 
-        result = null;
+        result = JsValue.Undefined;
         return false;
     }
 }
@@ -305,7 +310,7 @@ public class JintDateTimeConverter : IObjectConverter
             return true;
         }
 
-        result = null;
+        result = JsValue.Undefined;
         return false;
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/EmployeeIndex.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/EmployeeIndex.cs
@@ -13,6 +13,7 @@ using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Queries;
 using Foundatio.Serializer;
 using Microsoft.Extensions.Logging.Abstractions;
+
 namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Configuration.Indexes;
 
 public sealed class EmployeeIndex : Index<Employee>
@@ -93,7 +94,7 @@ public sealed class EmployeeIndex : Index<Employee>
         return "aliasedage:10";
     }
 
-    private async Task<ElasticRuntimeField> ResolveRuntimeFieldAsync(string name)
+    private async Task<ElasticRuntimeField?> ResolveRuntimeFieldAsync(string name)
     {
         await Task.Delay(100);
 
@@ -133,12 +134,12 @@ public sealed class EmployeeIndexWithYearsEmployed : Index<Employee>
 
 public sealed class VersionedEmployeeIndex : VersionedIndex<Employee>
 {
-    private readonly Action<CreateIndexRequestDescriptor> _createIndex;
-    private readonly Action<TypeMappingDescriptor<Employee>> _createMappings;
+    private readonly Action<CreateIndexRequestDescriptor>? _createIndex;
+    private readonly Action<TypeMappingDescriptor<Employee>>? _createMappings;
 
     public VersionedEmployeeIndex(IElasticConfiguration configuration, int version,
-        Action<CreateIndexRequestDescriptor> createIndex = null,
-        Action<TypeMappingDescriptor<Employee>> createMappings = null) : base(configuration, "employees", version)
+        Action<CreateIndexRequestDescriptor>? createIndex = null,
+        Action<TypeMappingDescriptor<Employee>>? createMappings = null) : base(configuration, "employees", version)
     {
         _createIndex = createIndex;
         _createMappings = createMappings;

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/EmployeeIndex.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/EmployeeIndex.cs
@@ -13,6 +13,7 @@ using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Queries;
 using Foundatio.Serializer;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nest;
+using Xunit;
 
 namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Configuration.Indexes;
 
@@ -91,13 +92,13 @@ public sealed class EmployeeIndex : Index<Employee>
 
     private async Task<string> ResolveIncludeAsync(string name)
     {
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
         return "aliasedage:10";
     }
 
-    private async Task<ElasticRuntimeField> ResolveRuntimeFieldAsync(string name)
+    private async Task<ElasticRuntimeField?> ResolveRuntimeFieldAsync(string name)
     {
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         if (name.Equals("unmappedEmailAddress", StringComparison.OrdinalIgnoreCase))
             return new ElasticRuntimeField { Name = "unmappedEmailAddress" };
@@ -136,12 +137,12 @@ public sealed class EmployeeIndexWithYearsEmployed : Index<Employee>
 
 public sealed class VersionedEmployeeIndex : VersionedIndex<Employee>
 {
-    private readonly Func<CreateIndexDescriptor, CreateIndexDescriptor> _createIndex;
-    private readonly Func<TypeMappingDescriptor<Employee>, TypeMappingDescriptor<Employee>> _createMappings;
+    private readonly Func<CreateIndexDescriptor, CreateIndexDescriptor>? _createIndex;
+    private readonly Func<TypeMappingDescriptor<Employee>, TypeMappingDescriptor<Employee>>? _createMappings;
 
     public VersionedEmployeeIndex(IElasticConfiguration configuration, int version,
-        Func<CreateIndexDescriptor, CreateIndexDescriptor> createIndex = null,
-        Func<TypeMappingDescriptor<Employee>, TypeMappingDescriptor<Employee>> createMappings = null) : base(configuration, "employees", version)
+        Func<CreateIndexDescriptor, CreateIndexDescriptor>? createIndex = null,
+        Func<TypeMappingDescriptor<Employee>, TypeMappingDescriptor<Employee>>? createMappings = null) : base(configuration, "employees", version)
     {
         _createIndex = createIndex;
         _createMappings = createMappings;

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/EmployeeWithCustomFieldsIndex.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/EmployeeWithCustomFieldsIndex.cs
@@ -87,7 +87,7 @@ public sealed class EmployeeWithCustomFieldsIndex : VersionedIndex<EmployeeWithC
         return "aliasedage:10";
     }
 
-    private async Task<ElasticRuntimeField> ResolveRuntimeFieldAsync(string name)
+    private async Task<ElasticRuntimeField?> ResolveRuntimeFieldAsync(string name)
     {
         await Task.Delay(100);
 

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/EmployeeWithCustomFieldsIndex.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/EmployeeWithCustomFieldsIndex.cs
@@ -13,6 +13,7 @@ using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Queries;
 using Foundatio.Serializer;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nest;
+using Xunit;
 
 namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Configuration.Indexes;
 
@@ -84,13 +85,13 @@ public sealed class EmployeeWithCustomFieldsIndex : VersionedIndex<EmployeeWithC
 
     private async Task<string> ResolveIncludeAsync(string name)
     {
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
         return "aliasedage:10";
     }
 
-    private async Task<ElasticRuntimeField> ResolveRuntimeFieldAsync(string name)
+    private async Task<ElasticRuntimeField?> ResolveRuntimeFieldAsync(string name)
     {
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         if (name.Equals("unmappedEmailAddress", StringComparison.OrdinalIgnoreCase))
             return new ElasticRuntimeField { Name = "unmappedEmailAddress" };

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/MyAppElasticConfiguration.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/MyAppElasticConfiguration.cs
@@ -36,7 +36,7 @@ public class MyAppElasticConfiguration : ElasticConfiguration
 
     protected override IConnectionPool CreateConnectionPool()
     {
-        string connectionString = null;
+        string? connectionString = null;
         bool fiddlerIsRunning = Process.GetProcessesByName("fiddler").Length > 0;
 
         var servers = new List<Uri>();

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/MyAppElasticConfiguration.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/MyAppElasticConfiguration.cs
@@ -33,7 +33,7 @@ public class MyAppElasticConfiguration : ElasticConfiguration
 
     protected override NodePool CreateConnectionPool()
     {
-        string connectionString = Environment.GetEnvironmentVariable("ELASTICSEARCH_URL");
+        string? connectionString = Environment.GetEnvironmentVariable("ELASTICSEARCH_URL");
         bool fiddlerIsRunning = String.Equals(Environment.GetEnvironmentVariable("USE_FIDDLER_PROXY"), "true", StringComparison.OrdinalIgnoreCase);
 
         if (!String.IsNullOrEmpty(connectionString))

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/EmployeeRepository.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/EmployeeRepository.cs
@@ -162,7 +162,7 @@ public class EmployeeRepository : ElasticRepositoryBase<Employee>, IEmployeeRepo
 
         var cacheEntries = new Dictionary<string, FindHit<Employee>>();
         foreach (var hit in findHits.Where(h => h.Document?.EmailAddress is { Length: > 0 }))
-            cacheEntries.Add($"email:{hit.Document!.EmailAddress.ToLowerInvariant()}", hit);
+            cacheEntries.Add($"email:{hit.Document!.EmailAddress!.ToLowerInvariant()}", hit);
 
         await AddDocumentsToCacheWithKeyAsync(cacheEntries, options.GetExpiresIn());
     }
@@ -170,7 +170,7 @@ public class EmployeeRepository : ElasticRepositoryBase<Employee>, IEmployeeRepo
     protected override async Task InvalidateCacheAsync(IReadOnlyCollection<ModifiedDocument<Employee>> documents, ChangeType? changeType = null)
     {
         await base.InvalidateCacheAsync(documents, changeType);
-        await Cache.RemoveAllAsync(documents.Where(d => !String.IsNullOrEmpty(d.Value.EmailAddress)).Select(d => $"email:{d.Value.EmailAddress.ToLowerInvariant()}"));
+        await Cache.RemoveAllAsync(documents.Where(d => !String.IsNullOrEmpty(d.Value.EmailAddress)).Select(d => $"email:{d.Value.EmailAddress!.ToLowerInvariant()}"));
     }
 }
 

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/EmployeeRepository.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/EmployeeRepository.cs
@@ -19,7 +19,7 @@ public interface IEmployeeRepository : ISearchableRepository<Employee>
 
     Task<FindHit<Employee>> GetByEmailAddressAsync(string emailAddress);
     Task<FindResults<Employee>> GetAllByAgeAsync(int age);
-    Task<FindResults<Employee>> GetAllByCompanyAsync(string company, CommandOptionsDescriptor<Employee> options = null);
+    Task<FindResults<Employee>> GetAllByCompanyAsync(string company, CommandOptionsDescriptor<Employee>? options = null);
 
     Task<FindResults<Employee>> GetAllByCompaniesWithFieldEqualsAsync(string[] companies);
     Task<CountResult> GetCountByCompanyAsync(string company);
@@ -74,7 +74,7 @@ public class EmployeeRepository : ElasticRepositoryBase<Employee>, IEmployeeRepo
         });
     }
 
-    protected override string GetTenantKey(IRepositoryQuery query)
+    protected override string? GetTenantKey(IRepositoryQuery query)
     {
         var companies = query.GetCompanies();
         if (companies.Count != 1)
@@ -96,7 +96,7 @@ public class EmployeeRepository : ElasticRepositoryBase<Employee>, IEmployeeRepo
         return FindOneAsync(q => q.EmailAddress(emailAddress), o => o.Cache($"email:{emailAddress.ToLowerInvariant()}"));
     }
 
-    public Task<FindResults<Employee>> GetAllByCompanyAsync(string company, CommandOptionsDescriptor<Employee> options = null)
+    public Task<FindResults<Employee>> GetAllByCompanyAsync(string company, CommandOptionsDescriptor<Employee>? options = null)
     {
         var commandOptions = options.Configure();
         if (commandOptions.ShouldUseCache())
@@ -141,7 +141,7 @@ public class EmployeeRepository : ElasticRepositoryBase<Employee>, IEmployeeRepo
     {
         string script = $"ctx._source.yearsEmployed += {years};";
         if (ids.Length == 0)
-            return await PatchAllAsync(null, new ScriptPatch(script), o => o.Notifications(false).ImmediateConsistency(true));
+            return await PatchAllAsync(q => q, new ScriptPatch(script), o => o.Notifications(false).ImmediateConsistency(true));
 
         await ((IRepository<Employee>)this).PatchAsync(ids, new ScriptPatch(script), o => o.ImmediateConsistency(true));
         return ids.Length;
@@ -161,8 +161,8 @@ public class EmployeeRepository : ElasticRepositoryBase<Employee>, IEmployeeRepo
         await base.AddDocumentsToCacheAsync(findHits, options, isDirtyRead);
 
         var cacheEntries = new Dictionary<string, FindHit<Employee>>();
-        foreach (var hit in findHits.Where(d => !String.IsNullOrEmpty(d.Document.EmailAddress)))
-            cacheEntries.Add($"email:{hit.Document.EmailAddress.ToLowerInvariant()}", hit);
+        foreach (var hit in findHits.Where(h => h.Document?.EmailAddress is { Length: > 0 }))
+            cacheEntries.Add($"email:{hit.Document!.EmailAddress.ToLowerInvariant()}", hit);
 
         await AddDocumentsToCacheWithKeyAsync(cacheEntries, options.GetExpiresIn());
     }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/EmployeeWithCustomFieldsRepository.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/EmployeeWithCustomFieldsRepository.cs
@@ -157,7 +157,7 @@ public class EmployeeWithCustomFieldsRepository : ElasticRepositoryBase<Employee
     protected override async Task InvalidateCacheAsync(IReadOnlyCollection<ModifiedDocument<EmployeeWithCustomFields>> documents, ChangeType? changeType = null)
     {
         await base.InvalidateCacheAsync(documents, changeType);
-        await Cache.RemoveAllAsync(documents.Where(d => !String.IsNullOrEmpty(d.Value.EmailAddress)).Select(d => $"email:{d.Value.EmailAddress.ToLowerInvariant()}"));
+        await Cache.RemoveAllAsync(documents.Where(d => !String.IsNullOrEmpty(d.Value.EmailAddress)).Select(d => $"email:{d.Value.EmailAddress!.ToLowerInvariant()}"));
     }
 }
 

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/EmployeeWithCustomFieldsRepository.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/EmployeeWithCustomFieldsRepository.cs
@@ -18,7 +18,7 @@ public interface IEmployeeWithCustomFieldsRepository : ISearchableRepository<Emp
 
     Task<FindHit<EmployeeWithCustomFields>> GetByEmailAddressAsync(string emailAddress);
     Task<FindResults<EmployeeWithCustomFields>> GetAllByAgeAsync(int age);
-    Task<FindResults<EmployeeWithCustomFields>> GetAllByCompanyAsync(string company, CommandOptionsDescriptor<EmployeeWithCustomFields> options = null);
+    Task<FindResults<EmployeeWithCustomFields>> GetAllByCompanyAsync(string company, CommandOptionsDescriptor<EmployeeWithCustomFields>? options = null);
 
     Task<FindResults<EmployeeWithCustomFields>> GetAllByCompaniesWithFieldEqualsAsync(string[] companies);
     Task<CountResult> GetCountByCompanyAsync(string company);
@@ -61,7 +61,7 @@ public class EmployeeWithCustomFieldsRepository : ElasticRepositoryBase<Employee
         });
     }
 
-    protected override string GetTenantKey(IRepositoryQuery query)
+    protected override string? GetTenantKey(IRepositoryQuery query)
     {
         var companies = query.GetCompanies();
         if (companies.Count != 1)
@@ -83,7 +83,7 @@ public class EmployeeWithCustomFieldsRepository : ElasticRepositoryBase<Employee
         return FindOneAsync(q => q.EmailAddress(emailAddress), o => o.Cache($"email:{emailAddress.ToLowerInvariant()}"));
     }
 
-    public Task<FindResults<EmployeeWithCustomFields>> GetAllByCompanyAsync(string company, CommandOptionsDescriptor<EmployeeWithCustomFields> options = null)
+    public Task<FindResults<EmployeeWithCustomFields>> GetAllByCompanyAsync(string company, CommandOptionsDescriptor<EmployeeWithCustomFields>? options = null)
     {
         var commandOptions = options.Configure();
         if (commandOptions.ShouldUseCache())
@@ -128,7 +128,7 @@ public class EmployeeWithCustomFieldsRepository : ElasticRepositoryBase<Employee
     {
         string script = $"ctx._source.yearsEmployed += {years};";
         if (ids.Length == 0)
-            return await PatchAllAsync(null, new ScriptPatch(script), o => o.Notifications(false).ImmediateConsistency(true));
+            return await PatchAllAsync(q => q, new ScriptPatch(script), o => o.Notifications(false).ImmediateConsistency(true));
 
         await ((IRepository<EmployeeWithCustomFields>)this).PatchAsync(ids, new ScriptPatch(script), o => o.ImmediateConsistency(true));
         return ids.Length;
@@ -148,8 +148,8 @@ public class EmployeeWithCustomFieldsRepository : ElasticRepositoryBase<Employee
         await base.AddDocumentsToCacheAsync(findHits, options, isDirtyRead);
 
         var cacheEntries = new Dictionary<string, FindHit<EmployeeWithCustomFields>>();
-        foreach (var hit in findHits.Where(d => !String.IsNullOrEmpty(d.Document.EmailAddress)))
-            cacheEntries.Add($"email:{hit.Document.EmailAddress.ToLowerInvariant()}", hit);
+        foreach (var hit in findHits.Where(d => !String.IsNullOrEmpty(d.Document?.EmailAddress)))
+            cacheEntries.Add($"email:{hit.Document!.EmailAddress!.ToLowerInvariant()}", hit);
 
         await AddDocumentsToCacheWithKeyAsync(cacheEntries, options.GetExpiresIn());
     }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/EmployeeWithDateMetaDataRepository.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/EmployeeWithDateMetaDataRepository.cs
@@ -26,7 +26,7 @@ public class EmployeeWithDateMetaDataRepository : ElasticRepositoryBase<Employee
 
     protected override string GetUpdatedUtcFieldPath()
     {
-        return InferField(d => ((IHaveDateMetaData)d).MetaData.DateUpdatedUtc);
+        return InferField(d => ((IHaveDateMetaData)d).MetaData.DateUpdatedUtc!);
     }
 
     protected override void SetDocumentDates(EmployeeWithDateMetaData document, TimeProvider timeProvider)

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/LogEventRepository.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/LogEventRepository.cs
@@ -65,7 +65,7 @@ public class DailyLogEventRepository : ElasticRepositoryBase<LogEvent>, ILogEven
 
         string script = $"ctx._source.value += {value};";
         if (ids.Length == 0)
-            return await PatchAllAsync(null, new ScriptPatch(script), o => o.Notifications(false).ImmediateConsistency(true));
+            return await PatchAllAsync(q => q, new ScriptPatch(script), o => o.Notifications(false).ImmediateConsistency(true));
 
         await ((IRepository<LogEvent>)this).PatchAsync(ids, new ScriptPatch(script), o => o.Notifications(false).ImmediateConsistency(true));
         return ids.Length;

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Child.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Child.cs
@@ -8,13 +8,13 @@ namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 
 public class Child : IParentChildDocument, IHaveDates, ISupportSoftDeletes
 {
-    public string Id { get; set; }
-    public string ParentId { get; set; }
+    public string Id { get; set; } = null!;
+    public string ParentId { get; set; } = null!;
 
     [JsonPropertyName("discriminator")]
-    public JoinField Discriminator { get; set; }
+    public JoinField Discriminator { get; set; } = null!;
 
-    public string ChildProperty { get; set; }
+    public string ChildProperty { get; set; } = null!;
     public DateTime CreatedUtc { get; set; }
     public DateTime UpdatedUtc { get; set; }
     public bool IsDeleted { get; set; }
@@ -26,8 +26,8 @@ public static class ChildGenerator
 
     public static Child Default => new() { Id = DefaultId, ParentId = ParentGenerator.DefaultId };
 
-    public static Child Generate(string id = null, string parentId = null)
+    public static Child Generate(string? id = null, string? parentId = null)
     {
-        return new Child { Id = id, ParentId = parentId };
+        return new Child { Id = id!, ParentId = parentId! };
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Child.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Child.cs
@@ -7,10 +7,10 @@ namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 
 public class Child : IParentChildDocument, IHaveDates, ISupportSoftDeletes
 {
-    public string Id { get; set; }
-    public string ParentId { get; set; }
-    JoinField IParentChildDocument.Discriminator { get; set; }
-    public string ChildProperty { get; set; }
+    public string Id { get; set; } = null!;
+    public string ParentId { get; set; } = null!;
+    JoinField IParentChildDocument.Discriminator { get; set; } = null!;
+    public string ChildProperty { get; set; } = null!;
     public DateTime CreatedUtc { get; set; }
     public DateTime UpdatedUtc { get; set; }
     public bool IsDeleted { get; set; }
@@ -22,8 +22,8 @@ public static class ChildGenerator
 
     public static Child Default => new() { Id = DefaultId, ParentId = ParentGenerator.DefaultId };
 
-    public static Child Generate(string id = null, string parentId = null)
+    public static Child Generate(string? id = null, string? parentId = null)
     {
-        return new Child { Id = id, ParentId = parentId };
+        return new Child { Id = id!, ParentId = parentId! };
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Employee.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Employee.cs
@@ -10,38 +10,38 @@ namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 
 public class PeerReview
 {
-    public string ReviewerEmployeeId { get; set; }
+    public string ReviewerEmployeeId { get; set; } = null!;
     public int Rating { get; set; }
 }
 
 public class PhoneInfo
 {
-    public string Number { get; set; }
-    public string Extension { get; set; }
+    public string Number { get; set; } = null!;
+    public string Extension { get; set; } = null!;
 }
 
 public class Employee : IIdentity, IHaveDates, IVersioned, ISupportSoftDeletes
 {
-    public string Id { get; set; }
-    public string CompanyId { get; set; }
-    public string CompanyName { get; set; }
+    public string Id { get; set; } = null!;
+    public string CompanyId { get; set; } = null!;
+    public string CompanyName { get; set; } = null!;
     public string UnmappedCompanyName => CompanyName;
-    public string Name { get; set; }
-    public string EmailAddress { get; set; }
+    public string Name { get; set; } = null!;
+    public string EmailAddress { get; set; } = null!;
     public string UnmappedEmailAddress => EmailAddress;
     public int Age { get; set; }
     public int UnmappedAge => Age;
     public double DecimalAge => Age + .5;
-    public string Location { get; set; }
+    public string Location { get; set; } = null!;
     public int YearsEmployed { get; set; }
     public EmploymentType EmploymentType { get; set; } = EmploymentType.FullTime;
     public DateTime LastReview { get; set; }
     public DateTimeOffset NextReview { get; set; }
     public DateTime CreatedUtc { get; set; }
     public DateTime UpdatedUtc { get; set; }
-    public string Version { get; set; }
+    public string Version { get; set; } = null!;
     public bool IsDeleted { get; set; }
-    public PeerReview[] PeerReviews { get; set; }
+    public PeerReview[]? PeerReviews { get; set; }
     public IList<PhoneInfo> PhoneNumbers { get; set; } = new List<PhoneInfo>();
 
     public IDictionary<string, object> Data { get; set; } = new Dictionary<string, object>();
@@ -61,7 +61,7 @@ public class Employee : IIdentity, IHaveDates, IVersioned, ISupportSoftDeletes
             Version == other.Version;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj))
             return false;
@@ -134,15 +134,15 @@ public static class EmployeeGenerator
         EmploymentType = EmploymentType.FullTime
     };
 
-    public static Employee Generate(string id = null, string name = null, int? age = null, int? yearsEmployed = null, string companyName = null, string companyId = null, string location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null, PeerReview[] peerReviews = null)
+    public static Employee Generate(string? id = null, string? name = null, int? age = null, int? yearsEmployed = null, string? companyName = null, string? companyId = null, string? location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null, PeerReview[]? peerReviews = null)
     {
         return new Employee
         {
-            Id = id,
-            Name = name,
+            Id = id!,
+            Name = name!,
             Age = age ?? RandomData.GetInt(18, 100),
             YearsEmployed = yearsEmployed ?? RandomData.GetInt(0, 1),
-            CompanyName = companyName,
+            CompanyName = companyName!,
             CompanyId = companyId ?? ObjectId.GenerateNewId().ToString(),
             EmploymentType = employmentType ?? EmploymentType.FullTime,
             LastReview = lastReview.GetValueOrDefault(),
@@ -154,11 +154,11 @@ public static class EmployeeGenerator
         };
     }
 
-    public static Employee GenerateRandom(string id = null, string name = null, int? age = null, int? yearsEmployed = null, string companyName = null, string companyId = null, string location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
+    public static Employee GenerateRandom(string? id = null, string? name = null, int? age = null, int? yearsEmployed = null, string? companyName = null, string? companyId = null, string? location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
     {
         var employee = new Employee
         {
-            Id = id,
+            Id = id!,
             Name = name ?? RandomData.GetAlphaString(),
             Age = age ?? RandomData.GetInt(18, 100),
             YearsEmployed = yearsEmployed ?? RandomData.GetInt(0, 40),
@@ -176,7 +176,7 @@ public static class EmployeeGenerator
         return employee;
     }
 
-    public static List<Employee> GenerateEmployees(int count = 10, string id = null, string name = null, int? age = null, int? yearsEmployed = null, string companyName = null, string companyId = null, string location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null)
+    public static List<Employee> GenerateEmployees(int count = 10, string? id = null, string? name = null, int? age = null, int? yearsEmployed = null, string? companyName = null, string? companyId = null, string? location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null)
     {
         var results = new List<Employee>(count);
         for (int index = 0; index < count; index++)
@@ -201,15 +201,15 @@ public static class EmployeeWithCustomFieldsGenerator
         EmploymentType = EmploymentType.FullTime
     };
 
-    public static EmployeeWithCustomFields Generate(string id = null, string name = null, int? age = null, int? yearsEmployed = null, string companyName = null, string companyId = null, string location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
+    public static EmployeeWithCustomFields Generate(string? id = null, string? name = null, int? age = null, int? yearsEmployed = null, string? companyName = null, string? companyId = null, string? location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
     {
         return new EmployeeWithCustomFields
         {
-            Id = id,
-            Name = name,
+            Id = id!,
+            Name = name!,
             Age = age ?? RandomData.GetInt(18, 100),
             YearsEmployed = yearsEmployed ?? RandomData.GetInt(0, 1),
-            CompanyName = companyName,
+            CompanyName = companyName!,
             CompanyId = companyId ?? ObjectId.GenerateNewId().ToString(),
             EmploymentType = employmentType ?? EmploymentType.FullTime,
             LastReview = lastReview.GetValueOrDefault(),
@@ -220,11 +220,11 @@ public static class EmployeeWithCustomFieldsGenerator
         };
     }
 
-    public static EmployeeWithCustomFields GenerateRandom(string id = null, string name = null, int? age = null, int? yearsEmployed = null, string companyName = null, string companyId = null, string location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
+    public static EmployeeWithCustomFields GenerateRandom(string? id = null, string? name = null, int? age = null, int? yearsEmployed = null, string? companyName = null, string? companyId = null, string? location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
     {
         var employee = new EmployeeWithCustomFields
         {
-            Id = id,
+            Id = id!,
             Name = name ?? RandomData.GetAlphaString(),
             Age = age ?? RandomData.GetInt(18, 100),
             YearsEmployed = yearsEmployed ?? RandomData.GetInt(0, 40),
@@ -242,7 +242,7 @@ public static class EmployeeWithCustomFieldsGenerator
         return employee;
     }
 
-    public static List<EmployeeWithCustomFields> GenerateEmployees(int count = 10, string id = null, string name = null, int? age = null, int? yearsEmployed = null, string companyName = null, string companyId = null, string location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
+    public static List<EmployeeWithCustomFields> GenerateEmployees(int count = 10, string? id = null, string? name = null, int? age = null, int? yearsEmployed = null, string? companyName = null, string? companyId = null, string? location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
     {
         var results = new List<EmployeeWithCustomFields>(count);
         for (int index = 0; index < count; index++)

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Employee.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Employee.cs
@@ -10,38 +10,38 @@ namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 
 public class PeerReview
 {
-    public string ReviewerEmployeeId { get; set; }
+    public string ReviewerEmployeeId { get; set; } = null!;
     public int Rating { get; set; }
 }
 
 public class PhoneInfo
 {
-    public string Number { get; set; }
-    public string Extension { get; set; }
+    public string Number { get; set; } = null!;
+    public string Extension { get; set; } = null!;
 }
 
 public class Employee : IIdentity, IHaveDates, IVersioned, ISupportSoftDeletes
 {
-    public string Id { get; set; }
-    public string CompanyId { get; set; }
-    public string CompanyName { get; set; }
+    public string Id { get; set; } = null!;
+    public string CompanyId { get; set; } = null!;
+    public string CompanyName { get; set; } = null!;
     public string UnmappedCompanyName => CompanyName;
-    public string Name { get; set; }
-    public string EmailAddress { get; set; }
+    public string Name { get; set; } = null!;
+    public string EmailAddress { get; set; } = null!;
     public string UnmappedEmailAddress => EmailAddress;
     public int Age { get; set; }
     public int UnmappedAge => Age;
     public double DecimalAge => Age + .5;
-    public string Location { get; set; }
+    public string Location { get; set; } = null!;
     public int YearsEmployed { get; set; }
     public EmploymentType EmploymentType { get; set; } = EmploymentType.FullTime;
     public DateTime LastReview { get; set; }
     public DateTimeOffset NextReview { get; set; }
     public DateTime CreatedUtc { get; set; }
     public DateTime UpdatedUtc { get; set; }
-    public string Version { get; set; }
+    public string Version { get; set; } = null!;
     public bool IsDeleted { get; set; }
-    public PeerReview[] PeerReviews { get; set; }
+    public PeerReview[]? PeerReviews { get; set; }
     public IList<PhoneInfo> PhoneNumbers { get; set; } = new List<PhoneInfo>();
 
     public IDictionary<string, object> Data { get; set; } = new Dictionary<string, object>();
@@ -61,7 +61,7 @@ public class Employee : IIdentity, IHaveDates, IVersioned, ISupportSoftDeletes
             Version == other.Version;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj))
             return false;
@@ -150,15 +150,15 @@ public static class EmployeeGenerator
         EmploymentType = EmploymentType.FullTime
     };
 
-    public static Employee Generate(string id = null, string name = null, int? age = null, int? yearsEmployed = null, string companyName = null, string companyId = null, string location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null, PeerReview[] peerReviews = null)
+    public static Employee Generate(string? id = null, string? name = null, int? age = null, int? yearsEmployed = null, string? companyName = null, string? companyId = null, string? location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null, PeerReview[]? peerReviews = null)
     {
         return new Employee
         {
-            Id = id,
-            Name = name,
+            Id = id!,
+            Name = name!,
             Age = age ?? RandomData.GetInt(18, 100),
             YearsEmployed = yearsEmployed ?? RandomData.GetInt(0, 1),
-            CompanyName = companyName,
+            CompanyName = companyName!,
             CompanyId = companyId ?? ObjectId.GenerateNewId().ToString(),
             EmploymentType = employmentType ?? EmploymentType.FullTime,
             LastReview = lastReview.GetValueOrDefault(),
@@ -170,11 +170,11 @@ public static class EmployeeGenerator
         };
     }
 
-    public static Employee GenerateRandom(string id = null, string name = null, int? age = null, int? yearsEmployed = null, string companyName = null, string companyId = null, string location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
+    public static Employee GenerateRandom(string? id = null, string? name = null, int? age = null, int? yearsEmployed = null, string? companyName = null, string? companyId = null, string? location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
     {
         var employee = new Employee
         {
-            Id = id,
+            Id = id!,
             Name = name ?? RandomData.GetAlphaString(),
             Age = age ?? RandomData.GetInt(18, 100),
             YearsEmployed = yearsEmployed ?? RandomData.GetInt(0, 40),
@@ -192,7 +192,7 @@ public static class EmployeeGenerator
         return employee;
     }
 
-    public static List<Employee> GenerateEmployees(int count = 10, string id = null, string name = null, int? age = null, int? yearsEmployed = null, string companyName = null, string companyId = null, string location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null)
+    public static List<Employee> GenerateEmployees(int count = 10, string? id = null, string? name = null, int? age = null, int? yearsEmployed = null, string? companyName = null, string? companyId = null, string? location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null)
     {
         var results = new List<Employee>(count);
         for (int index = 0; index < count; index++)
@@ -217,15 +217,15 @@ public static class EmployeeWithCustomFieldsGenerator
         EmploymentType = EmploymentType.FullTime
     };
 
-    public static EmployeeWithCustomFields Generate(string id = null, string name = null, int? age = null, int? yearsEmployed = null, string companyName = null, string companyId = null, string location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
+    public static EmployeeWithCustomFields Generate(string? id = null, string? name = null, int? age = null, int? yearsEmployed = null, string? companyName = null, string? companyId = null, string? location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
     {
         return new EmployeeWithCustomFields
         {
-            Id = id,
-            Name = name,
+            Id = id!,
+            Name = name!,
             Age = age ?? RandomData.GetInt(18, 100),
             YearsEmployed = yearsEmployed ?? RandomData.GetInt(0, 1),
-            CompanyName = companyName,
+            CompanyName = companyName!,
             CompanyId = companyId ?? ObjectId.GenerateNewId().ToString(),
             EmploymentType = employmentType ?? EmploymentType.FullTime,
             LastReview = lastReview.GetValueOrDefault(),
@@ -236,11 +236,11 @@ public static class EmployeeWithCustomFieldsGenerator
         };
     }
 
-    public static EmployeeWithCustomFields GenerateRandom(string id = null, string name = null, int? age = null, int? yearsEmployed = null, string companyName = null, string companyId = null, string location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
+    public static EmployeeWithCustomFields GenerateRandom(string? id = null, string? name = null, int? age = null, int? yearsEmployed = null, string? companyName = null, string? companyId = null, string? location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
     {
         var employee = new EmployeeWithCustomFields
         {
-            Id = id,
+            Id = id!,
             Name = name ?? RandomData.GetAlphaString(),
             Age = age ?? RandomData.GetInt(18, 100),
             YearsEmployed = yearsEmployed ?? RandomData.GetInt(0, 40),
@@ -258,7 +258,7 @@ public static class EmployeeWithCustomFieldsGenerator
         return employee;
     }
 
-    public static List<EmployeeWithCustomFields> GenerateEmployees(int count = 10, string id = null, string name = null, int? age = null, int? yearsEmployed = null, string companyName = null, string companyId = null, string location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
+    public static List<EmployeeWithCustomFields> GenerateEmployees(int count = 10, string? id = null, string? name = null, int? age = null, int? yearsEmployed = null, string? companyName = null, string? companyId = null, string? location = null, DateTime? lastReview = null, DateTimeOffset? nextReview = null, DateTime? createdUtc = null, DateTime? updatedUtc = null, EmploymentType? employmentType = null)
     {
         var results = new List<EmployeeWithCustomFields>(count);
         for (int index = 0; index < count; index++)

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Employee.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Employee.cs
@@ -24,15 +24,15 @@ public class Employee : IIdentity, IHaveDates, IVersioned, ISupportSoftDeletes
 {
     public string Id { get; set; } = null!;
     public string CompanyId { get; set; } = null!;
-    public string CompanyName { get; set; } = null!;
-    public string UnmappedCompanyName => CompanyName;
-    public string Name { get; set; } = null!;
-    public string EmailAddress { get; set; } = null!;
-    public string UnmappedEmailAddress => EmailAddress;
+    public string? CompanyName { get; set; }
+    public string? UnmappedCompanyName => CompanyName;
+    public string? Name { get; set; }
+    public string? EmailAddress { get; set; }
+    public string? UnmappedEmailAddress => EmailAddress;
     public int Age { get; set; }
     public int UnmappedAge => Age;
     public double DecimalAge => Age + .5;
-    public string Location { get; set; } = null!;
+    public string? Location { get; set; }
     public int YearsEmployed { get; set; }
     public EmploymentType EmploymentType { get; set; } = EmploymentType.FullTime;
     public DateTime LastReview { get; set; }
@@ -139,10 +139,10 @@ public static class EmployeeGenerator
         return new Employee
         {
             Id = id!,
-            Name = name!,
+            Name = name,
             Age = age ?? RandomData.GetInt(18, 100),
             YearsEmployed = yearsEmployed ?? RandomData.GetInt(0, 1),
-            CompanyName = companyName!,
+            CompanyName = companyName,
             CompanyId = companyId ?? ObjectId.GenerateNewId().ToString(),
             EmploymentType = employmentType ?? EmploymentType.FullTime,
             LastReview = lastReview.GetValueOrDefault(),
@@ -206,10 +206,10 @@ public static class EmployeeWithCustomFieldsGenerator
         return new EmployeeWithCustomFields
         {
             Id = id!,
-            Name = name!,
+            Name = name,
             Age = age ?? RandomData.GetInt(18, 100),
             YearsEmployed = yearsEmployed ?? RandomData.GetInt(0, 1),
-            CompanyName = companyName!,
+            CompanyName = companyName,
             CompanyId = companyId ?? ObjectId.GenerateNewId().ToString(),
             EmploymentType = employmentType ?? EmploymentType.FullTime,
             LastReview = lastReview.GetValueOrDefault(),

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/EmployeeWithDateMetaData.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/EmployeeWithDateMetaData.cs
@@ -22,12 +22,12 @@ public interface IHaveDateMetaData
 
 public class EmployeeWithDateMetaData : IIdentity, IVersioned, IHaveDateMetaData
 {
-    public string Id { get; set; }
-    public string Name { get; set; }
+    public string Id { get; set; } = null!;
+    public string Name { get; set; } = null!;
     public int Age { get; set; }
-    public string CompanyName { get; set; }
-    public string CompanyId { get; set; }
-    public string Version { get; set; }
+    public string CompanyName { get; set; } = null!;
+    public string CompanyId { get; set; } = null!;
+    public string Version { get; set; } = null!;
     public DateMetaData MetaData { get; set; } = new DateMetaData();
     IDateMetaData IHaveDateMetaData.MetaData { get => MetaData; set => MetaData = value as DateMetaData ?? new DateMetaData { DateCreatedUtc = value?.DateCreatedUtc, DateUpdatedUtc = value?.DateUpdatedUtc }; }
 }
@@ -42,15 +42,19 @@ public static class EmployeeWithDateMetaDataGenerator
         CompanyId = "default-company"
     };
 
-    public static EmployeeWithDateMetaData Generate(string id = null, string name = null, int? age = null, string companyName = null)
+    public static EmployeeWithDateMetaData Generate(string? id = null, string? name = null, int? age = null, string? companyName = null)
     {
-        return new EmployeeWithDateMetaData
+        var employee = new EmployeeWithDateMetaData
         {
-            Id = id,
             Name = name ?? "Test",
             Age = age ?? 25,
             CompanyName = companyName ?? "TestCo",
             CompanyId = "test-company"
         };
+
+        if (id is not null)
+            employee.Id = id;
+
+        return employee;
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/FileAccessHistory.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/FileAccessHistory.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 
 public record FileAccessHistory : IIdentity
 {
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
     public DateTime AccessedDateUtc { get; set; }
-    public string Path { get; set; }
+    public string Path { get; set; } = null!;
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Identity.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Identity.cs
@@ -7,14 +7,14 @@ namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 
 public class Identity : IIdentity
 {
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     protected bool Equals(Identity other)
     {
         return String.Equals(Id, other.Id, StringComparison.InvariantCultureIgnoreCase);
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj))
             return false;
@@ -50,9 +50,9 @@ public static class IdentityGenerator
         Id = DefaultId
     };
 
-    public static Identity Generate(string id = null)
+    public static Identity Generate(string? id = null)
     {
-        return new Identity { Id = id };
+        return new Identity { Id = id! };
     }
 
     public static List<Identity> GenerateIdentities(int count = 10)

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/LogEvent.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/LogEvent.cs
@@ -9,7 +9,7 @@ namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 
 public class LogEvent : IIdentity, IHaveCreatedDate
 {
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     protected bool Equals(LogEvent other)
     {
@@ -21,7 +21,7 @@ public class LogEvent : IIdentity, IHaveCreatedDate
             CreatedUtc.Equals(other.CreatedUtc);
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj))
             return false;
@@ -56,17 +56,17 @@ public class LogEvent : IIdentity, IHaveCreatedDate
         return !Equals(left, right);
     }
 
-    public string CompanyId { get; set; }
-    public string Message { get; set; }
+    public string CompanyId { get; set; } = null!;
+    public string Message { get; set; } = null!;
     public int Value { get; set; }
-    public LogEventMeta Meta { get; set; }
+    public LogEventMeta Meta { get; set; } = null!;
     public DateTimeOffset Date { get; set; }
     public DateTime CreatedUtc { get; set; }
 }
 
 public class LogEventMeta
 {
-    public string Stuff { get; set; }
+    public string Stuff { get; set; } = null!;
 }
 
 public static class LogEventGenerator
@@ -80,18 +80,18 @@ public static class LogEventGenerator
         CreatedUtc = DateTime.UtcNow
     };
 
-    public static LogEvent Generate(string id = null, string companyId = null, string message = null, DateTime? createdUtc = null, DateTimeOffset? date = null, string stuff = null)
+    public static LogEvent Generate(string? id = null, string? companyId = null, string? message = null, DateTime? createdUtc = null, DateTimeOffset? date = null, string? stuff = null)
     {
         var created = createdUtc ?? RandomData.GetDateTime(DateTime.UtcNow.StartOfMonth(), DateTime.UtcNow);
         return new LogEvent
         {
-            Id = id,
+            Id = id!,
             Message = message ?? RandomData.GetAlphaString(),
             CompanyId = companyId ?? ObjectId.GenerateNewId().ToString(),
             CreatedUtc = created,
             Meta = new LogEventMeta
             {
-                Stuff = stuff,
+                Stuff = stuff!,
             },
             Date = date ?? created
         };

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/LogEvent.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/LogEvent.cs
@@ -85,13 +85,13 @@ public static class LogEventGenerator
         var created = createdUtc ?? RandomData.GetDateTime(DateTime.UtcNow.StartOfMonth(), DateTime.UtcNow);
         return new LogEvent
         {
-            Id = id ?? ObjectId.GenerateNewId().ToString(),
+            Id = id!,
             Message = message ?? RandomData.GetAlphaString(),
             CompanyId = companyId ?? ObjectId.GenerateNewId().ToString(),
             CreatedUtc = created,
             Meta = new LogEventMeta
             {
-                Stuff = stuff ?? RandomData.GetAlphaString(),
+                Stuff = stuff!,
             },
             Date = date ?? created
         };

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/LogEvent.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/LogEvent.cs
@@ -85,13 +85,13 @@ public static class LogEventGenerator
         var created = createdUtc ?? RandomData.GetDateTime(DateTime.UtcNow.StartOfMonth(), DateTime.UtcNow);
         return new LogEvent
         {
-            Id = id!,
+            Id = id ?? String.Empty,
             Message = message ?? RandomData.GetAlphaString(),
             CompanyId = companyId ?? ObjectId.GenerateNewId().ToString(),
             CreatedUtc = created,
             Meta = new LogEventMeta
             {
-                Stuff = stuff!,
+                Stuff = stuff ?? String.Empty,
             },
             Date = date ?? created
         };

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/LogEvent.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/LogEvent.cs
@@ -85,13 +85,13 @@ public static class LogEventGenerator
         var created = createdUtc ?? RandomData.GetDateTime(DateTime.UtcNow.StartOfMonth(), DateTime.UtcNow);
         return new LogEvent
         {
-            Id = id ?? String.Empty,
+            Id = id ?? ObjectId.GenerateNewId().ToString(),
             Message = message ?? RandomData.GetAlphaString(),
             CompanyId = companyId ?? ObjectId.GenerateNewId().ToString(),
             CreatedUtc = created,
             Meta = new LogEventMeta
             {
-                Stuff = stuff ?? String.Empty,
+                Stuff = stuff ?? RandomData.GetAlphaString(),
             },
             Date = date ?? created
         };

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Parent.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Parent.cs
@@ -8,13 +8,13 @@ namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 
 public class Parent : IParentChildDocument, IHaveDates, ISupportSoftDeletes
 {
-    public string Id { get; set; }
-    string IParentChildDocument.ParentId { get; set; }
+    public string Id { get; set; } = null!;
+    string IParentChildDocument.ParentId { get; set; } = null!;
 
     [JsonPropertyName("discriminator")]
-    public JoinField Discriminator { get; set; }
+    public JoinField Discriminator { get; set; } = null!;
 
-    public string ParentProperty { get; set; }
+    public string ParentProperty { get; set; } = null!;
     public DateTime CreatedUtc { get; set; }
     public DateTime UpdatedUtc { get; set; }
     public bool IsDeleted { get; set; }
@@ -26,8 +26,8 @@ public static class ParentGenerator
 
     public static Parent Default => new() { Id = DefaultId };
 
-    public static Parent Generate(string id = null)
+    public static Parent Generate(string? id = null)
     {
-        return new Parent { Id = id };
+        return new Parent { Id = id! };
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Parent.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Models/Parent.cs
@@ -7,10 +7,10 @@ namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 
 public class Parent : IParentChildDocument, IHaveDates, ISupportSoftDeletes
 {
-    public string Id { get; set; }
-    string IParentChildDocument.ParentId { get; set; }
-    JoinField IParentChildDocument.Discriminator { get; set; }
-    public string ParentProperty { get; set; }
+    public string Id { get; set; } = null!;
+    string IParentChildDocument.ParentId { get; set; } = null!;
+    JoinField IParentChildDocument.Discriminator { get; set; } = null!;
+    public string ParentProperty { get; set; } = null!;
     public DateTime CreatedUtc { get; set; }
     public DateTime UpdatedUtc { get; set; }
     public bool IsDeleted { get; set; }
@@ -22,8 +22,8 @@ public static class ParentGenerator
 
     public static Parent Default => new() { Id = DefaultId };
 
-    public static Parent Generate(string id = null)
+    public static Parent Generate(string? id = null)
     {
-        return new Parent { Id = id };
+        return new Parent { Id = id! };
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -97,14 +97,14 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         await _employeeRepository.AddAsync(EmployeeGenerator.Generate(), o => o.ImmediateConsistency());
 
-        var allEmployees = await _employeeRepository.FindAsync(null, o => o.IncludeSoftDeletes());
+        var allEmployees = await _employeeRepository.FindAsync(null!, o => o.IncludeSoftDeletes());
         Assert.Equal(2, allEmployees.Total);
 
-        var onlyDeleted = await _employeeRepository.FindAsync(null, o => o.SoftDeleteMode(SoftDeleteQueryMode.DeletedOnly));
+        var onlyDeleted = await _employeeRepository.FindAsync(null!, o => o.SoftDeleteMode(SoftDeleteQueryMode.DeletedOnly));
         Assert.Equal(1, onlyDeleted.Total);
         Assert.Equal(employee1.Id, onlyDeleted.Documents.First().Id);
 
-        var nonDeletedEmployees = await _employeeRepository.FindAsync(null, o => o.SoftDeleteMode(SoftDeleteQueryMode.ActiveOnly));
+        var nonDeletedEmployees = await _employeeRepository.FindAsync(null!, o => o.SoftDeleteMode(SoftDeleteQueryMode.ActiveOnly));
         Assert.Equal(1, nonDeletedEmployees.Total);
         Assert.NotEqual(employee1.Id, nonDeletedEmployees.Documents.First().Id);
     }
@@ -120,7 +120,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         await _employeeRepository.AddAsync(EmployeeGenerator.Generate(), o => o.ImmediateConsistency());
 
-        var allEmployees = await _employeeRepository.FindAsync(null, o => o.IncludeSoftDeletes());
+        var allEmployees = await _employeeRepository.FindAsync(null!, o => o.IncludeSoftDeletes());
         Assert.Equal(2, allEmployees.Total);
 
         var onlyDeleted = await _employeeRepository.FindAsync(q => q.FilterExpression("isDeleted:true"), o => o.IncludeSoftDeletes());
@@ -552,7 +552,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         Assert.NotNull(dateAgg);
         Assert.Single(dateAgg.Buckets);
         Assert.Equal(utcNow.AddDays(-1).Date, dateAgg.Buckets.First().Date);
-        Assert.Equal(utcNow.AddDays(-1).Floor(TimeSpan.FromMilliseconds(1)), dateAgg.Buckets.First().Aggregations.Min<DateTime>("min_createdUtc").Value.Floor(TimeSpan.FromMilliseconds(1)));
+        Assert.Equal(utcNow.AddDays(-1).Floor(TimeSpan.FromMilliseconds(1)), dateAgg.Buckets.First().Aggregations.Min<DateTime>("min_createdUtc")!.Value.Floor(TimeSpan.FromMilliseconds(1)));
 
         result = await _dailyRepository.CountAsync(q => q.AggregationsExpression("date:(createdUtc~1h^-3h min:createdUtc)"));
         Assert.Single(result.Aggregations);
@@ -787,7 +787,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new JsonPatch(patch));
 
         // Assert
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(expectedUpdatedUtc, employee.UpdatedUtc);
@@ -841,7 +841,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new ActionPatch<Employee>(e => e.Name = "Patched"));
 
         // Assert
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(expectedUpdatedUtc, employee.UpdatedUtc);
@@ -894,7 +894,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new ScriptPatch("ctx._source.name = 'Patched';"));
 
         // Assert
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(expectedUpdatedUtc, employee.UpdatedUtc);
@@ -919,7 +919,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new PartialPatch(new { name = "Patched" }));
 
         // Assert
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(expectedUpdatedUtc, employee.UpdatedUtc);
@@ -946,7 +946,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         });
 
         // Assert
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(callerProvidedTime, employee.UpdatedUtc);
@@ -969,7 +969,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new PartialPatch(new { name = "Patched", updatedUtc = callerProvidedTime }));
 
         // Assert
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(callerProvidedTime, employee.UpdatedUtc);
@@ -987,10 +987,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
 
         // Assert
-        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.NotNull(employee.MetaData);
-        Assert.Equal(expectedTime, employee.MetaData.DateCreatedUtc);
-        Assert.Equal(expectedTime, employee.MetaData.DateUpdatedUtc);
+        Assert.Equal(expectedTime, employee.MetaData!.DateCreatedUtc);
+        Assert.Equal(expectedTime, employee.MetaData!.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1001,7 +1001,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData.DateCreatedUtc;
+        var originalCreated = employee.MetaData!.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var expectedUpdated = timeProvider.GetUtcNow().UtcDateTime;
@@ -1011,10 +1011,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeWithDateMetaDataRepository.SaveAsync(employee);
 
         // Assert
-        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("Saved", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
-        Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
+        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
+        Assert.Equal(expectedUpdated, employee.MetaData!.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1025,7 +1025,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData.DateCreatedUtc;
+        var originalCreated = employee.MetaData!.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var expectedUpdated = timeProvider.GetUtcNow().UtcDateTime;
@@ -1035,10 +1035,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeWithDateMetaDataRepository.PatchAsync(employee.Id, new JsonPatch(patch));
 
         // Assert
-        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("JsonPatched", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
-        Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
+        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
+        Assert.Equal(expectedUpdated, employee.MetaData!.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1049,7 +1049,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData.DateCreatedUtc;
+        var originalCreated = employee.MetaData!.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var expectedUpdated = timeProvider.GetUtcNow().UtcDateTime;
@@ -1059,10 +1059,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
             new ActionPatch<EmployeeWithDateMetaData>(e => e.Name = "ActionPatched"));
 
         // Assert
-        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("ActionPatched", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
-        Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
+        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
+        Assert.Equal(expectedUpdated, employee.MetaData!.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1073,7 +1073,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData.DateCreatedUtc;
+        var originalCreated = employee.MetaData!.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var expectedUpdated = timeProvider.GetUtcNow().UtcDateTime;
@@ -1083,10 +1083,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
             new ScriptPatch("ctx._source.name = 'ScriptPatched';"));
 
         // Assert
-        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("ScriptPatched", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
-        Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
+        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
+        Assert.Equal(expectedUpdated, employee.MetaData!.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1097,7 +1097,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData.DateCreatedUtc;
+        var originalCreated = employee.MetaData!.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var expectedUpdated = timeProvider.GetUtcNow().UtcDateTime;
@@ -1107,10 +1107,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
             new PartialPatch(new { name = "PartialPatched" }));
 
         // Assert
-        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("PartialPatched", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
-        Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
+        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
+        Assert.Equal(expectedUpdated, employee.MetaData!.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1121,7 +1121,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData.DateCreatedUtc;
+        var originalCreated = employee.MetaData!.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var callerProvidedTime = new DateTime(2020, 6, 15, 12, 0, 0, DateTimeKind.Utc);
@@ -1134,10 +1134,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
             });
 
         // Assert
-        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("CallerScript", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
-        Assert.Equal(callerProvidedTime, employee.MetaData.DateUpdatedUtc);
+        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
+        Assert.Equal(callerProvidedTime, employee.MetaData!.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1148,7 +1148,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData.DateCreatedUtc;
+        var originalCreated = employee.MetaData!.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var callerProvidedTime = new DateTime(2020, 6, 15, 12, 0, 0, DateTimeKind.Utc);
@@ -1158,10 +1158,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
             new PartialPatch(new { metaData = new { dateUpdatedUtc = callerProvidedTime }, name = "CallerPartial" }));
 
         // Assert
-        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("CallerPartial", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
-        Assert.Equal(callerProvidedTime, employee.MetaData.DateUpdatedUtc);
+        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
+        Assert.Equal(callerProvidedTime, employee.MetaData!.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1172,7 +1172,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var patch = new PatchDocument(new ReplaceOperation { Path = "name", Value = "Patched" });
         await _employeeRepository.PatchAsync(employee.Id, new JsonPatch(patch));
 
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal("1:1", employee.Version);
@@ -1197,10 +1197,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var cts = new CancellationTokenSource();
 
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default, o => o.Cache(false));
-        string employeeId = employee.Id;
+        string employeeId = employee.Id!;
         _ = Parallel.ForEachAsync(Enumerable.Range(1, 100), new ParallelOptions { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token }, async (iteration, ct) =>
         {
-            var e = await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false));
+            var e = (await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false)))!;
             resetEvent.Set();
             e.CompanyName = $"Company {iteration}";
             try
@@ -1216,7 +1216,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         _logger.LogInformation("Saving name");
         resetEvent.WaitOne();
-        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
         resetEvent.WaitOne();
         employee.Name = "Saved";
         try
@@ -1238,7 +1238,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await cts.CancelAsync();
         await Task.Delay(100, TestCancellationToken);
 
-        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         _logger.LogInformation("Got employee with company {CompanyName}", employee.CompanyName);
@@ -1252,10 +1252,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var cts = new CancellationTokenSource();
 
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default, o => o.Cache(false));
-        string employeeId = employee.Id;
+        string employeeId = employee.Id!;
         _ = Parallel.ForEachAsync(Enumerable.Range(1, 100), new ParallelOptions { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token }, async (iteration, ct) =>
         {
-            var e = await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false));
+            var e = (await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false)))!;
             resetEvent.Set();
             e.CompanyName = $"Company {iteration}";
             try
@@ -1271,7 +1271,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         _logger.LogInformation("Saving name");
         resetEvent.WaitOne();
-        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
         resetEvent.WaitOne();
         employee.Name = "Saved";
         try
@@ -1293,7 +1293,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await cts.CancelAsync();
         await Task.Delay(100, TestCancellationToken);
 
-        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         _logger.LogInformation("Got employee with company {CompanyName}", employee.CompanyName);
@@ -1306,7 +1306,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default);
         await _employeeRepository.PatchAsync(employee.Id, new PartialPatch(new { name = "Patched" }));
 
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal("1:1", employee.Version);
@@ -1325,10 +1325,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         Assert.Equal("OriginalCompany", employee.CompanyName);
 
         // Act
-        await _employeeRepository.PatchAsync(employee.Id, new PartialPatch(new { companyName = (string)null }));
+        await _employeeRepository.PatchAsync(employee.Id, new PartialPatch(new { companyName = (string?)null }));
 
         // Assert
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         // TODO: This should be null once elastic/elasticsearch-net#8763 is fixed.
         // Currently the null value is silently dropped, so the field retains its original value.
         Assert.Equal("OriginalCompany", employee.CompanyName);
@@ -1340,7 +1340,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default);
         await _employeeRepository.PatchAsync(employee.Id, new ScriptPatch("ctx._source.name = 'Patched';"));
 
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal("1:1", employee.Version);
@@ -1353,10 +1353,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var cts = new CancellationTokenSource();
 
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default, o => o.Cache(false));
-        string employeeId = employee.Id;
+        string employeeId = employee.Id!;
         _ = Parallel.ForEachAsync(Enumerable.Range(1, 100), new ParallelOptions { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token }, async (iteration, ct) =>
         {
-            var e = await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false));
+            var e = (await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false)))!;
             resetEvent.Set();
             e.CompanyName = $"Company {iteration}";
             try
@@ -1372,7 +1372,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         _logger.LogInformation("Saving name");
         resetEvent.WaitOne();
-        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
         resetEvent.WaitOne();
         employee.Name = "Saved";
         try
@@ -1393,7 +1393,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await cts.CancelAsync();
         await Task.Delay(100, TestCancellationToken);
 
-        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         _logger.LogInformation("Got employee with company {CompanyName}", employee.CompanyName);
@@ -1406,7 +1406,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default);
         await _employeeRepository.PatchAsync(employee.Id, new ActionPatch<Employee>(e => e.Name = "Patched"));
 
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal("1:1", employee.Version);
@@ -1430,10 +1430,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var cts = new CancellationTokenSource();
 
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default, o => o.Cache(false));
-        string employeeId = employee.Id;
+        string employeeId = employee.Id!;
         _ = Parallel.ForEachAsync(Enumerable.Range(1, 100), new ParallelOptions { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token }, async (iteration, ct) =>
         {
-            var e = await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false));
+            var e = (await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false)))!;
             resetEvent.Set();
             e.CompanyName = $"Company {iteration}";
             try
@@ -1449,7 +1449,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         _logger.LogInformation("Saving name");
         resetEvent.WaitOne();
-        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
         resetEvent.WaitOne();
         employee.Name = "Saved";
         try
@@ -1470,7 +1470,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await cts.CancelAsync();
         await Task.Delay(100, TestCancellationToken);
 
-        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         _logger.LogInformation("Got employee with company {CompanyName}", employee.CompanyName);
@@ -1943,7 +1943,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await Task.WhenAll(ids.Select(async id =>
         {
             var emp = await _employeeRepository.GetByIdAsync(id);
-            Assert.Equal("ActionPatched", emp.CompanyName);
+            Assert.Equal("ActionPatched", emp!.CompanyName);
         }));
     }
 
@@ -2032,7 +2032,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         Assert.True(modified);
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("Changed", employee.Name);
     }
 
@@ -2061,7 +2061,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         Assert.True(modified);
-        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("Changed", employee.Name);
     }
 
@@ -2244,7 +2244,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
     {
         // Arrange
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default, o => o.ImmediateConsistency());
-        var original = await _employeeRepository.GetByIdAsync(employee.Id);
+        var original = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         string originalVersion = original.Version;
 
         // Act — noop action should NOT write to Elasticsearch
@@ -2252,7 +2252,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         Assert.False(modified);
-        var after = await _employeeRepository.GetByIdAsync(employee.Id);
+        var after = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal(originalVersion, after.Version);
     }
 
@@ -2314,7 +2314,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         Assert.True(modified);
-        var after = await _employeeRepository.GetByIdAsync(employee.Id);
+        var after = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("Changed", after.Name);
     }
 
@@ -2433,7 +2433,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         Assert.True(modified);
-        var after = await _employeeRepository.GetByIdAsync(employee.Id);
+        var after = (await _employeeRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("Changed", after.Name);
         Assert.Equal(99, after.Age);
     }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -789,7 +789,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new JsonPatch(patch));
 
         // Assert
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(expectedUpdatedUtc, employee.UpdatedUtc);
@@ -843,7 +844,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new ActionPatch<Employee>(e => e.Name = "Patched"));
 
         // Assert
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(expectedUpdatedUtc, employee.UpdatedUtc);
@@ -896,7 +898,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new ScriptPatch("ctx._source.name = 'Patched';"));
 
         // Assert
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(expectedUpdatedUtc, employee.UpdatedUtc);
@@ -921,7 +924,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new PartialPatch(new { name = "Patched" }));
 
         // Assert
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(expectedUpdatedUtc, employee.UpdatedUtc);
@@ -948,7 +952,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         });
 
         // Assert
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(callerProvidedTime, employee.UpdatedUtc);
@@ -971,7 +976,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new PartialPatch(new { name = "Patched", updatedUtc = callerProvidedTime }));
 
         // Assert
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(callerProvidedTime, employee.UpdatedUtc);
@@ -989,7 +995,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
 
         // Assert
-        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.NotNull(employee.MetaData);
         Assert.Equal(expectedTime, employee.MetaData.DateCreatedUtc);
         Assert.Equal(expectedTime, employee.MetaData.DateUpdatedUtc);
@@ -1014,7 +1021,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeWithDateMetaDataRepository.SaveAsync(employee);
 
         // Assert
-        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Saved", employee.Name);
         Assert.NotNull(employee.MetaData);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
@@ -1040,7 +1048,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeWithDateMetaDataRepository.PatchAsync(employee.Id, new JsonPatch(patch));
 
         // Assert
-        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("JsonPatched", employee.Name);
         Assert.NotNull(employee.MetaData);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
@@ -1066,7 +1075,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
             new ActionPatch<EmployeeWithDateMetaData>(e => e.Name = "ActionPatched"));
 
         // Assert
-        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("ActionPatched", employee.Name);
         Assert.NotNull(employee.MetaData);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
@@ -1092,7 +1102,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
             new ScriptPatch("ctx._source.name = 'ScriptPatched';"));
 
         // Assert
-        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("ScriptPatched", employee.Name);
         Assert.NotNull(employee.MetaData);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
@@ -1118,7 +1129,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
             new PartialPatch(new { name = "PartialPatched" }));
 
         // Assert
-        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("PartialPatched", employee.Name);
         Assert.NotNull(employee.MetaData);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
@@ -1147,7 +1159,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
             });
 
         // Assert
-        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("CallerScript", employee.Name);
         Assert.NotNull(employee.MetaData);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
@@ -1173,7 +1186,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
             new PartialPatch(new { metaData = new { dateUpdatedUtc = callerProvidedTime }, name = "CallerPartial" }));
 
         // Assert
-        employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("CallerPartial", employee.Name);
         Assert.NotNull(employee.MetaData);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
@@ -1188,7 +1202,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var patch = new PatchDocument(new ReplaceOperation { Path = "name", Value = "Patched" });
         await _employeeRepository.PatchAsync(employee.Id, new JsonPatch(patch));
 
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal("1:1", employee.Version);
@@ -1213,10 +1228,11 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var cts = new CancellationTokenSource();
 
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default, o => o.Cache(false));
-        string employeeId = employee.Id!;
+        string employeeId = employee.Id;
         _ = Parallel.ForEachAsync(Enumerable.Range(1, 100), new ParallelOptions { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token }, async (iteration, ct) =>
         {
-            var e = (await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false)))!;
+            var e = await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false));
+            Assert.NotNull(e);
             resetEvent.Set();
             e.CompanyName = $"Company {iteration}";
             try
@@ -1232,7 +1248,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         _logger.LogInformation("Saving name");
         resetEvent.WaitOne();
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         resetEvent.WaitOne();
         employee.Name = "Saved";
         try
@@ -1254,7 +1271,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await cts.CancelAsync();
         await Task.Delay(100, TestCancellationToken);
 
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         _logger.LogInformation("Got employee with company {CompanyName}", employee.CompanyName);
@@ -1268,10 +1286,11 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var cts = new CancellationTokenSource();
 
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default, o => o.Cache(false));
-        string employeeId = employee.Id!;
+        string employeeId = employee.Id;
         _ = Parallel.ForEachAsync(Enumerable.Range(1, 100), new ParallelOptions { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token }, async (iteration, ct) =>
         {
-            var e = (await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false)))!;
+            var e = await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false));
+            Assert.NotNull(e);
             resetEvent.Set();
             e.CompanyName = $"Company {iteration}";
             try
@@ -1287,7 +1306,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         _logger.LogInformation("Saving name");
         resetEvent.WaitOne();
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         resetEvent.WaitOne();
         employee.Name = "Saved";
         try
@@ -1309,7 +1329,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await cts.CancelAsync();
         await Task.Delay(100, TestCancellationToken);
 
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         _logger.LogInformation("Got employee with company {CompanyName}", employee.CompanyName);
@@ -1322,7 +1343,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default);
         await _employeeRepository.PatchAsync(employee.Id, new PartialPatch(new { name = "Patched" }));
 
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal("1:1", employee.Version);
@@ -1344,7 +1366,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new PartialPatch(new { companyName = (string?)null }));
 
         // Assert
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         // TODO: This should be null once elastic/elasticsearch-net#8763 is fixed.
         // Currently the null value is silently dropped, so the field retains its original value.
         Assert.Equal("OriginalCompany", employee.CompanyName);
@@ -1356,7 +1379,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default);
         await _employeeRepository.PatchAsync(employee.Id, new ScriptPatch("ctx._source.name = 'Patched';"));
 
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal("1:1", employee.Version);
@@ -1369,10 +1393,11 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var cts = new CancellationTokenSource();
 
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default, o => o.Cache(false));
-        string employeeId = employee.Id!;
+        string employeeId = employee.Id;
         _ = Parallel.ForEachAsync(Enumerable.Range(1, 100), new ParallelOptions { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token }, async (iteration, ct) =>
         {
-            var e = (await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false)))!;
+            var e = await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false));
+            Assert.NotNull(e);
             resetEvent.Set();
             e.CompanyName = $"Company {iteration}";
             try
@@ -1388,7 +1413,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         _logger.LogInformation("Saving name");
         resetEvent.WaitOne();
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         resetEvent.WaitOne();
         employee.Name = "Saved";
         try
@@ -1409,7 +1435,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await cts.CancelAsync();
         await Task.Delay(100, TestCancellationToken);
 
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         _logger.LogInformation("Got employee with company {CompanyName}", employee.CompanyName);
@@ -1422,7 +1449,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default);
         await _employeeRepository.PatchAsync(employee.Id, new ActionPatch<Employee>(e => e.Name = "Patched"));
 
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal("1:1", employee.Version);
@@ -1446,10 +1474,11 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var cts = new CancellationTokenSource();
 
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default, o => o.Cache(false));
-        string employeeId = employee.Id!;
+        string employeeId = employee.Id;
         _ = Parallel.ForEachAsync(Enumerable.Range(1, 100), new ParallelOptions { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token }, async (iteration, ct) =>
         {
-            var e = (await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false)))!;
+            var e = await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false));
+            Assert.NotNull(e);
             resetEvent.Set();
             e.CompanyName = $"Company {iteration}";
             try
@@ -1465,7 +1494,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         _logger.LogInformation("Saving name");
         resetEvent.WaitOne();
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         resetEvent.WaitOne();
         employee.Name = "Saved";
         try
@@ -1486,7 +1516,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await cts.CancelAsync();
         await Task.Delay(100, TestCancellationToken);
 
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false)))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         _logger.LogInformation("Got employee with company {CompanyName}", employee.CompanyName);
@@ -2049,7 +2080,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         Assert.True(modified);
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Changed", employee.Name);
     }
 
@@ -2078,7 +2110,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         Assert.True(modified);
-        employee = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Changed", employee.Name);
     }
 
@@ -2261,7 +2294,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
     {
         // Arrange
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default, o => o.ImmediateConsistency());
-        var original = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        var original = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(original);
         string originalVersion = original.Version;
 
         // Act — noop action should NOT write to Elasticsearch
@@ -2269,7 +2303,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         Assert.False(modified);
-        var after = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        var after = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(after);
         Assert.Equal(originalVersion, after.Version);
     }
 
@@ -2331,7 +2366,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         Assert.True(modified);
-        var after = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        var after = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(after);
         Assert.Equal("Changed", after.Name);
     }
 
@@ -2450,7 +2486,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         Assert.True(modified);
-        var after = (await _employeeRepository.GetByIdAsync(employee.Id))!;
+        var after = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(after);
         Assert.Equal("Changed", after.Name);
         Assert.Equal(99, after.Age);
     }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -552,7 +552,9 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         Assert.NotNull(dateAgg);
         Assert.Single(dateAgg.Buckets);
         Assert.Equal(utcNow.AddDays(-1).Date, dateAgg.Buckets.First().Date);
-        Assert.Equal(utcNow.AddDays(-1).Floor(TimeSpan.FromMilliseconds(1)), dateAgg.Buckets.First().Aggregations.Min<DateTime>("min_createdUtc")!.Value.Floor(TimeSpan.FromMilliseconds(1)));
+        var minAgg = dateAgg.Buckets.First().Aggregations.Min<DateTime>("min_createdUtc");
+        Assert.NotNull(minAgg);
+        Assert.Equal(utcNow.AddDays(-1).Floor(TimeSpan.FromMilliseconds(1)), minAgg.Value.Floor(TimeSpan.FromMilliseconds(1)));
 
         result = await _dailyRepository.CountAsync(q => q.AggregationsExpression("date:(createdUtc~1h^-3h min:createdUtc)"));
         Assert.Single(result.Aggregations);
@@ -989,8 +991,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.NotNull(employee.MetaData);
-        Assert.Equal(expectedTime, employee.MetaData!.DateCreatedUtc);
-        Assert.Equal(expectedTime, employee.MetaData!.DateUpdatedUtc);
+        Assert.Equal(expectedTime, employee.MetaData.DateCreatedUtc);
+        Assert.Equal(expectedTime, employee.MetaData.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1001,7 +1003,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData!.DateCreatedUtc;
+        Assert.NotNull(employee.MetaData);
+        var originalCreated = employee.MetaData.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var expectedUpdated = timeProvider.GetUtcNow().UtcDateTime;
@@ -1013,8 +1016,9 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("Saved", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
-        Assert.Equal(expectedUpdated, employee.MetaData!.DateUpdatedUtc);
+        Assert.NotNull(employee.MetaData);
+        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
+        Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1025,7 +1029,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData!.DateCreatedUtc;
+        Assert.NotNull(employee.MetaData);
+        var originalCreated = employee.MetaData.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var expectedUpdated = timeProvider.GetUtcNow().UtcDateTime;
@@ -1037,8 +1042,9 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("JsonPatched", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
-        Assert.Equal(expectedUpdated, employee.MetaData!.DateUpdatedUtc);
+        Assert.NotNull(employee.MetaData);
+        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
+        Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1049,7 +1055,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData!.DateCreatedUtc;
+        Assert.NotNull(employee.MetaData);
+        var originalCreated = employee.MetaData.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var expectedUpdated = timeProvider.GetUtcNow().UtcDateTime;
@@ -1061,8 +1068,9 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("ActionPatched", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
-        Assert.Equal(expectedUpdated, employee.MetaData!.DateUpdatedUtc);
+        Assert.NotNull(employee.MetaData);
+        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
+        Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1073,7 +1081,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData!.DateCreatedUtc;
+        Assert.NotNull(employee.MetaData);
+        var originalCreated = employee.MetaData.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var expectedUpdated = timeProvider.GetUtcNow().UtcDateTime;
@@ -1085,8 +1094,9 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("ScriptPatched", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
-        Assert.Equal(expectedUpdated, employee.MetaData!.DateUpdatedUtc);
+        Assert.NotNull(employee.MetaData);
+        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
+        Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1097,7 +1107,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData!.DateCreatedUtc;
+        Assert.NotNull(employee.MetaData);
+        var originalCreated = employee.MetaData.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var expectedUpdated = timeProvider.GetUtcNow().UtcDateTime;
@@ -1109,8 +1120,9 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("PartialPatched", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
-        Assert.Equal(expectedUpdated, employee.MetaData!.DateUpdatedUtc);
+        Assert.NotNull(employee.MetaData);
+        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
+        Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1121,7 +1133,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData!.DateCreatedUtc;
+        Assert.NotNull(employee.MetaData);
+        var originalCreated = employee.MetaData.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var callerProvidedTime = new DateTime(2020, 6, 15, 12, 0, 0, DateTimeKind.Utc);
@@ -1136,8 +1149,9 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("CallerScript", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
-        Assert.Equal(callerProvidedTime, employee.MetaData!.DateUpdatedUtc);
+        Assert.NotNull(employee.MetaData);
+        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
+        Assert.Equal(callerProvidedTime, employee.MetaData.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1148,7 +1162,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _configuration.TimeProvider = timeProvider;
 
         var employee = await _employeeWithDateMetaDataRepository.AddAsync(EmployeeWithDateMetaDataGenerator.Default);
-        var originalCreated = employee.MetaData!.DateCreatedUtc;
+        Assert.NotNull(employee.MetaData);
+        var originalCreated = employee.MetaData.DateCreatedUtc;
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var callerProvidedTime = new DateTime(2020, 6, 15, 12, 0, 0, DateTimeKind.Utc);
@@ -1160,8 +1175,9 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         employee = (await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id))!;
         Assert.Equal("CallerPartial", employee.Name);
-        Assert.Equal(originalCreated, employee.MetaData!.DateCreatedUtc);
-        Assert.Equal(callerProvidedTime, employee.MetaData!.DateUpdatedUtc);
+        Assert.NotNull(employee.MetaData);
+        Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
+        Assert.Equal(callerProvidedTime, employee.MetaData.DateUpdatedUtc);
     }
 
     [Fact]
@@ -1943,7 +1959,8 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await Task.WhenAll(ids.Select(async id =>
         {
             var emp = await _employeeRepository.GetByIdAsync(id);
-            Assert.Equal("ActionPatched", emp!.CompanyName);
+            Assert.NotNull(emp);
+            Assert.Equal("ActionPatched", emp.CompanyName);
         }));
     }
 

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -97,14 +97,14 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         await _employeeRepository.AddAsync(EmployeeGenerator.Generate(), o => o.ImmediateConsistency());
 
-        var allEmployees = await _employeeRepository.FindAsync(null, o => o.IncludeSoftDeletes());
+        var allEmployees = await _employeeRepository.FindAsync(q => q, o => o.IncludeSoftDeletes());
         Assert.Equal(2, allEmployees.Total);
 
-        var onlyDeleted = await _employeeRepository.FindAsync(null, o => o.SoftDeleteMode(SoftDeleteQueryMode.DeletedOnly));
+        var onlyDeleted = await _employeeRepository.FindAsync(q => q, o => o.SoftDeleteMode(SoftDeleteQueryMode.DeletedOnly));
         Assert.Equal(1, onlyDeleted.Total);
         Assert.Equal(employee1.Id, onlyDeleted.Documents.First().Id);
 
-        var nonDeletedEmployees = await _employeeRepository.FindAsync(null, o => o.SoftDeleteMode(SoftDeleteQueryMode.ActiveOnly));
+        var nonDeletedEmployees = await _employeeRepository.FindAsync(q => q, o => o.SoftDeleteMode(SoftDeleteQueryMode.ActiveOnly));
         Assert.Equal(1, nonDeletedEmployees.Total);
         Assert.NotEqual(employee1.Id, nonDeletedEmployees.Documents.First().Id);
     }
@@ -120,7 +120,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         await _employeeRepository.AddAsync(EmployeeGenerator.Generate(), o => o.ImmediateConsistency());
 
-        var allEmployees = await _employeeRepository.FindAsync(null, o => o.IncludeSoftDeletes());
+        var allEmployees = await _employeeRepository.FindAsync(q => q, o => o.IncludeSoftDeletes());
         Assert.Equal(2, allEmployees.Total);
 
         var onlyDeleted = await _employeeRepository.FindAsync(q => q.FilterExpression("isDeleted:true"), o => o.IncludeSoftDeletes());
@@ -552,7 +552,9 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         Assert.NotNull(dateAgg);
         Assert.Single(dateAgg.Buckets);
         Assert.Equal(utcNow.AddDays(-1).Date, dateAgg.Buckets.First().Date);
-        Assert.Equal(utcNow.AddDays(-1).Floor(TimeSpan.FromMilliseconds(1)), dateAgg.Buckets.First().Aggregations.Min<DateTime>("min_createdUtc").Value.Floor(TimeSpan.FromMilliseconds(1)));
+        var minCreatedUtc = dateAgg.Buckets.First().Aggregations.Min<DateTime>("min_createdUtc");
+        Assert.NotNull(minCreatedUtc);
+        Assert.Equal(utcNow.AddDays(-1).Floor(TimeSpan.FromMilliseconds(1)), minCreatedUtc.Value.Floor(TimeSpan.FromMilliseconds(1)));
 
         result = await _dailyRepository.CountAsync(q => q.AggregationsExpression("date:(createdUtc~1h^-3h min:createdUtc)"));
         Assert.Single(result.Aggregations);
@@ -788,6 +790,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(expectedUpdatedUtc, employee.UpdatedUtc);
@@ -842,6 +845,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(expectedUpdatedUtc, employee.UpdatedUtc);
@@ -895,6 +899,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(expectedUpdatedUtc, employee.UpdatedUtc);
@@ -920,6 +925,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(expectedUpdatedUtc, employee.UpdatedUtc);
@@ -947,6 +953,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(callerProvidedTime, employee.UpdatedUtc);
@@ -970,6 +977,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal(originalCreatedUtc, employee.CreatedUtc);
         Assert.Equal(callerProvidedTime, employee.UpdatedUtc);
@@ -988,6 +996,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.NotNull(employee.MetaData);
         Assert.Equal(expectedTime, employee.MetaData.DateCreatedUtc);
         Assert.Equal(expectedTime, employee.MetaData.DateUpdatedUtc);
@@ -1012,6 +1021,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Saved", employee.Name);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
         Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
@@ -1036,6 +1046,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("JsonPatched", employee.Name);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
         Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
@@ -1060,6 +1071,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("ActionPatched", employee.Name);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
         Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
@@ -1084,6 +1096,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("ScriptPatched", employee.Name);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
         Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
@@ -1108,6 +1121,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("PartialPatched", employee.Name);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
         Assert.Equal(expectedUpdated, employee.MetaData.DateUpdatedUtc);
@@ -1135,6 +1149,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("CallerScript", employee.Name);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
         Assert.Equal(callerProvidedTime, employee.MetaData.DateUpdatedUtc);
@@ -1159,6 +1174,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         employee = await _employeeWithDateMetaDataRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("CallerPartial", employee.Name);
         Assert.Equal(originalCreated, employee.MetaData.DateCreatedUtc);
         Assert.Equal(callerProvidedTime, employee.MetaData.DateUpdatedUtc);
@@ -1173,6 +1189,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new JsonPatch(patch));
 
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal("1:1", employee.Version);
@@ -1201,6 +1218,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _ = Parallel.ForEachAsync(Enumerable.Range(1, 100), new ParallelOptions { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token }, async (i, ct) =>
         {
             var e = await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false));
+            Assert.NotNull(e);
             resetEvent.Set();
             e.CompanyName = "Company " + i;
             try
@@ -1217,6 +1235,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _logger.LogInformation("Saving name");
         resetEvent.WaitOne();
         employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         resetEvent.WaitOne();
         employee.Name = "Saved";
         try
@@ -1239,6 +1258,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await Task.Delay(100, TestCancellationToken);
 
         employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         _logger.LogInformation("Got employee with company {CompanyName}", employee.CompanyName);
@@ -1256,6 +1276,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _ = Parallel.ForEachAsync(Enumerable.Range(1, 100), new ParallelOptions { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token }, async (i, ct) =>
         {
             var e = await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false));
+            Assert.NotNull(e);
             resetEvent.Set();
             e.CompanyName = "Company " + i;
             try
@@ -1272,6 +1293,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _logger.LogInformation("Saving name");
         resetEvent.WaitOne();
         employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         resetEvent.WaitOne();
         employee.Name = "Saved";
         try
@@ -1294,6 +1316,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await Task.Delay(100, TestCancellationToken);
 
         employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         _logger.LogInformation("Got employee with company {CompanyName}", employee.CompanyName);
@@ -1307,6 +1330,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new PartialPatch(new { name = "Patched" }));
 
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal("1:1", employee.Version);
@@ -1319,6 +1343,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new ScriptPatch("ctx._source.name = 'Patched';"));
 
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal("1:1", employee.Version);
@@ -1335,6 +1360,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _ = Parallel.ForEachAsync(Enumerable.Range(1, 100), new ParallelOptions { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token }, async (i, ct) =>
         {
             var e = await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false));
+            Assert.NotNull(e);
             resetEvent.Set();
             e.CompanyName = "Company " + i;
             try
@@ -1351,6 +1377,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _logger.LogInformation("Saving name");
         resetEvent.WaitOne();
         employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         resetEvent.WaitOne();
         employee.Name = "Saved";
         try
@@ -1372,6 +1399,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await Task.Delay(100, TestCancellationToken);
 
         employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         _logger.LogInformation("Got employee with company {CompanyName}", employee.CompanyName);
@@ -1385,6 +1413,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await _employeeRepository.PatchAsync(employee.Id, new ActionPatch<Employee>(e => e.Name = "Patched"));
 
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         Assert.Equal("1:1", employee.Version);
@@ -1412,6 +1441,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _ = Parallel.ForEachAsync(Enumerable.Range(1, 100), new ParallelOptions { MaxDegreeOfParallelism = 2, CancellationToken = cts.Token }, async (i, ct) =>
         {
             var e = await _employeeRepository.GetByIdAsync(employeeId, o => o.Cache(false));
+            Assert.NotNull(e);
             resetEvent.Set();
             e.CompanyName = "Company " + i;
             try
@@ -1428,6 +1458,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         _logger.LogInformation("Saving name");
         resetEvent.WaitOne();
         employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         resetEvent.WaitOne();
         employee.Name = "Saved";
         try
@@ -1449,6 +1480,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await Task.Delay(100, TestCancellationToken);
 
         employee = await _employeeRepository.GetByIdAsync(employee.Id, o => o.Cache(false));
+        Assert.NotNull(employee);
         Assert.Equal(EmployeeGenerator.Default.Age, employee.Age);
         Assert.Equal("Patched", employee.Name);
         _logger.LogInformation("Got employee with company {CompanyName}", employee.CompanyName);
@@ -1919,6 +1951,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await Task.WhenAll(ids.Select(async id =>
         {
             var emp = await _employeeRepository.GetByIdAsync(id);
+            Assert.NotNull(emp);
             Assert.Equal("ActionPatched", emp.CompanyName);
         }));
     }
@@ -2009,6 +2042,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         Assert.True(modified);
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Changed", employee.Name);
     }
 
@@ -2038,6 +2072,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         Assert.True(modified);
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("Changed", employee.Name);
     }
 
@@ -2221,6 +2256,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Arrange
         var employee = await _employeeRepository.AddAsync(EmployeeGenerator.Default, o => o.ImmediateConsistency());
         var original = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(original);
         string originalVersion = original.Version;
 
         // Act — noop action should NOT write to Elasticsearch
@@ -2229,6 +2265,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         Assert.False(modified);
         var after = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(after);
         Assert.Equal(originalVersion, after.Version);
     }
 
@@ -2291,6 +2328,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         Assert.True(modified);
         var after = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(after);
         Assert.Equal("Changed", after.Name);
     }
 
@@ -2410,6 +2448,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         // Assert
         Assert.True(modified);
         var after = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(after);
         Assert.Equal("Changed", after.Name);
         Assert.Equal(99, after.Age);
     }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -97,14 +97,14 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         await _employeeRepository.AddAsync(EmployeeGenerator.Generate(), o => o.ImmediateConsistency());
 
-        var allEmployees = await _employeeRepository.FindAsync(null!, o => o.IncludeSoftDeletes());
+        var allEmployees = await _employeeRepository.FindAsync(q => q, o => o.IncludeSoftDeletes());
         Assert.Equal(2, allEmployees.Total);
 
-        var onlyDeleted = await _employeeRepository.FindAsync(null!, o => o.SoftDeleteMode(SoftDeleteQueryMode.DeletedOnly));
+        var onlyDeleted = await _employeeRepository.FindAsync(q => q, o => o.SoftDeleteMode(SoftDeleteQueryMode.DeletedOnly));
         Assert.Equal(1, onlyDeleted.Total);
         Assert.Equal(employee1.Id, onlyDeleted.Documents.First().Id);
 
-        var nonDeletedEmployees = await _employeeRepository.FindAsync(null!, o => o.SoftDeleteMode(SoftDeleteQueryMode.ActiveOnly));
+        var nonDeletedEmployees = await _employeeRepository.FindAsync(q => q, o => o.SoftDeleteMode(SoftDeleteQueryMode.ActiveOnly));
         Assert.Equal(1, nonDeletedEmployees.Total);
         Assert.NotEqual(employee1.Id, nonDeletedEmployees.Documents.First().Id);
     }
@@ -120,7 +120,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         await _employeeRepository.AddAsync(EmployeeGenerator.Generate(), o => o.ImmediateConsistency());
 
-        var allEmployees = await _employeeRepository.FindAsync(null!, o => o.IncludeSoftDeletes());
+        var allEmployees = await _employeeRepository.FindAsync(q => q, o => o.IncludeSoftDeletes());
         Assert.Equal(2, allEmployees.Total);
 
         var onlyDeleted = await _employeeRepository.FindAsync(q => q.FilterExpression("isDeleted:true"), o => o.IncludeSoftDeletes());

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/VersionedTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/VersionedTests.cs
@@ -100,7 +100,9 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         Assert.Equal("1:0", employee.Version);
 
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         var employeeCopy = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employeeCopy);
         Assert.Equal(employee, employeeCopy);
         Assert.Equal("1:0", employee.Version);
 
@@ -129,6 +131,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         Assert.True(response.IsValidResponse);
 
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("1:2", employee.Version);
 
         employee.CompanyName = "updated again";
@@ -161,6 +164,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         Assert.Equal("1:1", employee2.Version);
 
         var employee1Version1Copy = await _employeeRepository.GetByIdAsync(employee1.Id);
+        Assert.NotNull(employee1Version1Copy);
         Assert.Equal("1:0", employee1Version1Copy.Version);
         Assert.Equal(employee1, employee1Version1Copy);
 
@@ -243,7 +247,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         var results = await _employeeRepository.GetAllAsync(o => o.PageLimit(PAGE_SIZE));
         Assert.True(results.HasMore);
 
-        var viewedIds = new HashSet<string>();
+        var viewedIds = new HashSet<string?>();
         int pagedRecords = 0;
         do
         {
@@ -312,7 +316,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         var results = await _employeeRepository.GetAllAsync(o => o.PageLimit(PAGE_SIZE).SnapshotPaging());
         Assert.True(results.HasMore);
 
-        var viewedIds = new HashSet<string>();
+        var viewedIds = new HashSet<string?>();
         var newEmployees = new List<Employee>();
         int pagedRecords = 0;
         do
@@ -348,7 +352,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         var results = await _employeeRepository.GetAllAsync(o => o.PageLimit(PAGE_SIZE).SnapshotPaging());
         Assert.True(results.HasMore);
 
-        var viewedIds = new HashSet<string>();
+        var viewedIds = new HashSet<string?>();
         var newEmployees = new List<Employee>();
         int pagedRecords = 0;
         do
@@ -366,6 +370,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
             results = await _employeeRepository.GetAllAsync(o => o.SnapshotPagingScrollId(results));
         } while (results != null && results.Hits.Count > 0);
 
+        Assert.NotNull(results);
         Assert.False(results.HasMore);
         Assert.True(employees.All(e => viewedIds.Contains(e.Id)));
         Assert.Equal(NUMBER_OF_EMPLOYEES, pagedRecords);
@@ -385,7 +390,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         var results = await _employeeRepository.GetAllAsync(o => o.PageLimit(PAGE_SIZE));
         Assert.True(results.HasMore);
 
-        var viewedIds = new HashSet<string>();
+        var viewedIds = new HashSet<string?>();
         int pagedRecords = 0;
         do
         {
@@ -454,6 +459,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
 
         // Assert
         var updated = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(updated);
         Assert.Equal("PatchedCo", updated.CompanyName);
         Assert.True(updated.GetElasticVersion() > originalVersion);
     }
@@ -556,9 +562,11 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
 
         // Assert
         var emp2FromEs = await _employeeRepository.GetByIdAsync(emp2.Id, o => o.Cache(false));
+        Assert.NotNull(emp2FromEs);
         Assert.Equal("FreshUpdate", emp2FromEs.CompanyName);
 
         var emp1Cached = await _employeeRepository.GetByIdAsync(emp1.Id, o => o.Cache());
+        Assert.NotNull(emp1Cached);
         Assert.Equal("BumpedEmp1", emp1Cached.CompanyName);
     }
 

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/VersionedTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/VersionedTests.cs
@@ -101,7 +101,9 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         Assert.Equal("1:0", employee.Version);
 
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         var employeeCopy = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employeeCopy);
         Assert.Equal(employee, employeeCopy);
         Assert.Equal("1:0", employee.Version);
 
@@ -130,6 +132,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         Assert.True(response.IsValid);
 
         employee = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(employee);
         Assert.Equal("1:2", employee.Version);
 
         employee.CompanyName = "updated again";
@@ -162,6 +165,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         Assert.Equal("1:1", employee2.Version);
 
         var employee1Version1Copy = await _employeeRepository.GetByIdAsync(employee1.Id);
+        Assert.NotNull(employee1Version1Copy);
         Assert.Equal("1:0", employee1Version1Copy.Version);
         Assert.Equal(employee1, employee1Version1Copy);
 
@@ -244,7 +248,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         var results = await _employeeRepository.GetAllAsync(o => o.PageLimit(PAGE_SIZE));
         Assert.True(results.HasMore);
 
-        var viewedIds = new HashSet<string>();
+        var viewedIds = new HashSet<string?>();
         int pagedRecords = 0;
         do
         {
@@ -313,7 +317,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         var results = await _employeeRepository.GetAllAsync(o => o.PageLimit(PAGE_SIZE).SnapshotPaging());
         Assert.True(results.HasMore);
 
-        var viewedIds = new HashSet<string>();
+        var viewedIds = new HashSet<string?>();
         var newEmployees = new List<Employee>();
         int pagedRecords = 0;
         do
@@ -349,7 +353,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         var results = await _employeeRepository.GetAllAsync(o => o.PageLimit(PAGE_SIZE).SnapshotPaging());
         Assert.True(results.HasMore);
 
-        var viewedIds = new HashSet<string>();
+        var viewedIds = new HashSet<string?>();
         var newEmployees = new List<Employee>();
         int pagedRecords = 0;
         do
@@ -367,6 +371,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
             results = await _employeeRepository.GetAllAsync(o => o.SnapshotPagingScrollId(results));
         } while (results != null && results.Hits.Count > 0);
 
+        Assert.NotNull(results);
         Assert.False(results.HasMore);
         Assert.True(employees.All(e => viewedIds.Contains(e.Id)));
         Assert.Equal(NUMBER_OF_EMPLOYEES, pagedRecords);
@@ -386,7 +391,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
         var results = await _employeeRepository.GetAllAsync(o => o.PageLimit(PAGE_SIZE));
         Assert.True(results.HasMore);
 
-        var viewedIds = new HashSet<string>();
+        var viewedIds = new HashSet<string?>();
         int pagedRecords = 0;
         do
         {
@@ -455,6 +460,7 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
 
         // Assert
         var updated = await _employeeRepository.GetByIdAsync(employee.Id);
+        Assert.NotNull(updated);
         Assert.Equal("PatchedCo", updated.CompanyName);
         Assert.True(updated.GetElasticVersion() > originalVersion);
     }
@@ -557,9 +563,11 @@ public sealed class VersionedTests : ElasticRepositoryTestBase
 
         // Assert
         var emp2FromEs = await _employeeRepository.GetByIdAsync(emp2.Id, o => o.Cache(false));
+        Assert.NotNull(emp2FromEs);
         Assert.Equal("FreshUpdate", emp2FromEs.CompanyName);
 
         var emp1Cached = await _employeeRepository.GetByIdAsync(emp1.Id, o => o.Cache());
+        Assert.NotNull(emp1Cached);
         Assert.Equal("BumpedEmp1", emp1Cached.CompanyName);
     }
 

--- a/tests/Foundatio.Repositories.Tests/AggregationsExtensionsTests.cs
+++ b/tests/Foundatio.Repositories.Tests/AggregationsExtensionsTests.cs
@@ -77,10 +77,10 @@ public sealed class AggregationsExtensionsTests
 
         // Act
         var result = aggs.Terms<string>("test");
-        var resultBuckets = result.Buckets.ToList();
 
         // Assert
         Assert.NotNull(result);
+        var resultBuckets = result.Buckets.ToList();
         Assert.Equal(6, resultBuckets.Count);
         Assert.Equal("str", resultBuckets[0].Key);
         Assert.Equal("2.5", resultBuckets[1].Key);

--- a/tests/Foundatio.Repositories.Tests/JsonPatch/JsonPatchTests.cs
+++ b/tests/Foundatio.Repositories.Tests/JsonPatch/JsonPatchTests.cs
@@ -185,7 +185,8 @@ public class JsonPatchTests
     [Fact]
     public void TestExample1()
     {
-        JsonNode targetDoc = JsonNode.Parse(@"{ ""foo"": ""bar""}")!;
+        var targetDoc = JsonNode.Parse(@"{ ""foo"": ""bar""}");
+        Assert.NotNull(targetDoc);
         var patchDoc = PatchDocument.Parse(@"[
                                                     { ""op"": ""add"", ""path"": ""/baz"", ""value"": ""qux"" }
                                                 ]");
@@ -218,9 +219,10 @@ public class JsonPatchTests
         string output = streamReader.ReadToEnd();
 
         var jOutput = JsonNode.Parse(output);
+        Assert.NotNull(jOutput);
 
         Assert.Equal(@"[{""op"":""test"",""path"":""/a/b/c"",""value"":""foo""},{""op"":""remove"",""path"":""/a/b/c""},{""op"":""add"",""path"":""/a/b/c"",""value"":[""foo"",""bar""]},{""op"":""replace"",""path"":""/a/b/c"",""value"":42},{""op"":""move"",""path"":""/a/b/d"",""from"":""/a/b/c""},{""op"":""copy"",""path"":""/a/b/e"",""from"":""/a/b/d""}]",
-            jOutput!.ToJsonString());
+            jOutput.ToJsonString());
     }
 
     [Fact]
@@ -266,7 +268,8 @@ public class JsonPatchTests
         ""2018PropertyTwo"" : ""2018 property two value"",
         ""2018Properties"" : [""First value from 2018"",""Second value from 2018""]
     }
-}")!;
+}");
+        Assert.NotNull(sample);
 
         Assert.NotNull(sample.SelectPatchToken("/data/2017Properties/1"));
 
@@ -301,7 +304,8 @@ public class JsonPatchTests
     [Fact]
     public void Replace_non_existant_property()
     {
-        var sample = JsonNode.Parse(@"{ ""data"": {} }")!;
+        var sample = JsonNode.Parse(@"{ ""data"": {} }");
+        Assert.NotNull(sample);
 
         var patchDocument = new PatchDocument();
         string pointer = "/data/author";
@@ -314,7 +318,8 @@ public class JsonPatchTests
         Assert.NotNull(token);
         Assert.Equal("Bob Brown", token.GetValue<string>());
 
-        sample = JsonNode.Parse("{}")!;
+        sample = JsonNode.Parse("{}");
+        Assert.NotNull(sample);
 
         patchDocument = new PatchDocument();
         pointer = "/data/author";
@@ -327,7 +332,8 @@ public class JsonPatchTests
         Assert.NotNull(token);
         Assert.Equal("Bob Brown", token.GetValue<string>());
 
-        sample = JsonNode.Parse("{}")!;
+        sample = JsonNode.Parse("{}");
+        Assert.NotNull(sample);
 
         patchDocument = new PatchDocument();
         pointer = "/";
@@ -340,7 +346,8 @@ public class JsonPatchTests
         Assert.NotNull(token);
         Assert.Equal("Bob Brown", token.GetValue<string>());
 
-        sample = JsonNode.Parse("{}")!;
+        sample = JsonNode.Parse("{}");
+        Assert.NotNull(sample);
 
         patchDocument = new PatchDocument();
         pointer = "/hey/now/0/you";
@@ -376,7 +383,8 @@ public class JsonPatchTests
         const string operations = "[{\"op\":\"remove\",\"path\":\"/data/Address/full_address\"},{\"op\":\"remove\",\"path\":\"/data/Address/longitude\"},{\"op\":\"remove\",\"path\":\"/data/Address/latitude\"},{\"op\":\"remove\",\"path\":\"/data/Address/geo_locality\"},{\"op\":\"remove\",\"path\":\"/data/Address/geo_level2\"},{\"op\":\"remove\",\"path\":\"/data/Address/geo_level1\"},{\"op\":\"remove\",\"path\":\"/data/Address/geo_country\"},{\"op\":\"remove\",\"path\":\"/data/Address/normalized_geo_hash\"},{\"op\":\"remove\",\"path\":\"/data/Address/geo_hash\"},{\"op\":\"remove\",\"path\":\"/data/Address/geo\"},{\"op\":\"replace\",\"path\":\"/data/Address/country\",\"value\":\"US\"},{\"op\":\"replace\",\"path\":\"/data/Address/postal_code\",\"value\":\"54173\"},{\"op\":\"replace\",\"path\":\"/data/Address/state\",\"value\":\"Wi\"},{\"op\":\"replace\",\"path\":\"/data/Address/city\",\"value\":\"Suamico\"},{\"op\":\"remove\",\"path\":\"/data/Address/address2\"},{\"op\":\"replace\",\"path\":\"/data/Address/address1\",\"value\":\"100 Main Street\"}]";
 
         var patchDocument = JsonSerializer.Deserialize<PatchDocument>(operations);
-        var token = JsonNode.Parse("{ \"data\": { \"Address\": { \"address1\": null, \"address2\": null, \"city\": \"e\", \"state\": null, \"postal_code\": null, \"country\": null, \"geo\": null, \"geo_hash\": null, \"normalized_geo_hash\": null, \"geo_country\": null, \"geo_level1\": null, \"geo_level2\": null, \"geo_locality\": null, \"latitude\": null, \"longitude\": null, \"full_address\": null } } }")!;
+        var token = JsonNode.Parse("{ \"data\": { \"Address\": { \"address1\": null, \"address2\": null, \"city\": \"e\", \"state\": null, \"postal_code\": null, \"country\": null, \"geo\": null, \"geo_hash\": null, \"normalized_geo_hash\": null, \"geo_country\": null, \"geo_level1\": null, \"geo_level2\": null, \"geo_locality\": null, \"latitude\": null, \"longitude\": null, \"full_address\": null } } }");
+        Assert.NotNull(token);
 
         Assert.NotNull(patchDocument);
         new JsonPatcher().Patch(ref token, patchDocument);
@@ -404,7 +412,8 @@ public class JsonPatchTests
     [Fact]
     public void Can_replace_existing_boolean()
     {
-        JsonNode sample = JsonSerializer.SerializeToNode(new MyConfigClass { RequiresConfiguration = true })!;
+        var sample = JsonSerializer.SerializeToNode(new MyConfigClass { RequiresConfiguration = true });
+        Assert.NotNull(sample);
 
         var patchDocument = new PatchDocument();
         patchDocument.AddOperation(new ReplaceOperation { Path = "/RequiresConfiguration", Value = JsonValue.Create(false) });
@@ -419,7 +428,7 @@ public class JsonPatchTests
 
     public static JsonNode GetSample2()
     {
-        return JsonNode.Parse(@"{
+        var result = JsonNode.Parse(@"{
     ""books"": [
         {
           ""title"" : ""The Great Gatsby"",
@@ -430,7 +439,9 @@ public class JsonPatchTests
           ""author"" : ""John Steinbeck""
         }
     ]
-}")!;
+}");
+        Assert.NotNull(result);
+        return result;
     }
 
     [Fact]
@@ -452,7 +463,8 @@ public class JsonPatchTests
           ""author"" : ""John Steinbeck""
         }
     ]
-}")!;
+}");
+        Assert.NotNull(sample);
 
         var patchDocument = new PatchDocument();
         string pointer = "$.books[?(@.author == 'John Steinbeck')]";
@@ -463,14 +475,16 @@ public class JsonPatchTests
 
         // Assert
         var list = sample["books"] as System.Text.Json.Nodes.JsonArray;
-        Assert.Single(list!);
+        Assert.NotNull(list);
+        Assert.Single(list);
     }
 
     [Fact]
     public void Remove_WithJsonPathValueFilter_RemovesMatchingItem()
     {
         // Arrange
-        var sample = JsonNode.Parse(@"{ ""tags"": [ ""tag1"", ""tag2"", ""tag3"" ] }")!;
+        var sample = JsonNode.Parse(@"{ ""tags"": [ ""tag1"", ""tag2"", ""tag3"" ] }");
+        Assert.NotNull(sample);
 
         var patchDocument = new PatchDocument();
         string pointer = "$.tags[?(@ == 'tag2')]";
@@ -504,7 +518,8 @@ public class JsonPatchTests
           ""author"" : ""John Steinbeck""
         }
     ]
-}")!;
+}");
+        Assert.NotNull(sample);
 
         var patchDocument = new PatchDocument();
         string pointer = "$.books[?(@.author == 'John Steinbeck')].author";

--- a/tests/Foundatio.Repositories.Tests/JsonPatch/JsonPatchTests.cs
+++ b/tests/Foundatio.Repositories.Tests/JsonPatch/JsonPatchTests.cs
@@ -28,6 +28,7 @@ public class JsonPatchTests
         patcher.Patch(ref sample, patchDocument);
 
         var list = sample["books"] as JsonArray;
+        Assert.NotNull(list);
 
         Assert.Equal(3, list.Count);
     }
@@ -45,7 +46,10 @@ public class JsonPatchTests
         var patcher = new JsonPatcher();
         patcher.Patch(ref sample, patchDocument);
 
-        var list = sample["someobject"]["somearray"] as JsonArray;
+        var someobject = sample["someobject"];
+        Assert.NotNull(someobject);
+        var list = someobject["somearray"] as JsonArray;
+        Assert.NotNull(list);
 
         Assert.Single(list);
     }
@@ -63,7 +67,10 @@ public class JsonPatchTests
         var patcher = new JsonPatcher();
         patcher.Patch(ref sample, patchDocument);
 
-        string result = sample.SelectPatchToken(pointer)?.GetValue<string>();
+        var token = sample.SelectPatchToken(pointer);
+        Assert.NotNull(token);
+        string? result = token.GetValue<string>();
+        Assert.NotNull(result);
         Assert.Equal("Little Red Riding Hood", result);
     }
 
@@ -80,7 +87,10 @@ public class JsonPatchTests
         var patcher = new JsonPatcher();
         patcher.Patch(ref sample, patchDocument);
 
-        string result = sample.SelectPatchToken(pointer)?.GetValue<string>();
+        var token = sample.SelectPatchToken(pointer);
+        Assert.NotNull(token);
+        string? result = token.GetValue<string>();
+        Assert.NotNull(result);
         Assert.Equal("213324234343", result);
     }
 
@@ -135,7 +145,10 @@ public class JsonPatchTests
         var patcher = new JsonPatcher();
         patcher.Patch(ref sample, patchDocument);
 
-        string result = sample.SelectPatchToken(topointer)?.GetValue<string>();
+        var token = sample.SelectPatchToken(topointer);
+        Assert.NotNull(token);
+        string? result = token.GetValue<string>();
+        Assert.NotNull(result);
         Assert.Equal("F. Scott Fitzgerald", result);
     }
 
@@ -172,7 +185,7 @@ public class JsonPatchTests
     [Fact]
     public void TestExample1()
     {
-        var targetDoc = JsonNode.Parse(@"{ ""foo"": ""bar""}");
+        JsonNode targetDoc = JsonNode.Parse(@"{ ""foo"": ""bar""}")!;
         var patchDoc = PatchDocument.Parse(@"[
                                                     { ""op"": ""add"", ""path"": ""/baz"", ""value"": ""qux"" }
                                                 ]");
@@ -207,7 +220,7 @@ public class JsonPatchTests
         var jOutput = JsonNode.Parse(output);
 
         Assert.Equal(@"[{""op"":""test"",""path"":""/a/b/c"",""value"":""foo""},{""op"":""remove"",""path"":""/a/b/c""},{""op"":""add"",""path"":""/a/b/c"",""value"":[""foo"",""bar""]},{""op"":""replace"",""path"":""/a/b/c"",""value"":42},{""op"":""move"",""path"":""/a/b/d"",""from"":""/a/b/c""},{""op"":""copy"",""path"":""/a/b/e"",""from"":""/a/b/d""}]",
-            jOutput.ToJsonString());
+            jOutput!.ToJsonString());
     }
 
     [Fact]
@@ -253,7 +266,7 @@ public class JsonPatchTests
         ""2018PropertyTwo"" : ""2018 property two value"",
         ""2018Properties"" : [""First value from 2018"",""Second value from 2018""]
     }
-}");
+}")!;
 
         Assert.NotNull(sample.SelectPatchToken("/data/2017Properties/1"));
 
@@ -280,13 +293,15 @@ public class JsonPatchTests
 
         new JsonPatcher().Patch(ref sample, patchDocument);
 
-        Assert.Equal("Bob Brown", sample.SelectPatchToken(pointer)?.GetValue<string>());
+        var token = sample.SelectPatchToken(pointer);
+        Assert.NotNull(token);
+        Assert.Equal("Bob Brown", token.GetValue<string>());
     }
 
     [Fact]
     public void Replace_non_existant_property()
     {
-        var sample = JsonNode.Parse(@"{ ""data"": {} }");
+        var sample = JsonNode.Parse(@"{ ""data"": {} }")!;
 
         var patchDocument = new PatchDocument();
         string pointer = "/data/author";
@@ -295,9 +310,11 @@ public class JsonPatchTests
 
         new JsonPatcher().Patch(ref sample, patchDocument);
 
-        Assert.Equal("Bob Brown", sample.SelectPatchToken(pointer)?.GetValue<string>());
+        var token = sample.SelectPatchToken(pointer);
+        Assert.NotNull(token);
+        Assert.Equal("Bob Brown", token.GetValue<string>());
 
-        sample = JsonNode.Parse("{}");
+        sample = JsonNode.Parse("{}")!;
 
         patchDocument = new PatchDocument();
         pointer = "/data/author";
@@ -306,9 +323,11 @@ public class JsonPatchTests
 
         new JsonPatcher().Patch(ref sample, patchDocument);
 
-        Assert.Equal("Bob Brown", sample.SelectPatchToken(pointer)?.GetValue<string>());
+        token = sample.SelectPatchToken(pointer);
+        Assert.NotNull(token);
+        Assert.Equal("Bob Brown", token.GetValue<string>());
 
-        sample = JsonNode.Parse("{}");
+        sample = JsonNode.Parse("{}")!;
 
         patchDocument = new PatchDocument();
         pointer = "/";
@@ -317,9 +336,11 @@ public class JsonPatchTests
 
         new JsonPatcher().Patch(ref sample, patchDocument);
 
-        Assert.Equal("Bob Brown", sample.SelectPatchToken(pointer)?.GetValue<string>());
+        token = sample.SelectPatchToken(pointer);
+        Assert.NotNull(token);
+        Assert.Equal("Bob Brown", token.GetValue<string>());
 
-        sample = JsonNode.Parse("{}");
+        sample = JsonNode.Parse("{}")!;
 
         patchDocument = new PatchDocument();
         pointer = "/hey/now/0/you";
@@ -344,7 +365,9 @@ public class JsonPatchTests
         new JsonPatcher().Patch(ref sample, patchDocument);
 
         string newPointer = "/books/0/author/hello";
-        Assert.Equal("world", sample.SelectPatchToken(newPointer)?.GetValue<string>());
+        var token = sample.SelectPatchToken(newPointer);
+        Assert.NotNull(token);
+        Assert.Equal("world", token.GetValue<string>());
     }
 
     [Fact]
@@ -353,8 +376,9 @@ public class JsonPatchTests
         const string operations = "[{\"op\":\"remove\",\"path\":\"/data/Address/full_address\"},{\"op\":\"remove\",\"path\":\"/data/Address/longitude\"},{\"op\":\"remove\",\"path\":\"/data/Address/latitude\"},{\"op\":\"remove\",\"path\":\"/data/Address/geo_locality\"},{\"op\":\"remove\",\"path\":\"/data/Address/geo_level2\"},{\"op\":\"remove\",\"path\":\"/data/Address/geo_level1\"},{\"op\":\"remove\",\"path\":\"/data/Address/geo_country\"},{\"op\":\"remove\",\"path\":\"/data/Address/normalized_geo_hash\"},{\"op\":\"remove\",\"path\":\"/data/Address/geo_hash\"},{\"op\":\"remove\",\"path\":\"/data/Address/geo\"},{\"op\":\"replace\",\"path\":\"/data/Address/country\",\"value\":\"US\"},{\"op\":\"replace\",\"path\":\"/data/Address/postal_code\",\"value\":\"54173\"},{\"op\":\"replace\",\"path\":\"/data/Address/state\",\"value\":\"Wi\"},{\"op\":\"replace\",\"path\":\"/data/Address/city\",\"value\":\"Suamico\"},{\"op\":\"remove\",\"path\":\"/data/Address/address2\"},{\"op\":\"replace\",\"path\":\"/data/Address/address1\",\"value\":\"100 Main Street\"}]";
 
         var patchDocument = JsonSerializer.Deserialize<PatchDocument>(operations);
-        var token = JsonNode.Parse("{ \"data\": { \"Address\": { \"address1\": null, \"address2\": null, \"city\": \"e\", \"state\": null, \"postal_code\": null, \"country\": null, \"geo\": null, \"geo_hash\": null, \"normalized_geo_hash\": null, \"geo_country\": null, \"geo_level1\": null, \"geo_level2\": null, \"geo_locality\": null, \"latitude\": null, \"longitude\": null, \"full_address\": null } } }");
+        var token = JsonNode.Parse("{ \"data\": { \"Address\": { \"address1\": null, \"address2\": null, \"city\": \"e\", \"state\": null, \"postal_code\": null, \"country\": null, \"geo\": null, \"geo_hash\": null, \"normalized_geo_hash\": null, \"geo_country\": null, \"geo_level1\": null, \"geo_level2\": null, \"geo_locality\": null, \"latitude\": null, \"longitude\": null, \"full_address\": null } } }")!;
 
+        Assert.NotNull(patchDocument);
         new JsonPatcher().Patch(ref token, patchDocument);
 
         Assert.Equal("{\"data\":{\"Address\":{\"address1\":\"100 Main Street\",\"city\":\"Suamico\",\"state\":\"Wi\",\"postal_code\":\"54173\",\"country\":\"US\"}}}", token.ToJsonString());
@@ -380,7 +404,7 @@ public class JsonPatchTests
     [Fact]
     public void Can_replace_existing_boolean()
     {
-        var sample = JsonSerializer.SerializeToNode(new MyConfigClass { RequiresConfiguration = true });
+        JsonNode sample = JsonSerializer.SerializeToNode(new MyConfigClass { RequiresConfiguration = true })!;
 
         var patchDocument = new PatchDocument();
         patchDocument.AddOperation(new ReplaceOperation { Path = "/RequiresConfiguration", Value = JsonValue.Create(false) });
@@ -388,7 +412,9 @@ public class JsonPatchTests
         var patcher = new JsonPatcher();
         patcher.Patch(ref sample, patchDocument);
 
-        Assert.False(sample.Deserialize<MyConfigClass>().RequiresConfiguration);
+        var config = sample.Deserialize<MyConfigClass>();
+        Assert.NotNull(config);
+        Assert.False(config.RequiresConfiguration);
     }
 
     public static JsonNode GetSample2()
@@ -404,7 +430,7 @@ public class JsonPatchTests
           ""author"" : ""John Steinbeck""
         }
     ]
-}");
+}")!;
     }
 
     [Fact]
@@ -426,7 +452,7 @@ public class JsonPatchTests
           ""author"" : ""John Steinbeck""
         }
     ]
-}");
+}")!;
 
         var patchDocument = new PatchDocument();
         string pointer = "$.books[?(@.author == 'John Steinbeck')]";
@@ -437,14 +463,14 @@ public class JsonPatchTests
 
         // Assert
         var list = sample["books"] as System.Text.Json.Nodes.JsonArray;
-        Assert.Single(list);
+        Assert.Single(list!);
     }
 
     [Fact]
     public void Remove_WithJsonPathValueFilter_RemovesMatchingItem()
     {
         // Arrange
-        var sample = JsonNode.Parse(@"{ ""tags"": [ ""tag1"", ""tag2"", ""tag3"" ] }");
+        var sample = JsonNode.Parse(@"{ ""tags"": [ ""tag1"", ""tag2"", ""tag3"" ] }")!;
 
         var patchDocument = new PatchDocument();
         string pointer = "$.tags[?(@ == 'tag2')]";
@@ -478,7 +504,7 @@ public class JsonPatchTests
           ""author"" : ""John Steinbeck""
         }
     ]
-}");
+}")!;
 
         var patchDocument = new PatchDocument();
         string pointer = "$.books[?(@.author == 'John Steinbeck')].author";

--- a/tests/Foundatio.Repositories.Tests/JsonPatch/JsonPatchTests.cs
+++ b/tests/Foundatio.Repositories.Tests/JsonPatch/JsonPatchTests.cs
@@ -23,6 +23,7 @@ public class JsonPatchTests
         patcher.Patch(ref sample, patchDocument);
 
         var list = sample["books"] as JArray;
+        Assert.NotNull(list);
 
         Assert.Equal(3, list.Count);
     }
@@ -40,7 +41,10 @@ public class JsonPatchTests
         var patcher = new JsonPatcher();
         patcher.Patch(ref sample, patchDocument);
 
-        var list = sample["someobject"]["somearray"] as JArray;
+        var someobject = sample["someobject"];
+        Assert.NotNull(someobject);
+        var list = someobject["somearray"] as JArray;
+        Assert.NotNull(list);
 
         Assert.Single(list);
     }
@@ -73,6 +77,7 @@ public class JsonPatchTests
         new JsonPatcher().Patch(ref sample, patchDocument);
 
         var list = sample["books"] as JArray;
+        Assert.NotNull(list);
 
         Assert.Single(list);
     }
@@ -90,6 +95,7 @@ public class JsonPatchTests
         new JsonPatcher().Patch(ref sample, patchDocument);
 
         var list = sample["tags"] as JArray;
+        Assert.NotNull(list);
 
         Assert.Equal(2, list.Count);
     }
@@ -107,7 +113,10 @@ public class JsonPatchTests
         var patcher = new JsonPatcher();
         patcher.Patch(ref sample, patchDocument);
 
-        string result = sample.SelectPatchToken(pointer).Value<string>();
+        var token = sample.SelectPatchToken(pointer);
+        Assert.NotNull(token);
+        string? result = token.Value<string>();
+        Assert.NotNull(result);
         Assert.Equal("Little Red Riding Hood", result);
     }
 
@@ -124,7 +133,10 @@ public class JsonPatchTests
         var patcher = new JsonPatcher();
         patcher.Patch(ref sample, patchDocument);
 
-        string result = sample.SelectPatchToken(pointer).Value<string>();
+        var token = sample.SelectPatchToken(pointer);
+        Assert.NotNull(token);
+        string? result = token.Value<string>();
+        Assert.NotNull(result);
         Assert.Equal("213324234343", result);
     }
 
@@ -179,7 +191,10 @@ public class JsonPatchTests
         var patcher = new JsonPatcher();
         patcher.Patch(ref sample, patchDocument);
 
-        string result = sample.SelectPatchToken(topointer).Value<string>();
+        var token = sample.SelectPatchToken(topointer);
+        Assert.NotNull(token);
+        string? result = token.Value<string>();
+        Assert.NotNull(result);
         Assert.Equal("F. Scott Fitzgerald", result);
     }
 
@@ -323,7 +338,9 @@ public class JsonPatchTests
 
         new JsonPatcher().Patch(ref sample, patchDocument);
 
-        Assert.Equal("Bob Brown", sample.SelectPatchToken(pointer).Value<string>());
+        var token = sample.SelectPatchToken(pointer);
+        Assert.NotNull(token);
+        Assert.Equal("Bob Brown", token.Value<string>());
     }
 
     [Fact]
@@ -338,7 +355,9 @@ public class JsonPatchTests
 
         new JsonPatcher().Patch(ref sample, patchDocument);
 
-        Assert.Equal("Bob Brown", sample.SelectPatchToken(pointer).Value<string>());
+        var token = sample.SelectPatchToken(pointer);
+        Assert.NotNull(token);
+        Assert.Equal("Bob Brown", token.Value<string>());
 
         sample = JToken.Parse("{}");
 
@@ -349,7 +368,9 @@ public class JsonPatchTests
 
         new JsonPatcher().Patch(ref sample, patchDocument);
 
-        Assert.Equal("Bob Brown", sample.SelectPatchToken(pointer).Value<string>());
+        token = sample.SelectPatchToken(pointer);
+        Assert.NotNull(token);
+        Assert.Equal("Bob Brown", token.Value<string>());
 
         sample = JToken.Parse("{}");
 
@@ -360,7 +381,9 @@ public class JsonPatchTests
 
         new JsonPatcher().Patch(ref sample, patchDocument);
 
-        Assert.Equal("Bob Brown", sample.SelectPatchToken(pointer).Value<string>());
+        token = sample.SelectPatchToken(pointer);
+        Assert.NotNull(token);
+        Assert.Equal("Bob Brown", token.Value<string>());
 
         sample = JToken.Parse("{}");
 
@@ -387,7 +410,9 @@ public class JsonPatchTests
         new JsonPatcher().Patch(ref sample, patchDocument);
 
         string newPointer = "/books/0/author/hello";
-        Assert.Equal("world", sample.SelectPatchToken(newPointer).Value<string>());
+        var token = sample.SelectPatchToken(newPointer);
+        Assert.NotNull(token);
+        Assert.Equal("world", token.Value<string>());
     }
 
     [Fact]
@@ -418,10 +443,14 @@ public class JsonPatchTests
         new JsonPatcher().Patch(ref sample, patchDocument);
 
         string newPointer = "/books/1/author";
-        Assert.Equal("Eric", sample.SelectPatchToken(newPointer).Value<string>());
+        var token = sample.SelectPatchToken(newPointer);
+        Assert.NotNull(token);
+        Assert.Equal("Eric", token.Value<string>());
 
         newPointer = "/books/2/author";
-        Assert.Equal("Eric", sample.SelectPatchToken(newPointer).Value<string>());
+        token = sample.SelectPatchToken(newPointer);
+        Assert.NotNull(token);
+        Assert.Equal("Eric", token.Value<string>());
     }
 
     [Fact]
@@ -432,6 +461,7 @@ public class JsonPatchTests
         var patchDocument = JsonConvert.DeserializeObject<PatchDocument>(operations);
         var token = JToken.Parse("{ \"data\": { \"Address\": { \"address1\": null, \"address2\": null, \"city\": \"e\", \"state\": null, \"postal_code\": null, \"country\": null, \"geo\": null, \"geo_hash\": null, \"normalized_geo_hash\": null, \"geo_country\": null, \"geo_level1\": null, \"geo_level2\": null, \"geo_locality\": null, \"latitude\": null, \"longitude\": null, \"full_address\": null } } }");
 
+        Assert.NotNull(patchDocument);
         new JsonPatcher().Patch(ref token, patchDocument);
 
         Assert.Equal("{\"data\":{\"Address\":{\"address1\":\"100 Main Street\",\"city\":\"Suamico\",\"state\":\"Wi\",\"postal_code\":\"54173\",\"country\":\"US\"}}}", token.ToString(Formatting.None));
@@ -465,7 +495,9 @@ public class JsonPatchTests
         var patcher = new JsonPatcher();
         patcher.Patch(ref sample, patchDocument);
 
-        Assert.False(sample.ToObject<MyConfigClass>().RequiresConfiguration);
+        var config = sample.ToObject<MyConfigClass>();
+        Assert.NotNull(config);
+        Assert.False(config.RequiresConfiguration);
     }
 
     public static JToken GetSample2()

--- a/tests/Foundatio.Repositories.Tests/Serialization/JsonSerializerOptionsExtensionsTests.cs
+++ b/tests/Foundatio.Repositories.Tests/Serialization/JsonSerializerOptionsExtensionsTests.cs
@@ -101,6 +101,7 @@ public class JsonSerializerOptionsExtensionsTests
         var result = serializer.Deserialize<Dictionary<string, object>>(json);
 
         // Assert
+        Assert.NotNull(result);
         Assert.IsType<string>(result["name"]);
         Assert.IsType<long>(result["count"]);
         Assert.IsType<bool>(result["active"]);

--- a/tests/Foundatio.Repositories.Tests/Serialization/Models/BucketSerializationTests.cs
+++ b/tests/Foundatio.Repositories.Tests/Serialization/Models/BucketSerializationTests.cs
@@ -33,6 +33,7 @@ public class BucketSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var bucket = roundTripped.Aggregations["terms"] as BucketAggregate;
             Assert.NotNull(bucket);
             var item = Assert.IsType<KeyedBucket<string>>(bucket.Items.First());
@@ -64,6 +65,7 @@ public class BucketSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var bucket = roundTripped.Aggregations["histogram"] as BucketAggregate;
             Assert.NotNull(bucket);
             var item = Assert.IsType<KeyedBucket<double>>(bucket.Items.First());
@@ -97,6 +99,7 @@ public class BucketSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var bucket = roundTripped.Aggregations["date_hist"] as BucketAggregate;
             Assert.NotNull(bucket);
             var item = Assert.IsType<DateHistogramBucket>(bucket.Items.First());
@@ -136,6 +139,7 @@ public class BucketSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var bucket = roundTripped.Aggregations["price_ranges"] as BucketAggregate;
             Assert.NotNull(bucket);
             Assert.Equal(2, bucket.Items.Count);
@@ -183,6 +187,7 @@ public class BucketSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var nested = roundTripped.Aggregations["nested_reviews"] as SingleBucketAggregate;
             Assert.NotNull(nested);
             Assert.Equal(5, nested.Total);

--- a/tests/Foundatio.Repositories.Tests/Serialization/Models/BucketSerializationTests.cs
+++ b/tests/Foundatio.Repositories.Tests/Serialization/Models/BucketSerializationTests.cs
@@ -32,6 +32,7 @@ public class BucketSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var bucket = roundTripped.Aggregations["terms"] as BucketAggregate;
             Assert.NotNull(bucket);
             var item = Assert.IsType<KeyedBucket<string>>(bucket.Items.First());
@@ -63,6 +64,7 @@ public class BucketSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var bucket = roundTripped.Aggregations["histogram"] as BucketAggregate;
             Assert.NotNull(bucket);
             var item = Assert.IsType<KeyedBucket<double>>(bucket.Items.First());
@@ -96,6 +98,7 @@ public class BucketSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var bucket = roundTripped.Aggregations["date_hist"] as BucketAggregate;
             Assert.NotNull(bucket);
             var item = Assert.IsType<DateHistogramBucket>(bucket.Items.First());
@@ -135,6 +138,7 @@ public class BucketSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var bucket = roundTripped.Aggregations["price_ranges"] as BucketAggregate;
             Assert.NotNull(bucket);
             Assert.Equal(2, bucket.Items.Count);
@@ -182,6 +186,7 @@ public class BucketSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var nested = roundTripped.Aggregations["nested_reviews"] as SingleBucketAggregate;
             Assert.NotNull(nested);
             Assert.Equal(5, nested.Total);

--- a/tests/Foundatio.Repositories.Tests/Serialization/Models/FindResultsSerializationTests.cs
+++ b/tests/Foundatio.Repositories.Tests/Serialization/Models/FindResultsSerializationTests.cs
@@ -27,6 +27,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<FindResults<TestDocument>>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             Assert.Equal(original.Total, roundTripped.Total);
             Assert.Equal(original.Page, roundTripped.Page);
             Assert.Equal(original.HasMore, roundTripped.HasMore);
@@ -49,6 +50,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             Assert.Equal(original.Total, roundTripped.Total);
         }
     }
@@ -70,6 +72,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             Assert.Equal(original.Total, roundTripped.Total);
             Assert.Equal(original.Aggregations.Count, roundTripped.Aggregations.Count);
         }
@@ -99,6 +102,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var nested = roundTripped.Aggregations["nested_test"] as SingleBucketAggregate;
             Assert.NotNull(nested);
             Assert.Equal(6, nested.Total);
@@ -139,6 +143,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert - Level 1: outer sbucket
+            Assert.NotNull(roundTripped);
             var outer = roundTripped.Aggregations["nested_outer"] as SingleBucketAggregate;
             Assert.NotNull(outer);
             Assert.Equal(50, outer.Total);
@@ -194,6 +199,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert - sbucket preserved
+            Assert.NotNull(roundTripped);
             var nested = roundTripped.Aggregations["nested_reviews"] as SingleBucketAggregate;
             Assert.True(nested != null, $"{serializer.GetType().Name}: SingleBucketAggregate lost");
             Assert.Equal(3, nested.Aggregations.Count);
@@ -246,6 +252,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var bucket = roundTripped.Aggregations["terms_status"] as BucketAggregate;
             Assert.NotNull(bucket);
             Assert.Equal(2, bucket.Items.Count);
@@ -275,6 +282,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var maxAge = roundTripped.Aggregations["max_age"] as ValueAggregate;
             Assert.NotNull(maxAge);
             Assert.Equal(65.0, maxAge.Value);
@@ -301,6 +309,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var stats = roundTripped.Aggregations["stats_age"] as StatsAggregate;
             Assert.NotNull(stats);
             Assert.Equal(100, stats.Count);
@@ -330,6 +339,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var percentiles = roundTripped.Aggregations["percentiles_age"] as PercentilesAggregate;
             Assert.NotNull(percentiles);
             Assert.NotNull(percentiles.Items);
@@ -355,6 +365,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var objVal = roundTripped.Aggregations["obj_val"] as ObjectValueAggregate;
             Assert.NotNull(objVal);
             Assert.Equal("test_string", objVal.Value?.ToString());
@@ -378,6 +389,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var dateVal = roundTripped.Aggregations["date_val"] as ValueAggregate<DateTime>;
             Assert.NotNull(dateVal);
             Assert.Equal(date, dateVal.Value);
@@ -411,6 +423,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var exstats = roundTripped.Aggregations["exstats_age"] as ExtendedStatsAggregate;
             Assert.NotNull(exstats);
             Assert.Equal(100, exstats.Count);
@@ -432,11 +445,13 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<FindHit<TestDocument>>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             Assert.Equal(original.Id, roundTripped.Id);
             Assert.Equal(original.Score, roundTripped.Score);
             Assert.Equal(original.Version, roundTripped.Version);
             Assert.Equal(original.Routing, roundTripped.Routing);
-            Assert.Equal(original.Document.Name, roundTripped.Document.Name);
+            Assert.NotNull(roundTripped.Document);
+            Assert.Equal(original.Document!.Name, roundTripped.Document.Name);
         }
     }
 
@@ -453,6 +468,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<FindResults<TestDocument>>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             Assert.Equal(0, roundTripped.Total);
             Assert.Empty(roundTripped.Hits);
             Assert.Empty(roundTripped.Documents);
@@ -478,6 +494,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<FindResults<TestDocument>>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             Assert.Equal(3, roundTripped.Total);
             Assert.Equal(3, roundTripped.Hits.Count);
             Assert.Equal(3, roundTripped.Documents.Count);
@@ -489,6 +506,6 @@ public class FindResultsSerializationTests
 
 public class TestDocument
 {
-    public string Id { get; set; }
-    public string Name { get; set; }
+    public string Id { get; set; } = null!;
+    public string Name { get; set; } = null!;
 }

--- a/tests/Foundatio.Repositories.Tests/Serialization/Models/FindResultsSerializationTests.cs
+++ b/tests/Foundatio.Repositories.Tests/Serialization/Models/FindResultsSerializationTests.cs
@@ -28,6 +28,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<FindResults<TestDocument>>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             Assert.Equal(original.Total, roundTripped.Total);
             Assert.Equal(original.Page, roundTripped.Page);
             Assert.Equal(original.HasMore, roundTripped.HasMore);
@@ -50,6 +51,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             Assert.Equal(original.Total, roundTripped.Total);
         }
     }
@@ -71,6 +73,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             Assert.Equal(original.Total, roundTripped.Total);
             Assert.Equal(original.Aggregations.Count, roundTripped.Aggregations.Count);
         }
@@ -100,6 +103,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var nested = roundTripped.Aggregations["nested_test"] as SingleBucketAggregate;
             Assert.NotNull(nested);
             Assert.Equal(6, nested.Total);
@@ -140,6 +144,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert - Level 1: outer sbucket
+            Assert.NotNull(roundTripped);
             var outer = roundTripped.Aggregations["nested_outer"] as SingleBucketAggregate;
             Assert.NotNull(outer);
             Assert.Equal(50, outer.Total);
@@ -195,6 +200,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert - sbucket preserved
+            Assert.NotNull(roundTripped);
             var nested = roundTripped.Aggregations["nested_reviews"] as SingleBucketAggregate;
             Assert.True(nested != null, $"{serializer.GetType().Name}: SingleBucketAggregate lost");
             Assert.Equal(3, nested.Aggregations.Count);
@@ -247,6 +253,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var bucket = roundTripped.Aggregations["terms_status"] as BucketAggregate;
             Assert.NotNull(bucket);
             Assert.Equal(2, bucket.Items.Count);
@@ -276,6 +283,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var maxAge = roundTripped.Aggregations["max_age"] as ValueAggregate;
             Assert.NotNull(maxAge);
             Assert.Equal(65.0, maxAge.Value);
@@ -302,6 +310,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var stats = roundTripped.Aggregations["stats_age"] as StatsAggregate;
             Assert.NotNull(stats);
             Assert.Equal(100, stats.Count);
@@ -331,6 +340,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var percentiles = roundTripped.Aggregations["percentiles_age"] as PercentilesAggregate;
             Assert.NotNull(percentiles);
             Assert.NotNull(percentiles.Items);
@@ -356,6 +366,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var objVal = roundTripped.Aggregations["obj_val"] as ObjectValueAggregate;
             Assert.NotNull(objVal);
             Assert.Equal("test_string", objVal.Value?.ToString());
@@ -379,6 +390,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var dateVal = roundTripped.Aggregations["date_val"] as ValueAggregate<DateTime>;
             Assert.NotNull(dateVal);
             Assert.Equal(date, dateVal.Value);
@@ -412,6 +424,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<CountResult>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             var exstats = roundTripped.Aggregations["exstats_age"] as ExtendedStatsAggregate;
             Assert.NotNull(exstats);
             Assert.Equal(100, exstats.Count);
@@ -433,11 +446,13 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<FindHit<TestDocument>>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             Assert.Equal(original.Id, roundTripped.Id);
             Assert.Equal(original.Score, roundTripped.Score);
             Assert.Equal(original.Version, roundTripped.Version);
             Assert.Equal(original.Routing, roundTripped.Routing);
-            Assert.Equal(original.Document.Name, roundTripped.Document.Name);
+            Assert.NotNull(roundTripped.Document);
+            Assert.Equal(original.Document!.Name, roundTripped.Document.Name);
         }
     }
 
@@ -454,6 +469,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<FindResults<TestDocument>>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             Assert.Equal(0, roundTripped.Total);
             Assert.Empty(roundTripped.Hits);
             Assert.Empty(roundTripped.Documents);
@@ -479,6 +495,7 @@ public class FindResultsSerializationTests
             var roundTripped = serializer.Deserialize<FindResults<TestDocument>>(json);
 
             // Assert
+            Assert.NotNull(roundTripped);
             Assert.Equal(3, roundTripped.Total);
             Assert.Equal(3, roundTripped.Hits.Count);
             Assert.Equal(3, roundTripped.Documents.Count);
@@ -490,6 +507,6 @@ public class FindResultsSerializationTests
 
 public class TestDocument
 {
-    public string Id { get; set; }
-    public string Name { get; set; }
+    public string Id { get; set; } = null!;
+    public string Name { get; set; } = null!;
 }

--- a/tests/Foundatio.Repositories.Tests/Serialization/ObjectToInferredTypesConverterTests.cs
+++ b/tests/Foundatio.Repositories.Tests/Serialization/ObjectToInferredTypesConverterTests.cs
@@ -269,6 +269,7 @@ public class ObjectToInferredTypesConverterTests
         var result = _serializer.Deserialize<object[]>(json);
 
         // Assert
+        Assert.NotNull(result);
         Assert.Equal(4, result.Length);
         Assert.Equal("test", result[0]);
         Assert.Equal(42L, result[1]);
@@ -280,7 +281,7 @@ public class ObjectToInferredTypesConverterTests
     public void Write_WithNull_WritesNullLiteral()
     {
         // Arrange
-        object value = null;
+        object? value = null;
 
         // Act
         string json = _serializer.SerializeToString(value);


### PR DESCRIPTION
## Summary
- Merged origin/main into feature/elastic-client-nrt to bring in NRT (Nullable Reference Types) commits
- Resolved 45 merge conflicts by keeping the new ES 8.x client code while incorporating NRT annotations
- Fixed all NRT compilation errors across JsonPatch, Models, ES Configuration, Extensions, Repositories, Jobs, Query Builders, and test projects
- Build passes with 0 warnings and 0 errors

## Conflict Resolution Strategy
- **JsonPatch** (client-agnostic, System.Text.Json): Kept STJ code, applied NRT null guards
- **Models/Serialization** (client-agnostic): Applied nullable annotations and null-safety patterns
- **ES Configuration/Extensions/Jobs/Builders/Repositories**: Kept ES 8.x client types, translated NRT annotations from NEST-based main
- **Tests**: Kept new ES client assertions, applied NRT patterns

## Test plan
- [x] dotnet build Foundatio.Repositories.slnx (0 errors, 0 warnings)
- [ ] dotnet test Foundatio.Repositories.slnx (requires Elasticsearch)