### PR TITLE
Fix NRT code smells across repository layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,18 @@ samples
 - Write complete, runnable code—no placeholders, TODOs, or `// existing code...` comments
 - Use modern C# features: pattern matching, nullable references, `is` expressions, target-typed `new()`
 - Follow SOLID, DRY principles; remove unused code and parameters
+
+### Nullable Reference Types (NRT) Conventions
+
+The codebase has NRT enabled. Follow these patterns:
+
+- **Entity/model properties** (`= null!`): Acceptable for properties set by deserialization or Elasticsearch mapping. Prefer `required` keyword where construction is controlled.
+- **Expression tree `!`**: Required when expressions box nullable value types to `object?` but the delegate expects `object` (e.g., `SortDescending`, `InferField`). The value is never evaluated.
+- **`.Where(x => x is not null).Select(x => x!)`**: The compiler can't prove non-null through a lambda boundary after filtering. This is the idiomatic post-filter pattern.
+- **`null!` in test `Assert.Throws` calls**: Intentional contract violation to test null guards.
+- **`CommandOptionsDescriptor<T>?`**: The descriptor parameter is nullable on all repository interfaces. Use `options?.Configure()` to convert to `ICommandOptions?` when forwarding, or pass directly since implementations handle null.
+- **`SafeGetOption<T>` returns `[MaybeNull]`**: Callers that omit the default value for reference types must null-check the result. Use `?.` or pattern matching before dereferencing.
+- **Avoid `!` to forward nullable parameters**: Prefer making the parameter nullable on the interface, or using an overload that accepts nullable.
 - Clear, descriptive naming; prefer explicit over clever
 - Use `AnyContext()` (e.g., `ConfigureAwait(false)`) in library code (not in tests)
 - Prefer `ValueTask<T>` for hot paths that may complete synchronously

--- a/src/Foundatio.Repositories.Elasticsearch/Jobs/ReindexWorkItemHandler.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Jobs/ReindexWorkItemHandler.cs
@@ -25,12 +25,14 @@ public class ReindexWorkItemHandler : WorkItemHandlerBase
         if (workItem is not ReindexWorkItem reindexWorkItem)
             return Task.FromResult<ILock?>(null);
 
-        return _lockProvider.AcquireAsync(String.Join(":", "reindex", reindexWorkItem.Alias, reindexWorkItem.OldIndex, reindexWorkItem.NewIndex), TimeSpan.FromMinutes(20), cancellationToken)!;
+        return _lockProvider.AcquireAsync(String.Join(":", "reindex", reindexWorkItem.Alias, reindexWorkItem.OldIndex, reindexWorkItem.NewIndex), TimeSpan.FromMinutes(20), cancellationToken);
     }
 
     public override Task HandleItemAsync(WorkItemContext context)
     {
         var workItem = context.GetData<ReindexWorkItem>();
-        return _reindexer.ReindexAsync(workItem!, context.ReportProgressAsync);
+        ArgumentNullException.ThrowIfNull(workItem);
+
+        return _reindexer.ReindexAsync(workItem, context.ReportProgressAsync);
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Options/ElasticCommandOptions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Options/ElasticCommandOptions.cs
@@ -115,7 +115,7 @@ namespace Foundatio.Repositories.Options
 
         public static Type ParentDocumentType(this ICommandOptions options)
         {
-            return options.SafeGetOption<Type>(ParentDocumentTypeKey, typeof(object))!;
+            return options.SafeGetOption<Type>(ParentDocumentTypeKey, typeof(object));
         }
 
         internal const string QueryFieldResolverKey = "@QueryFieldResolver";

--- a/src/Foundatio.Repositories.Elasticsearch/Options/ElasticCommandOptions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Options/ElasticCommandOptions.cs
@@ -68,7 +68,7 @@ namespace Foundatio.Repositories.Options
             return options;
         }
 
-        public static IIndex GetElasticIndex(this ICommandOptions options)
+        public static IIndex? GetElasticIndex(this ICommandOptions options)
         {
             return options.SafeGetOption<IIndex>(ElasticIndexKey);
         }
@@ -97,7 +97,7 @@ namespace Foundatio.Repositories.Options
             return options;
         }
 
-        public static Type DocumentType(this ICommandOptions options)
+        public static Type? DocumentType(this ICommandOptions options)
         {
             return options.SafeGetOption<Type>(DocumentTypeKey);
         }
@@ -115,7 +115,7 @@ namespace Foundatio.Repositories.Options
 
         public static Type ParentDocumentType(this ICommandOptions options)
         {
-            return options.SafeGetOption<Type>(ParentDocumentTypeKey, typeof(object));
+            return options.SafeGetOption<Type>(ParentDocumentTypeKey, typeof(object))!;
         }
 
         internal const string QueryFieldResolverKey = "@QueryFieldResolver";
@@ -125,7 +125,7 @@ namespace Foundatio.Repositories.Options
             return options;
         }
 
-        public static QueryFieldResolver GetQueryFieldResolver(this ICommandOptions options)
+        public static QueryFieldResolver? GetQueryFieldResolver(this ICommandOptions options)
         {
             return options.SafeGetOption<QueryFieldResolver>(QueryFieldResolverKey);
         }
@@ -137,7 +137,7 @@ namespace Foundatio.Repositories.Options
             return options;
         }
 
-        public static IncludeResolver GetIncludeResolver(this ICommandOptions options)
+        public static IncludeResolver? GetIncludeResolver(this ICommandOptions options)
         {
             return options.SafeGetOption<IncludeResolver>(IncludeResolverKey);
         }

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ChildQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ChildQueryBuilder.cs
@@ -57,6 +57,9 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
                 return;
 
             var index = ctx.Options.GetElasticIndex();
