### PR TITLE
fix!: throw RepositoryException when custom field helpers are called on unsupported types

### DIFF
--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -1202,7 +1202,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             foreach (var doc in args.Documents.Select(d => d.Value))
             {
                 var idx = GetDocumentIdx(doc);
-                idx?.Clear();
+                idx.Clear();
             }
 
             return;
@@ -1217,14 +1217,9 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             foreach (var doc in tenant)
             {
                 var idx = GetDocumentIdx(doc);
-                if (idx == null)
-                    continue;
-
                 idx.Clear();
 
                 var customFields = GetDocumentCustomFields(doc);
-                if (customFields == null)
-                    continue;
 
                 foreach (var customField in customFields)
                 {
@@ -1315,13 +1310,13 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     /// Gets the custom fields dictionary from the document (<c>Data</c> for <see cref="IHaveCustomFields"/>,
     /// or the virtual fields collection for <see cref="IHaveVirtualCustomFields"/>).
     /// </summary>
-    protected IDictionary<string, object?>? GetDocumentCustomFields(T document)
+    protected IDictionary<string, object?> GetDocumentCustomFields(T document)
     {
         return document switch
         {
             IHaveCustomFields f => f.Data,
             IHaveVirtualCustomFields v => v.GetCustomFields(),
-            _ => null
+            _ => throw new RepositoryException($"Document type {typeof(T).Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.")
         };
     }
 
@@ -1345,6 +1340,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             case IHaveVirtualCustomFields v:
                 v.SetCustomField(name, value);
                 return;
+            default:
+                throw new RepositoryException($"Document type {typeof(T).Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.");
         }
     }
 
@@ -1363,6 +1360,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             case IHaveVirtualCustomFields v:
                 v.RemoveCustomField(name);
                 return;
+            default:
+                throw new RepositoryException($"Document type {typeof(T).Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.");
         }
     }
 
@@ -1375,20 +1374,20 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         {
             IHaveCustomFields f => f.Data.GetValueOrDefault(name),
             IHaveVirtualCustomFields v => v.GetCustomField(name),
-            _ => null,
+            _ => throw new RepositoryException($"Document type {typeof(T).Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.")
         };
     }
 
     /// <summary>
     /// Gets the indexed custom field values dictionary (<c>Idx</c>) from the document.
     /// </summary>