+            if (index is null)
+                return;
+
             foreach (var childQuery in childQueries)
             {
                 var childOptions = ctx.Options.Clone();

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ChildQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ChildQueryBuilder.cs
@@ -56,9 +56,8 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
             if (childQueries.Count == 0)
                 return;
 
-            var index = ctx.Options.GetElasticIndex();
-            if (index is null)
-                return;
+            var index = ctx.Options.GetElasticIndex()
+                ?? throw new InvalidOperationException("ElasticIndex must be set on options to build child queries.");
 
             foreach (var childQuery in childQueries)
             {

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ExpressionQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ExpressionQueryBuilder.cs
@@ -86,17 +86,17 @@ namespace Foundatio.Repositories.Options
 {
     public static class ReadQueryExpressionsExtensions
     {
-        public static ISystemFilter GetSystemFilter(this IRepositoryQuery query)
+        public static ISystemFilter? GetSystemFilter(this IRepositoryQuery query)
         {
             return query.SafeGetOption<ISystemFilter>(QueryExpressionsExtensions.SystemFilterKey);
         }
 
-        public static string GetFilterExpression(this IRepositoryQuery query)
+        public static string? GetFilterExpression(this IRepositoryQuery query)
         {
             return query.SafeGetOption<string>(QueryExpressionsExtensions.FilterKey);
         }
 
-        public static string GetSearchExpression(this IRepositoryQuery query)
+        public static string? GetSearchExpression(this IRepositoryQuery query)
         {
             return query.SafeGetOption<string>(QueryExpressionsExtensions.SearchKey);
         }
@@ -106,7 +106,7 @@ namespace Foundatio.Repositories.Options
             return query.SafeGetOption<SearchOperator>(QueryExpressionsExtensions.CriteriaDefaultOperatorKey, SearchOperator.Or);
         }
 
-        public static string GetSortExpression(this IRepositoryQuery query)
+        public static string? GetSortExpression(this IRepositoryQuery query)
         {
             return query.SafeGetOption<string>(QueryExpressionsExtensions.SortKey);
         }
@@ -129,9 +129,9 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
 
         public Task BuildAsync<T>(QueryBuilderContext<T> ctx) where T : class, new()
         {
-            string filter = ctx.Source.GetFilterExpression();
-            string search = ctx.Source.GetSearchExpression();
-            string sort = ctx.Source.GetSortExpression();
+            string? filter = ctx.Source.GetFilterExpression();
+            string? search = ctx.Source.GetSearchExpression();
+            string? sort = ctx.Source.GetSortExpression();
 
             if (!String.IsNullOrEmpty(filter))
             {
@@ -202,9 +202,9 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
 
         public Task BuildAsync<T>(QueryBuilderContext<T> ctx) where T : class, new()
         {
-            string filter = ctx.Source.GetFilterExpression();
-            string search = ctx.Source.GetSearchExpression();
-            string sort = ctx.Source.GetSortExpression();
+            string? filter = ctx.Source.GetFilterExpression();
+            string? search = ctx.Source.GetSearchExpression();
+            string? sort = ctx.Source.GetSortExpression();
 
             if (!String.IsNullOrEmpty(filter))
                 ctx.Filter &= new QueryStringQuery
@@ -247,9 +247,9 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
 
         public async Task BuildAsync<T>(QueryBuilderContext<T> ctx) where T : class, new()
         {
-            string filter = ctx.Source.GetFilterExpression();
-            string search = ctx.Source.GetSearchExpression();
-            string sort = ctx.Source.GetSortExpression();
+            string? filter = ctx.Source.GetFilterExpression();
+            string? search = ctx.Source.GetSearchExpression();
+            string? sort = ctx.Source.GetSortExpression();
 
             // NOTE: Calling UseScoring here to keep the query from being wrapped in a filter which happens ElasticQueryBuilderExtensions.BuildQuery
             if (!String.IsNullOrEmpty(filter))

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldIncludesQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/FieldIncludesQueryBuilder.cs
@@ -292,7 +292,7 @@ namespace Foundatio.Repositories.Options
             return options.SafeGetCollection<Field>(FieldIncludesQueryExtensions.IncludesKey);
         }
 
-        public static string GetIncludeMask(this IRepositoryQuery options)
+        public static string? GetIncludeMask(this IRepositoryQuery options)
         {
             return options.SafeGetOption<string>(FieldIncludesQueryExtensions.IncludesMaskKey);
         }
@@ -302,7 +302,7 @@ namespace Foundatio.Repositories.Options
             return options.SafeGetCollection<Field>(FieldIncludesQueryExtensions.ExcludesKey);
         }
 
-        public static string GetExcludeMask(this IRepositoryQuery options)
+        public static string? GetExcludeMask(this IRepositoryQuery options)
         {
             return options.SafeGetOption<string>(FieldIncludesQueryExtensions.ExcludesMaskKey);
         }
@@ -315,7 +315,7 @@ namespace Foundatio.Repositories.Options
             return options.SafeGetCollection<Field>(FieldIncludesCommandExtensions.IncludesKey);
         }
 
-        public static string GetIncludeMask(this ICommandOptions options)
+        public static string? GetIncludeMask(this ICommandOptions options)
         {
             return options.SafeGetOption<string>(FieldIncludesCommandExtensions.IncludesMaskKey);
         }
@@ -325,7 +325,7 @@ namespace Foundatio.Repositories.Options
             return options.SafeGetCollection<Field>(FieldIncludesCommandExtensions.ExcludesKey);
         }
 
-        public static string GetExcludeMask(this ICommandOptions options)
+        public static string? GetExcludeMask(this ICommandOptions options)
         {
             return options.SafeGetOption<string>(FieldIncludesCommandExtensions.ExcludesMaskKey);
         }
@@ -368,11 +368,11 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
             includes.AddRange(ctx.Source.GetIncludes());
             includes.AddRange(ctx.Options.GetIncludes());
 
-            string queryIncludeMask = ctx.Source.GetIncludeMask();
+            string? queryIncludeMask = ctx.Source.GetIncludeMask();
             if (!String.IsNullOrEmpty(queryIncludeMask))
                 includes.AddRange(FieldIncludeParser.ParseFieldPaths(queryIncludeMask).Select(f => (Field)f));
 
-            string optionIncludeMask = ctx.Options.GetIncludeMask();
+            string? optionIncludeMask = ctx.Options.GetIncludeMask();
             if (!String.IsNullOrEmpty(optionIncludeMask))
                 includes.AddRange(FieldIncludeParser.ParseFieldPaths(optionIncludeMask).Select(f => (Field)f));
 
@@ -380,11 +380,11 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
             excludes.AddRange(ctx.Source.GetExcludes());
             excludes.AddRange(ctx.Options.GetExcludes());
 
-            string queryExcludeMask = ctx.Source.GetExcludeMask();
+            string? queryExcludeMask = ctx.Source.GetExcludeMask();
             if (!String.IsNullOrEmpty(queryExcludeMask))
                 excludes.AddRange(FieldIncludeParser.ParseFieldPaths(queryExcludeMask).Select(f => (Field)f));
 
-            string optionExcludeMask = ctx.Options.GetExcludeMask();
+            string? optionExcludeMask = ctx.Options.GetExcludeMask();
             if (!String.IsNullOrEmpty(optionExcludeMask))
                 excludes.AddRange(FieldIncludeParser.ParseFieldPaths(optionExcludeMask).Select(f => (Field)f));
 

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ParentQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ParentQueryBuilder.cs
@@ -56,7 +56,7 @@ namespace Foundatio.Repositories.Options
             return query.SafeGetOption<(string Relation, string ParentId)>(ParentQueryExtensions.ParentIdKey);
         }
 
-        public static string GetDiscriminator(this IRepositoryQuery query)
+        public static string? GetDiscriminator(this IRepositoryQuery query)
         {
             return query.SafeGetOption<string>(ParentQueryExtensions.DiscriminatorKey);
         }
@@ -75,12 +75,12 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
             if (!String.IsNullOrEmpty(parentId.Item2))
                 ctx.Filter &= new ParentIdQuery { Id = parentId.ParentId, Type = parentId.Relation };
 
-            string discriminator = ctx.Source.GetDiscriminator();
+            string? discriminator = ctx.Source.GetDiscriminator();
             if (discriminator != null)
                 ctx.Filter &= new TermQuery { Field = "discriminator", Value = discriminator };
 
             var parentQueries = ctx.Source.GetParentQueries();
-            if (parentQueries.Count > 0)
+            if (parentQueries.Count > 0 && index is not null)
             {
                 foreach (var parentQuery in parentQueries)
                 {

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ParentQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ParentQueryBuilder.cs
@@ -69,8 +69,6 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
     {
         public async Task BuildAsync<T>(QueryBuilderContext<T> ctx) where T : class, new()
         {
-            var index = ctx.Options.GetElasticIndex();
-
             var parentId = ctx.Source.GetParentId();
             if (!String.IsNullOrEmpty(parentId.Item2))
                 ctx.Filter &= new ParentIdQuery { Id = parentId.ParentId, Type = parentId.Relation };
@@ -82,7 +80,7 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
             var parentQueries = ctx.Source.GetParentQueries();
             if (parentQueries.Count > 0)
             {
-                var resolvedIndex = index
+                var index = ctx.Options.GetElasticIndex()
                     ?? throw new InvalidOperationException("ElasticIndex must be set on options to build parent queries.");
 
                 foreach (var parentQuery in parentQueries)
@@ -96,7 +94,7 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
 
                     var parentContext = new QueryBuilderContext<object>(parentQuery, parentOptions);
 
-                    await resolvedIndex.QueryBuilder.BuildAsync(parentContext);
+                    await index.QueryBuilder.BuildAsync(parentContext);
 
                     if (parentContext.Filter != null && ((IQueryContainer)parentContext.Filter).IsConditionless == false)
                         ctx.Filter &= new HasParentQuery

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ParentQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/ParentQueryBuilder.cs
@@ -80,8 +80,11 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
                 ctx.Filter &= new TermQuery { Field = "discriminator", Value = discriminator };
 
             var parentQueries = ctx.Source.GetParentQueries();
-            if (parentQueries.Count > 0 && index is not null)
+            if (parentQueries.Count > 0)
             {
+                var resolvedIndex = index
+                    ?? throw new InvalidOperationException("ElasticIndex must be set on options to build parent queries.");
+
                 foreach (var parentQuery in parentQueries)
                 {
                     var parentOptions = ctx.Options.Clone();
@@ -93,7 +96,7 @@ namespace Foundatio.Repositories.Elasticsearch.Queries.Builders
 
                     var parentContext = new QueryBuilderContext<object>(parentQuery, parentOptions);
 
-                    await index.QueryBuilder.BuildAsync(parentContext);
+                    await resolvedIndex.QueryBuilder.BuildAsync(parentContext);
 
                     if (parentContext.Filter != null && ((IQueryContainer)parentContext.Filter).IsConditionless == false)
                         ctx.Filter &= new HasParentQuery

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/RuntimeFieldsQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/RuntimeFieldsQueryBuilder.cs
@@ -65,7 +65,7 @@ namespace Foundatio.Repositories.Options
             return options.SafeGetOption<bool?>(RuntimeFieldsOptionsExtensions.EnableRuntimeFieldResolverKey);
         }
 
-        public static RuntimeFieldResolver GetRuntimeFieldResolver(this ICommandOptions options)
+        public static RuntimeFieldResolver? GetRuntimeFieldResolver(this ICommandOptions options)
         {
             return options.SafeGetOption<RuntimeFieldResolver>(RuntimeFieldsOptionsExtensions.RuntimeFieldResolverKey);
         }

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
@@ -93,25 +93,25 @@ namespace Foundatio.Repositories.Options
             return options.SafeGetOption<bool>(SearchAfterQueryExtensions.SearchAfterPagingKey, false);
         }
 
-        public static object[] GetSearchAfter(this ICommandOptions options)
+        public static object[]? GetSearchAfter(this ICommandOptions options)
         {
             return options.SafeGetOption<object[]>(SearchAfterQueryExtensions.SearchAfterKey);
         }
 
         public static bool HasSearchAfter(this ICommandOptions options)
         {
-            object[] sorts = options.SafeGetOption<object[]>(SearchAfterQueryExtensions.SearchAfterKey);
+            object[]? sorts = options.SafeGetOption<object[]>(SearchAfterQueryExtensions.SearchAfterKey);
             return sorts != null && sorts.Length > 0;
         }
 
-        public static object[] GetSearchBefore(this ICommandOptions options)
+        public static object[]? GetSearchBefore(this ICommandOptions options)
         {
             return options.SafeGetOption<object[]>(SearchAfterQueryExtensions.SearchBeforeKey);
         }
 
         public static bool HasSearchBefore(this ICommandOptions options)
         {
-            object[] sorts = options.SafeGetOption<object[]>(SearchAfterQueryExtensions.SearchBeforeKey);
+            object[]? sorts = options.SafeGetOption<object[]>(SearchAfterQueryExtensions.SearchBeforeKey);
             return sorts != null && sorts.Length > 0;
         }
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SoftDeletesQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SoftDeletesQueryBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Foundatio.Repositories.Models;
 using Foundatio.Repositories.Options;
 using Nest;
@@ -26,8 +27,9 @@ public class SoftDeletesQueryBuilder : IElasticQueryBuilder
         if (!ctx.Options.SupportsSoftDeletes())
             return Task.CompletedTask;
 
-        var documentType = ctx.Options.DocumentType();
-        var property = documentType?.GetProperty(nameof(ISupportSoftDeletes.IsDeleted));
+        var documentType = ctx.Options.DocumentType()
+            ?? throw new InvalidOperationException("DocumentType must be set on options when SupportsSoftDeletes is enabled.");
+        var property = documentType.GetProperty(nameof(ISupportSoftDeletes.IsDeleted));
         var index = ctx.Options.GetElasticIndex();
 
         string fieldName = property != null ? index?.Configuration.Client.Infer.Field(new Field(property)) ?? "isDeleted" : "isDeleted";

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SoftDeletesQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SoftDeletesQueryBuilder.cs
@@ -27,7 +27,7 @@ public class SoftDeletesQueryBuilder : IElasticQueryBuilder
             return Task.CompletedTask;
 
         var documentType = ctx.Options.DocumentType();
-        var property = documentType.GetProperty(nameof(ISupportSoftDeletes.IsDeleted));
+        var property = documentType?.GetProperty(nameof(ISupportSoftDeletes.IsDeleted));
         var index = ctx.Options.GetElasticIndex();
 
         string fieldName = property != null ? index?.Configuration.Client.Infer.Field(new Field(property)) ?? "isDeleted" : "isDeleted";

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -847,7 +847,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             includes.AddRange(query.GetIncludes());
         includes.AddRange(options.GetIncludes());
 
-        string optionIncludeMask = options.GetIncludeMask();
+        string? optionIncludeMask = options.GetIncludeMask();
         if (!String.IsNullOrEmpty(optionIncludeMask))
             includes.AddRange(FieldIncludeParser.ParseFieldPaths(optionIncludeMask).Select(f => (Field)f));
 
@@ -856,7 +856,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             excludes.AddRange(query.GetExcludes());
         excludes.AddRange(options.GetExcludes());
 
-        string optionExcludeMask = options.GetExcludeMask();
+        string? optionExcludeMask = options.GetExcludeMask();
         if (!String.IsNullOrEmpty(optionExcludeMask))
             excludes.AddRange(FieldIncludeParser.ParseFieldPaths(optionExcludeMask).Select(f => (Field)f));
 

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -62,7 +62,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
     protected string? DefaultPipeline { get; set; } = null;
     protected bool AutoCreateCustomFields { get; set; } = false;
 
-    public Task<T> AddAsync(T document, CommandOptionsDescriptor<T> options)
+    public Task<T> AddAsync(T document, CommandOptionsDescriptor<T>? options)
     {
         return AddAsync(document, options?.Configure());
     }
@@ -76,7 +76,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return document;
     }
 
-    public Task AddAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options)
+    public Task AddAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T>? options)
     {
         return AddAsync(documents, options?.Configure());
     }
@@ -114,7 +114,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
     protected virtual Task ValidateAndThrowAsync(T document) { return Task.CompletedTask; }
 
-    public Task<T> SaveAsync(T document, CommandOptionsDescriptor<T> options)
+    public Task<T> SaveAsync(T document, CommandOptionsDescriptor<T>? options)
     {
         return SaveAsync(document, options?.Configure());
     }
@@ -128,7 +128,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return document;
     }
 
-    public Task SaveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options)
+    public Task SaveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T>? options)
     {
         return SaveAsync(documents, options?.Configure());
     }
@@ -172,7 +172,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             ThrowForBulkErrors(result, isCreateOperation: false);
     }
 
-    public Task<bool> PatchAsync(Id id, IPatchOperation operation, CommandOptionsDescriptor<T> options)
+    public Task<bool> PatchAsync(Id id, IPatchOperation operation, CommandOptionsDescriptor<T>? options)
     {
         return PatchAsync(id, operation, options?.Configure());
     }
@@ -413,7 +413,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return modified;
     }
 
-    public Task<long> PatchAsync(Ids ids, IPatchOperation operation, CommandOptionsDescriptor<T> options)
+    public Task<long> PatchAsync(Ids ids, IPatchOperation operation, CommandOptionsDescriptor<T>? options)
     {
         return PatchAsync(ids, operation, options?.Configure());
     }
@@ -513,7 +513,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return result.ModifiedCount;
     }
 
-    public Task RemoveAsync(Id id, CommandOptionsDescriptor<T> options)
+    public Task RemoveAsync(Id id, CommandOptionsDescriptor<T>? options)
     {
         return RemoveAsync(id, options?.Configure());
     }
@@ -526,7 +526,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return RemoveAsync((Ids)id, options);
     }
 
-    public Task RemoveAsync(Ids ids, CommandOptionsDescriptor<T> options)
+    public Task RemoveAsync(Ids ids, CommandOptionsDescriptor<T>? options)
     {
         return RemoveAsync(ids, options?.Configure());
     }