-    protected IDictionary<string, object>? GetDocumentIdx(T document)
+    protected IDictionary<string, object> GetDocumentIdx(T document)
     {
         return document switch
         {
             IHaveCustomFields f => f.Idx,
             IHaveVirtualCustomFields v => v.Idx,
-            _ => null,
+            _ => throw new RepositoryException($"Document type {typeof(T).Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.")
         };
     }
 

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -1312,6 +1312,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     /// </summary>
     protected IDictionary<string, object?> GetDocumentCustomFields(T document)
     {
+        ArgumentNullException.ThrowIfNull(document);
+
         return document switch
         {
             IHaveCustomFields f => f.Data,
@@ -1326,6 +1328,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     /// </summary>
     protected void SetDocumentCustomField(T document, string name, object? value)
     {
+        ArgumentNullException.ThrowIfNull(document);
+
         if (value is null)
         {
             RemoveDocumentCustomField(document, name);
@@ -1352,6 +1356,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     /// </summary>
     protected void RemoveDocumentCustomField(T document, string name)
     {
+        ArgumentNullException.ThrowIfNull(document);
+
         switch (document)
         {
             case IHaveCustomFields f:
@@ -1370,6 +1376,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     /// </summary>
     protected object? GetDocumentCustomField(T document, string name)
     {
+        ArgumentNullException.ThrowIfNull(document);
+
         return document switch
         {
             IHaveCustomFields f => f.Data.GetValueOrDefault(name),
@@ -1383,6 +1391,8 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     /// </summary>
     protected IDictionary<string, object> GetDocumentIdx(T document)
     {
+        ArgumentNullException.ThrowIfNull(document);
+
         return document switch
         {
             IHaveCustomFields f => f.Idx,

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -1316,7 +1316,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         {
             IHaveCustomFields f => f.Data,
             IHaveVirtualCustomFields v => v.GetCustomFields(),
-            _ => throw new RepositoryException($"Document type {typeof(T).Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.")
+            _ => throw new RepositoryException($"Document type {document.GetType().Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.")
         };
     }
 
@@ -1341,7 +1341,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 v.SetCustomField(name, value);
                 return;
             default:
-                throw new RepositoryException($"Document type {typeof(T).Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.");
+                throw new RepositoryException($"Document type {document.GetType().Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.");
         }
     }
 
@@ -1361,7 +1361,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 v.RemoveCustomField(name);
                 return;
             default:
-                throw new RepositoryException($"Document type {typeof(T).Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.");
+                throw new RepositoryException($"Document type {document.GetType().Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.");
         }
     }
 
@@ -1374,7 +1374,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         {
             IHaveCustomFields f => f.Data.GetValueOrDefault(name),
             IHaveVirtualCustomFields v => v.GetCustomField(name),
-            _ => throw new RepositoryException($"Document type {typeof(T).Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.")
+            _ => throw new RepositoryException($"Document type {document.GetType().Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.")
         };
     }
 
@@ -1387,7 +1387,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         {
             IHaveCustomFields f => f.Idx,
             IHaveVirtualCustomFields v => v.Idx,
-            _ => throw new RepositoryException($"Document type {typeof(T).Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.")
+            _ => throw new RepositoryException($"Document type {document.GetType().Name} does not implement IHaveCustomFields or IHaveVirtualCustomFields.")
         };
     }
 

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/CustomFieldTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/CustomFieldTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Foundatio.Caching;
+using Foundatio.Repositories.Elasticsearch.Configuration;
 using Foundatio.Repositories.Elasticsearch.CustomFields;
 using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 using Foundatio.Repositories.Exceptions;
@@ -827,4 +828,28 @@ public sealed class CustomFieldTests : ElasticRepositoryTestBase
         var noHit = await _employeeRepository.FindAsync(q => q.Company("1").FilterExpression("updcalc:3"), o => o.QueryLogLevel(LogLevel.Information));
         Assert.Empty(noHit.Documents);
     }
+
+    [Fact]
+    public void CustomFieldHelpers_OnNonCustomFieldType_ThrowRepositoryException()
+    {
+        var repo = new CustomFieldHelperTestRepository(_configuration.Employees);
+        var employee = EmployeeGenerator.Generate();
+
+        Assert.Throws<RepositoryException>(new Action(() => repo.TestGetDocumentCustomFields(employee)));
+        Assert.Throws<RepositoryException>(new Action(() => repo.TestGetDocumentCustomField(employee, "field")));
+        Assert.Throws<RepositoryException>(new Action(() => repo.TestSetDocumentCustomField(employee, "field", "value")));
+        Assert.Throws<RepositoryException>(new Action(() => repo.TestRemoveDocumentCustomField(employee, "field")));
+        Assert.Throws<RepositoryException>(new Action(() => repo.TestGetDocumentIdx(employee)));
+    }
+}
+
+internal sealed class CustomFieldHelperTestRepository : ElasticRepositoryBase<Employee>
+{
+    public CustomFieldHelperTestRepository(IIndex index) : base(index) { }
+
+    public IDictionary<string, object?> TestGetDocumentCustomFields(Employee doc) => GetDocumentCustomFields(doc);
+    public object? TestGetDocumentCustomField(Employee doc, string name) => GetDocumentCustomField(doc, name);
+    public void TestSetDocumentCustomField(Employee doc, string name, object? value) => SetDocumentCustomField(doc, name, value);
+    public void TestRemoveDocumentCustomField(Employee doc, string name) => RemoveDocumentCustomField(doc, name);
+    public IDictionary<string, object> TestGetDocumentIdx(Employee doc) => GetDocumentIdx(doc);
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/CustomFieldTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/CustomFieldTests.cs
@@ -832,9 +832,11 @@ public sealed class CustomFieldTests : ElasticRepositoryTestBase
     [Fact]
     public void CustomFieldHelpers_OnNonCustomFieldType_ThrowsRepositoryException()
     {
+        // Arrange
         var repo = new CustomFieldHelperTestRepository(_configuration.Employees);
         var employee = EmployeeGenerator.Generate();
 
+        // Act & Assert
         Assert.Throws<RepositoryException>(() => { repo.TestGetDocumentCustomFields(employee); });
         Assert.Throws<RepositoryException>(() => { repo.TestGetDocumentCustomField(employee, "field"); });
         Assert.Throws<RepositoryException>(() => repo.TestSetDocumentCustomField(employee, "field", "value"));

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/CustomFieldTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/CustomFieldTests.cs
@@ -830,16 +830,16 @@ public sealed class CustomFieldTests : ElasticRepositoryTestBase
     }
 
     [Fact]
-    public void CustomFieldHelpers_OnNonCustomFieldType_ThrowRepositoryException()
+    public void CustomFieldHelpers_OnNonCustomFieldType_ThrowsRepositoryException()
     {
         var repo = new CustomFieldHelperTestRepository(_configuration.Employees);
         var employee = EmployeeGenerator.Generate();
 
-        Assert.Throws<RepositoryException>(new Action(() => repo.TestGetDocumentCustomFields(employee)));
-        Assert.Throws<RepositoryException>(new Action(() => repo.TestGetDocumentCustomField(employee, "field")));
-        Assert.Throws<RepositoryException>(new Action(() => repo.TestSetDocumentCustomField(employee, "field", "value")));
-        Assert.Throws<RepositoryException>(new Action(() => repo.TestRemoveDocumentCustomField(employee, "field")));
-        Assert.Throws<RepositoryException>(new Action(() => repo.TestGetDocumentIdx(employee)));
+        Assert.Throws<RepositoryException>(() => { repo.TestGetDocumentCustomFields(employee); });
+        Assert.Throws<RepositoryException>(() => { repo.TestGetDocumentCustomField(employee, "field"); });
+        Assert.Throws<RepositoryException>(() => repo.TestSetDocumentCustomField(employee, "field", "value"));
+        Assert.Throws<RepositoryException>(() => repo.TestRemoveDocumentCustomField(employee, "field"));
+        Assert.Throws<RepositoryException>(() => { repo.TestGetDocumentIdx(employee); });
     }
 }
 


### PR DESCRIPTION
## Summary

- The five protected custom field helper methods (\GetDocumentCustomFields\, \SetDocumentCustomField\, \RemoveDocumentCustomField\, \GetDocumentCustomField\, \GetDocumentIdx\) previously returned \
ull\ or silently no-oped when \T\ did not implement \IHaveCustomFields\ or \IHaveVirtualCustomFields\. They now throw \RepositoryException\ with a clear message.
- Removed dead null checks in \OnCustomFieldsDocumentsChanging\ that were unreachable after the change.
- Added test \CustomFieldHelpers_OnNonCustomFieldType_ThrowRepositoryException\ verifying all five methods throw on a non-custom-field document type.

## Breaking Change

Subclasses calling these protected methods on a document type that does not implement \IHaveCustomFields\ or \IHaveVirtualCustomFields\ will now receive a \RepositoryException\ instead of \
ull\/no-op. Internal callers are unaffected because the custom field event handler is only registered when \HasCustomFields\ is \	rue\.

## Test plan

- [x] New test passes: \CustomFieldHelpers_OnNonCustomFieldType_ThrowRepositoryException\
- [x] All 20 \CustomFieldTests\ pass (no regressions in existing custom field behavior)
- [x] All 56 core repository tests pass
- [x] Build succeeds with zero warnings/errors