@@ -549,7 +549,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         await RemoveAsync(documents, options).AnyContext();
     }
 
-    public Task RemoveAsync(T document, CommandOptionsDescriptor<T> options)
+    public Task RemoveAsync(T document, CommandOptionsDescriptor<T>? options)
     {
         return RemoveAsync(document, options?.Configure());
     }
@@ -562,7 +562,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         return RemoveAsync(new[] { document }, options);
     }
 
-    public Task RemoveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options)
+    public Task RemoveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T>? options)
     {
         return RemoveAsync(documents, options?.Configure());
     }

--- a/src/Foundatio.Repositories/IReadOnlyRepository.cs
+++ b/src/Foundatio.Repositories/IReadOnlyRepository.cs
@@ -21,7 +21,7 @@ public interface IReadOnlyRepository<T> where T : class, new()
     /// </summary>
     /// <param name="id">The document identifier.</param>
     /// <param name="options">Options to control caching, soft delete filtering, and other behaviors.</param>
-    Task<T?> GetByIdAsync(Id id, CommandOptionsDescriptor<T> options);
+    Task<T?> GetByIdAsync(Id id, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="GetByIdAsync(Id, CommandOptionsDescriptor{T})"/>
     Task<T?> GetByIdAsync(Id id, ICommandOptions? options = null);
@@ -31,7 +31,7 @@ public interface IReadOnlyRepository<T> where T : class, new()
     /// </summary>
     /// <param name="ids">The document identifiers.</param>
     /// <param name="options">Options to control caching, soft delete filtering, and other behaviors.</param>
-    Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, CommandOptionsDescriptor<T> options);
+    Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="GetByIdsAsync(Ids, CommandOptionsDescriptor{T})"/>
     Task<IReadOnlyCollection<T>> GetByIdsAsync(Ids ids, ICommandOptions? options = null);
@@ -40,7 +40,7 @@ public interface IReadOnlyRepository<T> where T : class, new()
     /// Retrieves all documents in the repository.
     /// </summary>
     /// <param name="options">Options to control paging, caching, soft delete filtering, and other behaviors.</param>
-    Task<FindResults<T>> GetAllAsync(CommandOptionsDescriptor<T> options);
+    Task<FindResults<T>> GetAllAsync(CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="GetAllAsync(CommandOptionsDescriptor{T})"/>
     Task<FindResults<T>> GetAllAsync(ICommandOptions? options = null);
@@ -50,7 +50,7 @@ public interface IReadOnlyRepository<T> where T : class, new()
     /// </summary>
     /// <param name="id">The document identifier.</param>
     /// <param name="options">Options to control caching, soft delete filtering, and other behaviors.</param>
-    Task<bool> ExistsAsync(Id id, CommandOptionsDescriptor<T> options);
+    Task<bool> ExistsAsync(Id id, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="ExistsAsync(Id, CommandOptionsDescriptor{T})"/>
     Task<bool> ExistsAsync(Id id, ICommandOptions? options = null);
@@ -59,7 +59,7 @@ public interface IReadOnlyRepository<T> where T : class, new()
     /// Gets the total count of documents in the repository.
     /// </summary>
     /// <param name="options">Options to control caching, soft delete filtering, and other behaviors.</param>
-    Task<CountResult> CountAsync(CommandOptionsDescriptor<T> options);
+    Task<CountResult> CountAsync(CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="CountAsync(CommandOptionsDescriptor{T})"/>
     Task<CountResult> CountAsync(ICommandOptions? options = null);

--- a/src/Foundatio.Repositories/IRepository.cs
+++ b/src/Foundatio.Repositories/IRepository.cs
@@ -27,7 +27,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     /// <returns>The added document with any generated fields populated (e.g., Id).</returns>
     /// <exception cref="Exceptions.DuplicateDocumentException">Thrown when a document with the same ID already exists.</exception>
     /// <exception cref="Exceptions.DocumentException">Thrown when the Elasticsearch request fails.</exception>
-    Task<T> AddAsync(T document, CommandOptionsDescriptor<T> options);
+    Task<T> AddAsync(T document, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="AddAsync(T, CommandOptionsDescriptor{T})"/>
     Task<T> AddAsync(T document, ICommandOptions? options = null);
@@ -39,7 +39,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     /// <param name="options">Options to control caching, notifications, and other behaviors.</param>
     /// <exception cref="Exceptions.DuplicateDocumentException">Thrown when any document ID already exists. Successfully added documents are still cached and notified.</exception>
     /// <exception cref="Exceptions.DocumentException">Thrown when the Elasticsearch request fails.</exception>
-    Task AddAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options);
+    Task AddAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="AddAsync(IEnumerable{T}, CommandOptionsDescriptor{T})"/>
     Task AddAsync(IEnumerable<T> documents, ICommandOptions? options = null);
@@ -52,7 +52,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     /// <returns>The saved document.</returns>
     /// <exception cref="Exceptions.VersionConflictDocumentException">Thrown when the document version conflicts with the stored version (optimistic concurrency).</exception>
     /// <exception cref="Exceptions.DocumentException">Thrown when the Elasticsearch request fails.</exception>
-    Task<T> SaveAsync(T document, CommandOptionsDescriptor<T> options);
+    Task<T> SaveAsync(T document, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="SaveAsync(T, CommandOptionsDescriptor{T})"/>
     Task<T> SaveAsync(T document, ICommandOptions? options = null);
@@ -64,7 +64,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     /// <param name="options">Options to control caching, notifications, and other behaviors.</param>
     /// <exception cref="Exceptions.VersionConflictDocumentException">Thrown when any document has a version conflict. Successfully saved documents are still cached and notified.</exception>
     /// <exception cref="Exceptions.DocumentException">Thrown when the Elasticsearch request fails.</exception>
-    Task SaveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options);
+    Task SaveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="SaveAsync(IEnumerable{T}, CommandOptionsDescriptor{T})"/>
     Task SaveAsync(IEnumerable<T> documents, ICommandOptions? options = null);
@@ -92,7 +92,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     /// (the modified <typeparamref name="T"/> is passed to <c>InvalidateCacheAsync</c>), so custom cache key
     /// overrides work correctly. All other patch types use ID-based invalidation only.</para>
     /// </remarks>
-    Task<bool> PatchAsync(Id id, IPatchOperation operation, CommandOptionsDescriptor<T> options);
+    Task<bool> PatchAsync(Id id, IPatchOperation operation, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="PatchAsync(Id, IPatchOperation, CommandOptionsDescriptor{T})"/>
     Task<bool> PatchAsync(Id id, IPatchOperation operation, ICommandOptions? options = null);
@@ -109,7 +109,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     /// document-based cache invalidation. <see cref="ScriptPatch"/> and <see cref="PartialPatch"/> use
     /// ID-based invalidation only (the modified document is not available client-side).</para>
     /// </remarks>
-    Task<long> PatchAsync(Ids ids, IPatchOperation operation, CommandOptionsDescriptor<T> options);
+    Task<long> PatchAsync(Ids ids, IPatchOperation operation, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="PatchAsync(Ids, IPatchOperation, CommandOptionsDescriptor{T})"/>
     Task<long> PatchAsync(Ids ids, IPatchOperation operation, ICommandOptions? options = null);
@@ -119,7 +119,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     /// </summary>
     /// <param name="id">The identifier of the document to remove.</param>
     /// <param name="options">Options to control caching, notifications, and other behaviors.</param>
-    Task RemoveAsync(Id id, CommandOptionsDescriptor<T> options);
+    Task RemoveAsync(Id id, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="RemoveAsync(Id, CommandOptionsDescriptor{T})"/>
     Task RemoveAsync(Id id, ICommandOptions? options = null);
@@ -129,7 +129,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     /// </summary>
     /// <param name="ids">The identifiers of the documents to remove.</param>
     /// <param name="options">Options to control caching, notifications, and other behaviors.</param>
-    Task RemoveAsync(Ids ids, CommandOptionsDescriptor<T> options);
+    Task RemoveAsync(Ids ids, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="RemoveAsync(Ids, CommandOptionsDescriptor{T})"/>
     Task RemoveAsync(Ids ids, ICommandOptions? options = null);
@@ -139,7 +139,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     /// </summary>
     /// <param name="document">The document to remove.</param>
     /// <param name="options">Options to control caching, notifications, and other behaviors.</param>
-    Task RemoveAsync(T document, CommandOptionsDescriptor<T> options);
+    Task RemoveAsync(T document, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="RemoveAsync(T, CommandOptionsDescriptor{T})"/>
     Task RemoveAsync(T document, ICommandOptions? options = null);
@@ -149,7 +149,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     /// </summary>
     /// <param name="documents">The documents to remove.</param>
     /// <param name="options">Options to control caching, notifications, and other behaviors.</param>
-    Task RemoveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T> options);
+    Task RemoveAsync(IEnumerable<T> documents, CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="RemoveAsync(IEnumerable{T}, CommandOptionsDescriptor{T})"/>
     Task RemoveAsync(IEnumerable<T> documents, ICommandOptions? options = null);
@@ -159,7 +159,7 @@ public interface IRepository<T> : IReadOnlyRepository<T> where T : class, IIdent
     /// </summary>
     /// <param name="options">Options to control caching, notifications, and other behaviors.</param>
     /// <returns>The number of documents removed.</returns>
-    Task<long> RemoveAllAsync(CommandOptionsDescriptor<T> options);
+    Task<long> RemoveAllAsync(CommandOptionsDescriptor<T>? options);
 
     /// <inheritdoc cref="RemoveAllAsync(CommandOptionsDescriptor{T})"/>
     Task<long> RemoveAllAsync(ICommandOptions? options = null);

--- a/src/Foundatio.Repositories/Migration/MigrationBase.cs
+++ b/src/Foundatio.Repositories/Migration/MigrationBase.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Repositories.Migrations;
 
 public abstract class MigrationBase : IMigration
 {
-    protected ILogger _logger = null!;
+    protected ILogger _logger = NullLogger.Instance;
 
     public MigrationBase()
     {

--- a/src/Foundatio.Repositories/Migration/MigrationManager.cs
+++ b/src/Foundatio.Repositories/Migration/MigrationManager.cs
@@ -138,7 +138,8 @@ public class MigrationManager
                 {
                     _logger.LogError(ex, "Failed running migration {Id}", migrationInfo.Migration.GetId());
 
-                    migrationInfo.State!.ErrorMessage = ex.Message;
+                    Debug.Assert(migrationInfo.State is not null, "State is set by MarkMigrationStartedAsync before try block");
+                    migrationInfo.State.ErrorMessage = ex.Message;
                     await _migrationStatusRepository.SaveAsync(migrationInfo.State).AnyContext();
 
                     return MigrationResult.Failed;
@@ -183,7 +184,8 @@ public class MigrationManager
 
     private async Task MarkMigrationCompleteAsync(MigrationInfo info)
     {
-        info.State!.CompletedUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        Debug.Assert(info.State is not null, "State is set by MarkMigrationStartedAsync");
+        info.State.CompletedUtc = _timeProvider.GetUtcNow().UtcDateTime;
         info.State.ErrorMessage = null;
         await _migrationStatusRepository.SaveAsync(info.State).AnyContext();
         _logger.LogInformation("Completed migration {Id}", info.State.Id);

--- a/src/Foundatio.Repositories/Options/ICommandOptions.cs
+++ b/src/Foundatio.Repositories/Options/ICommandOptions.cs
@@ -16,9 +16,9 @@ namespace Foundatio.Repositories.Options
 {
     public static class CommandOptionsExtensions
     {
-        public static ICommandOptions<T> As<T>(this ICommandOptions options) where T : class
+        public static ICommandOptions<T> As<T>(this ICommandOptions? options) where T : class
         {
-            if (options == null)
+            if (options is null)
                 return new CommandOptions<T>();
 
             if (options is ICommandOptions<T> typedOptions)

--- a/src/Foundatio.Repositories/Options/IOptions.cs
+++ b/src/Foundatio.Repositories/Options/IOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Foundatio.Repositories.Extensions;
 using Foundatio.Repositories.Utility;
 
@@ -16,6 +17,7 @@ public interface IOptionsDictionary : IEnumerable<KeyValuePair<string, object>>
     void Set(string name, object value);
     bool Contains(string name);
     bool Remove(string name);
+    [return: MaybeNull]
     T Get<T>(string name, T defaultValue = default!);
 }
 
@@ -92,6 +94,7 @@ public static class OptionsExtensions
         return options;
     }
 
+    [return: MaybeNull]
     public static T SafeGetOption<T>(this IOptions? options, string name, T defaultValue = default!)
     {
         if (options == null)
@@ -113,7 +116,7 @@ public static class OptionsExtensions
         if (options == null)
             return new List<T>();
 
-        return options.Values.Get(name, new List<T>());
+        return options.Values.Get(name, new List<T>())!;
     }
 
     public static TOptions AddCollectionOptionValue<TOptions, TValue>(this TOptions options, string name, TValue value) where TOptions : IOptions
@@ -121,7 +124,7 @@ public static class OptionsExtensions
         if (options == null)
             throw new ArgumentNullException(nameof(options));
 
-        var setOption = options.SafeGetOption(name, new List<TValue>());
+        var setOption = options.SafeGetOption(name, new List<TValue>())!;
         setOption.Add(value);
         options.Values.Set(name, setOption);
 
@@ -133,19 +136,19 @@ public static class OptionsExtensions
         if (options == null)
             throw new ArgumentNullException(nameof(options));
 
-        var setOption = options.SafeGetOption(name, new List<TValue>());
+        var setOption = options.SafeGetOption(name, new List<TValue>())!;
         setOption.AddRange(values);
         options.Values.Set(name, setOption);
 
         return options;
     }
 
-    public static ISet<T> SafeGetSet<T>(this IOptions options, string name)
+    public static ISet<T> SafeGetSet<T>(this IOptions? options, string name)
     {
         if (options == null)
             return new HashSet<T>();
 
-        return options.Values.Get(name, new HashSet<T>());
+        return options.Values.Get(name, new HashSet<T>())!;
     }
 
     public static T AddSetOptionValue<T>(this T options, string name, string value) where T : IOptions
@@ -153,7 +156,7 @@ public static class OptionsExtensions
         if (options == null)
             throw new ArgumentNullException(nameof(options));
 
-        var setOption = options.SafeGetOption(name, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+        var setOption = options.SafeGetOption(name, new HashSet<string>(StringComparer.OrdinalIgnoreCase))!;
         setOption.Add(value);
         options.Values.Set(name, setOption);
 
@@ -165,7 +168,7 @@ public static class OptionsExtensions
         if (options == null)
             throw new ArgumentNullException(nameof(options));
 
-        var setOption = options.SafeGetOption(name, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+        var setOption = options.SafeGetOption(name, new HashSet<string>(StringComparer.OrdinalIgnoreCase))!;
         setOption.AddRange(values);
         options.Values.Set(name, setOption);
 

--- a/src/Foundatio.Repositories/Options/IOptions.cs
+++ b/src/Foundatio.Repositories/Options/IOptions.cs
@@ -18,6 +18,7 @@ public interface IOptionsDictionary : IEnumerable<KeyValuePair<string, object>>
     bool Contains(string name);
     bool Remove(string name);
     [return: MaybeNull]
+    [return: NotNullIfNotNull(nameof(defaultValue))]
     T Get<T>(string name, T defaultValue = default!);
 }
 
@@ -95,6 +96,7 @@ public static class OptionsExtensions
     }
 
     [return: MaybeNull]
+    [return: NotNullIfNotNull(nameof(defaultValue))]
     public static T SafeGetOption<T>(this IOptions? options, string name, T defaultValue = default!)
     {
         if (options == null)
@@ -116,7 +118,7 @@ public static class OptionsExtensions
         if (options == null)
             return new List<T>();
 
-        return options.Values.Get(name, new List<T>())!;
+        return options.Values.Get(name, new List<T>());
     }
 
     public static TOptions AddCollectionOptionValue<TOptions, TValue>(this TOptions options, string name, TValue value) where TOptions : IOptions
@@ -124,7 +126,7 @@ public static class OptionsExtensions
         if (options == null)
             throw new ArgumentNullException(nameof(options));
 
-        var setOption = options.SafeGetOption(name, new List<TValue>())!;
+        var setOption = options.SafeGetOption(name, new List<TValue>());
         setOption.Add(value);
         options.Values.Set(name, setOption);
 
@@ -136,7 +138,7 @@ public static class OptionsExtensions
         if (options == null)
             throw new ArgumentNullException(nameof(options));
 
-        var setOption = options.SafeGetOption(name, new List<TValue>())!;
+        var setOption = options.SafeGetOption(name, new List<TValue>());
         setOption.AddRange(values);
         options.Values.Set(name, setOption);
 
@@ -148,7 +150,7 @@ public static class OptionsExtensions
         if (options == null)
             return new HashSet<T>();
 
-        return options.Values.Get(name, new HashSet<T>())!;
+        return options.Values.Get(name, new HashSet<T>());
     }
 
     public static T AddSetOptionValue<T>(this T options, string name, string value) where T : IOptions
@@ -156,7 +158,7 @@ public static class OptionsExtensions
         if (options == null)
             throw new ArgumentNullException(nameof(options));
 
-        var setOption = options.SafeGetOption(name, new HashSet<string>(StringComparer.OrdinalIgnoreCase))!;
+        var setOption = options.SafeGetOption(name, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
         setOption.Add(value);
         options.Values.Set(name, setOption);
 
@@ -168,7 +170,7 @@ public static class OptionsExtensions
         if (options == null)
             throw new ArgumentNullException(nameof(options));
 
-        var setOption = options.SafeGetOption(name, new HashSet<string>(StringComparer.OrdinalIgnoreCase))!;
+        var setOption = options.SafeGetOption(name, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
         setOption.AddRange(values);
         options.Values.Set(name, setOption);
 

--- a/src/Foundatio.Repositories/Options/TimeProviderOptions.cs
+++ b/src/Foundatio.Repositories/Options/TimeProviderOptions.cs
@@ -20,7 +20,7 @@ namespace Foundatio.Repositories.Options
     {
         public static TimeProvider GetTimeProvider(this IOptions options)
         {
-            return options.SafeGetOption(SetTimeProviderOptionsExtensions.TimeProviderKey, TimeProvider.System);
+            return options.SafeGetOption(SetTimeProviderOptionsExtensions.TimeProviderKey, TimeProvider.System)!;
         }
     }
 }

--- a/src/Foundatio.Repositories/Options/TimeProviderOptions.cs
+++ b/src/Foundatio.Repositories/Options/TimeProviderOptions.cs
@@ -20,7 +20,7 @@ namespace Foundatio.Repositories.Options
     {
         public static TimeProvider GetTimeProvider(this IOptions options)
         {
-            return options.SafeGetOption(SetTimeProviderOptionsExtensions.TimeProviderKey, TimeProvider.System)!;
+            return options.SafeGetOption(SetTimeProviderOptionsExtensions.TimeProviderKey, TimeProvider.System);
         }
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Queries/EmailAddressQuery.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Queries/EmailAddressQuery.cs
@@ -22,7 +22,7 @@ namespace Foundatio.Repositories.Options
 {
     public static class ReadEmailAddressQueryExtensions
     {
-        public static string GetEmailAddress(this IRepositoryQuery query)
+        public static string? GetEmailAddress(this IRepositoryQuery query)
         {
             return query.SafeGetOption<string>(EmailAddressQueryExtensions.EmailAddressKey);
         }
@@ -35,7 +35,7 @@ namespace Foundatio.Repositories.Elasticsearch.Tests.Repositories.Queries
     {
         public Task BuildAsync<T>(QueryBuilderContext<T> ctx) where T : class, new()
         {
-            string emailAddress = ctx.Source.GetEmailAddress();
+            string? emailAddress = ctx.Source.GetEmailAddress();
             if (String.IsNullOrEmpty(emailAddress))
                 return Task.CompletedTask;
 


### PR DESCRIPTION
## Summary

Comprehensive NRT code smell fixes after enabling nullable reference types. Addresses dangerous `!` suppressions, makes interface signatures honest about nullability, and fixes all cascading compiler errors.

**HIGH priority fixes:**
- **ReindexWorkItemHandler**: Remove `!` from `AcquireAsync` (return type is already `Task<ILock?>`), add `ArgumentNullException.ThrowIfNull` for `workItem` instead of `!` suppression
- **MigrationBase._logger**: Initialize to `NullLogger.Instance` instead of `null!` (NRE if parameterless ctor used)
- **MigrationManager.State**: Add `Debug.Assert` to document control-flow invariant instead of `!` suppression
- **IOptions.Get\<T\>/SafeGetOption**: Add `[return: MaybeNull]` so the compiler warns callers who omit `defaultValue` for reference types

**MEDIUM priority fixes:**
- **CommandOptionsDescriptor\<T\>**: Make nullable on all 16 `IRepository`/`IReadOnlyRepository` interface methods and 10 `ElasticRepositoryBase` implementations (without `= null` default to avoid overload ambiguity)
- **CommandOptionsExtensions.As\<T\>** and **SafeGetSet\<T\>**: Make `this` parameter nullable to match existing null-check logic
- **AGENTS.md**: Document NRT conventions for the repository layer

**Cascading fixes from `[return: MaybeNull]`:**
- Nullable return types on ~16 option getter methods (ElasticCommandOptions, SearchAfter, RuntimeFields, FieldIncludes, Expression, Parent)
- `string?` locals in 3 expression query builder classes, ElasticReadOnlyRepositoryBase, and test query
- Null guards in SoftDeletesQueryBuilder (`?.`), ParentQueryBuilder, ChildQueryBuilder

## Test plan

- [ ] CI passes -- `dotnet build` with 0 warnings, 0 errors across all TFMs
- [ ] Existing tests pass with no regressions
- [ ] Verify `CommandOptionsDescriptor<T>?` change is non-breaking (existing lambda callers still compile)
- [ ] Verify `[return: MaybeNull]` doesn't break any callers that pass explicit non-null defaults
