### PR TITLE
fix: correct consistency option propagation in batch and fallback paths

### DIFF
--- a/docs/guide/consistency.md
+++ b/docs/guide/consistency.md
@@ -179,12 +179,15 @@ await repository.AddAsync(doc, o => o.ImmediateConsistency(shouldWait: true));
 
 ### DefaultConsistency Property
 
-Repositories can override `DefaultConsistency` to apply a non-Eventual mode by default for all operations:
+Repositories can set `DefaultConsistency` in the constructor to apply a non-Eventual mode by default for all operations:
 
 ```csharp
 public class MigrationStateRepository : ElasticRepositoryBase<MigrationState>
 {
-    protected override Consistency DefaultConsistency => Consistency.Immediate;
+    public MigrationStateRepository(IIndexType<MigrationState> index) : base(index)
+    {
+        DefaultConsistency = Consistency.Immediate;
+    }
 }
 ```
 

--- a/docs/guide/consistency.md
+++ b/docs/guide/consistency.md
@@ -157,6 +157,64 @@ bool exists = await repository.ExistsAsync(q => q
     o => o.ImmediateConsistency());
 ```
 
+## Consistency Modes (Internal Mechanics)
+
+The `Consistency` enum controls how the repository ensures write visibility:
+
+| Mode | Write Behavior | Read Behavior | Use Case |
+|------|---------------|---------------|----------|
+| `Eventual` (default) | `Refresh.False` -- no forced refresh | No pre-query refresh | Normal production operations |
+| `Immediate` | `Refresh.True` -- synchronous refresh before response | `Indices.RefreshAsync` before search | Tests, critical paths needing instant visibility |
+| `Wait` | `Refresh.WaitFor` -- blocks until next scheduled refresh | `Indices.RefreshAsync` before search | Lower-overhead alternative to Immediate |
+
+### Setting Consistency
+
+```csharp
+// On a specific operation
+await repository.AddAsync(doc, o => o.ImmediateConsistency());
+
+// Or wait for next scheduled refresh (gentler on the cluster)
+await repository.AddAsync(doc, o => o.ImmediateConsistency(shouldWait: true));
+```
+
+### DefaultConsistency Property
+
+Repositories can override `DefaultConsistency` to apply a non-Eventual mode by default for all operations:
+
+```csharp
+public class MigrationStateRepository : ElasticRepositoryBase<MigrationState>
+{
+    protected override Consistency DefaultConsistency => Consistency.Immediate;
+}
+```
+
+This is appropriate for small, correctness-critical indices (migration state, field definitions). Avoid for large or high-write indices due to the refresh cost.
+
+### How Read-Side Refresh Works
+
+Search-based operations (`FindAsync`, `CountAsync`, `ExistsAsync(query)`, `FindOneAsync`) call `RefreshForConsistency` before executing the search. This is essential for:
+
+1. **Cross-process consistency**: Process A writes with Eventual consistency, Process B reads with Immediate -- the read-side refresh ensures B sees A's write.
+2. **Batch pagination correctness**: `RemoveAllAsync` and `PatchAllAsync` intentionally downgrade inner writes to Eventual for performance, then rely on the read-side refresh between pages to prevent reprocessing.
+
+### Batch Processing and Consistency
+
+`BatchProcessAsAsync` (used by `RemoveAllAsync` and `PatchAllAsync` when listeners/cache are active) uses this pattern:
+
+1. Refresh (via `FindAsAsync`) → search for page 1
+2. Process batch (inner writes use Eventual for performance)
+3. Refresh (via next `FindAsAsync`) → search for page 2 (correctly skips processed docs)
+4. Repeat until done
+5. Final `RefreshForConsistency` for the last batch
+
+The inner writes are downgraded to Eventual to avoid the cost of per-write refresh during bulk operations. The inter-page refresh makes the completed batch invisible to subsequent queries, preventing infinite loops or double-processing.
+
+### Known Limitations
+
+- **`UpdateByQuery` and `DeleteByQuery`**: These ES APIs only accept `bool?` for their refresh parameter (not the `Refresh` enum). `Consistency.Wait` is treated identically to `Immediate` for these operations.
+- **Non-idempotent scripts**: If using `PatchAllAsync` with a non-idempotent script (e.g., counter increment) and Eventual consistency, a document could theoretically be processed twice between page refreshes. Use `ImmediateConsistency` for non-idempotent patches.
+- **Exceptions bypass final refresh**: If an exception occurs during batch processing, the final refresh is skipped. Partially-processed writes may not be immediately visible.
+
 ## Next Steps
 
 - [Caching](caching.md) - How the cache layer handles dirty reads

--- a/docs/guide/consistency.md
+++ b/docs/guide/consistency.md
@@ -184,7 +184,7 @@ Repositories can set `DefaultConsistency` in the constructor to apply a non-Even
 ```csharp
 public class MigrationStateRepository : ElasticRepositoryBase<MigrationState>
 {
-    public MigrationStateRepository(IIndexType<MigrationState> index) : base(index)
+    public MigrationStateRepository(IIndex index) : base(index)
     {
         DefaultConsistency = Consistency.Immediate;
     }

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -202,8 +202,9 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         // fallback to doing a find
         if (itemsToFind.Count > 0 && (HasParent || ElasticIndex.HasMultipleIndexes))
         {
-            var consistency = options.GetConsistency(DefaultConsistency);
-            var response = await FindAsync(q => q.Id(itemsToFind.Select(id => id.Value)!), o => o.PageLimit(1000).Consistency(consistency)).AnyContext();
+            var findOptions = options.Clone();
+            findOptions.PageLimit(1000);
+            var response = await FindAsync(NewQuery().Id(itemsToFind.Select(id => id.Value)!), findOptions).AnyContext();
             do
             {
                 if (response.Hits.Count > 0)
@@ -520,11 +521,12 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             return results;
         }
 
-        if (options.ShouldUseSearchAfterPaging())
-            options.SearchAfterToken(previousResults.GetSearchAfterToken(), ElasticIndex.Configuration.Serializer);
+        var nextPageOptions = options.Clone();
+        if (nextPageOptions.ShouldUseSearchAfterPaging())
+            nextPageOptions.SearchAfterToken(previousResults.GetSearchAfterToken(), ElasticIndex.Configuration.Serializer);
 
-        options.PageNumber(!options.HasPageNumber() ? 2 : options.GetPage() + 1);
-        return await FindAsAsync<TResult>(query, options).AnyContext();
+        nextPageOptions.PageNumber(!nextPageOptions.HasPageNumber() ? 2 : nextPageOptions.GetPage() + 1);
+        return await FindAsAsync<TResult>(query, nextPageOptions).AnyContext();
     }
 
     public Task<FindHit<T>> FindOneAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null)

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -521,12 +521,11 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             return results;
         }
 
-        var nextPageOptions = options.Clone();
-        if (nextPageOptions.ShouldUseSearchAfterPaging())
-            nextPageOptions.SearchAfterToken(previousResults.GetSearchAfterToken(), ElasticIndex.Configuration.Serializer);
+        if (options.ShouldUseSearchAfterPaging())
+            options.SearchAfterToken(previousResults.GetSearchAfterToken(), ElasticIndex.Configuration.Serializer);
 
-        nextPageOptions.PageNumber(!nextPageOptions.HasPageNumber() ? 2 : nextPageOptions.GetPage() + 1);
-        return await FindAsAsync<TResult>(query, nextPageOptions).AnyContext();
+        options.PageNumber(!options.HasPageNumber() ? 2 : options.GetPage() + 1);
+        return await FindAsAsync<TResult>(query, options).AnyContext();
     }
 
     public Task<FindHit<T>> FindOneAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null)

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -959,6 +959,9 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     ///   with inner writes downgraded to Eventual, this refresh between pages prevents reprocessing
     ///   of already-handled documents.</description></item>
     /// </list>
+    /// <para><strong>Override contract:</strong> Implementations must preserve the no-op behavior when
+    /// consistency is <see cref="Consistency.Eventual"/>. Suppressing the refresh for non-Eventual modes
+    /// will break batch pagination correctness (infinite loops or double-processing).</para>
     /// </remarks>
     protected virtual async Task RefreshForConsistency(IRepositoryQuery query, ICommandOptions options)
     {

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -202,7 +202,8 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         // fallback to doing a find
         if (itemsToFind.Count > 0 && (HasParent || ElasticIndex.HasMultipleIndexes))
         {
-            var response = await FindAsync(q => q.Id(itemsToFind.Select(id => id.Value)!), o => o.PageLimit(1000)).AnyContext();
+            var consistency = options.GetConsistency(DefaultConsistency);
+            var response = await FindAsync(q => q.Id(itemsToFind.Select(id => id.Value)!), o => o.PageLimit(1000).Consistency(consistency)).AnyContext();
             do
             {
                 if (response.Hits.Count > 0)
@@ -944,7 +945,21 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         };
     }
 
-    protected async Task RefreshForConsistency(IRepositoryQuery query, ICommandOptions options)
+    /// <summary>
+    /// Forces a refresh on all indices targeted by the query, making any pending writes
+    /// immediately visible to search operations. Only executes when consistency is non-Eventual.
+    /// </summary>
+    /// <remarks>
+    /// This method is critical for two scenarios:
+    /// <list type="number">
+    ///   <item><description>Cross-process reads: ensures writes from other processes (which may have used
+    ///   Eventual consistency) are visible to the current read operation.</description></item>
+    ///   <item><description>Batch pagination: when <c>BatchProcessAsAsync</c> uses search_after pagination
+    ///   with inner writes downgraded to Eventual, this refresh between pages prevents reprocessing
+    ///   of already-handled documents.</description></item>
+    /// </list>
+    /// </remarks>
+    protected virtual async Task RefreshForConsistency(IRepositoryQuery query, ICommandOptions options)
     {
         if (options.GetConsistency(DefaultConsistency) is not Consistency.Eventual)
         {

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -965,15 +965,15 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     /// </remarks>
     protected virtual async Task RefreshForConsistency(IRepositoryQuery query, ICommandOptions options)
     {
-        if (options.GetConsistency(DefaultConsistency) is not Consistency.Eventual)
-        {
-            string[] indices = ElasticIndex.GetIndexesByQuery(query);
-            var response = await _client.Indices.RefreshAsync(indices).AnyContext();
-            if (response.IsValidResponse)
-                _logger.LogRequest(response);
-            else
-                _logger.LogErrorRequest(response, "Failed to refresh indices for immediate consistency");
-        }
+        if (options.GetConsistency(DefaultConsistency) is Consistency.Eventual)
+            return;
+
+        string[] indices = ElasticIndex.GetIndexesByQuery(query);
+        var response = await _client.Indices.RefreshAsync(indices).AnyContext();
+        if (response.IsValidResponse)
+            _logger.LogRequest(response);
+        else
+            _logger.LogErrorRequest(response, "Failed to refresh indices for immediate consistency");
     }
 
     protected async Task<TResult?> GetCachedQueryResultAsync<TResult>(ICommandOptions options, string? cachePrefix = null, string? cacheSuffix = null)

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -961,7 +961,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 }
 
                 return true;
-            }, options).AnyContext();
+            }, options.Clone()).AnyContext();
 
             affectedRecords += modifiedRecords;
         }
@@ -1058,7 +1058,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 }
 
                 return true;
-            }, options).AnyContext();
+            }, options.Clone()).AnyContext();
 
             affectedRecords += modifiedRecords;
         }
@@ -1275,7 +1275,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     }
 
                     return true;
-                }, options).AnyContext();
+                }, options.Clone()).AnyContext();
 
                 affectedRecords += modifiedInBatch;
             }

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -872,12 +872,16 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         {
             var patcher = new JsonPatcher();
             long modifiedRecords = 0;
+            var batchOptions = options.Clone();
+            if (batchOptions.GetConsistency(DefaultConsistency) != Consistency.Eventual)
+                batchOptions.Consistency(Consistency.Eventual);
+
             await BatchProcessAsync(query, async results =>
             {
                 var processedDocs = new Dictionary<string, T>(results.Hits.Count);
                 var bulkResult = await _client.BulkAsync(b =>
                 {
-                    b.Refresh(options.GetRefreshMode(DefaultConsistency));
+                    b.Refresh(Refresh.False);
                     foreach (var h in results.Hits)
                     {
                         // Using System.Text.Json.Nodes.JsonNode since Elastic.Clients.Elasticsearch uses System.Text.Json exclusively
@@ -960,13 +964,16 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 }
 
                 return true;
-            }, options.Clone()).AnyContext();
+            }, batchOptions).AnyContext();
 
             affectedRecords += modifiedRecords;
         }
         else if (operation is ActionPatch<T> actionOperation)
         {
             long modifiedRecords = 0;
+            var actionBatchOptions = options.Clone();
+            if (actionBatchOptions.GetConsistency(DefaultConsistency) != Consistency.Eventual)
+                actionBatchOptions.Consistency(Consistency.Eventual);
             await BatchProcessAsync(query, async results =>
             {
                 var modifiedHits = new List<FindHit<T>>(results.Hits.Count);
@@ -993,7 +1000,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
 
                 var bulkResult = await _client.BulkAsync(b =>
                 {
-                    b.Refresh(options.GetRefreshMode(DefaultConsistency));
+                    b.Refresh(Refresh.False);
                     foreach (var h in modifiedHits)
                     {
                         var elasticVersion = h.GetElasticVersion();
@@ -1057,7 +1064,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 }
 
                 return true;
-            }, options.Clone()).AnyContext();
+            }, actionBatchOptions).AnyContext();
 
             affectedRecords += modifiedRecords;
         }
@@ -1161,13 +1168,17 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     query.Include(_idField!.Value);
 
                 long modifiedInBatch = 0;
+                var partialBatchOptions = options.Clone();
+                if (partialBatchOptions.GetConsistency(DefaultConsistency) != Consistency.Eventual)
+                    partialBatchOptions.Consistency(Consistency.Eventual);
+
                 await BatchProcessAsync(query, async results =>
                 {
                     var bulkResult = await _client.BulkAsync(b =>
                     {
                         if (DefaultPipeline is not null)
                             b.Pipeline(DefaultPipeline);
-                        b.Refresh(options.GetRefreshMode(DefaultConsistency));
+                        b.Refresh(Refresh.False);
 
                         foreach (var h in results.Hits)
                         {
@@ -1273,7 +1284,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     }
 
                     return true;
-                }, options.Clone()).AnyContext();
+                }, partialBatchOptions).AnyContext();
 
                 affectedRecords += modifiedInBatch;
             }
@@ -1399,8 +1410,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             recordsProcessed += results.Documents.Count;
         } while (await results.NextPageAsync().AnyContext());
 
-        if (options.GetConsistency(DefaultConsistency) != Consistency.Eventual)
-            await RefreshForConsistency(query, options).AnyContext();
+        await RefreshForConsistency(query, options).AnyContext();
 
         _logger.LogTrace("{Processed} records processed", recordsProcessed);
         return recordsProcessed;

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -1315,7 +1315,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 options.PageLimit(1000);
 
             var removeOptions = options.Clone();
-            if (removeOptions.GetConsistency() != Consistency.Eventual)
+            if (removeOptions.GetConsistency(DefaultConsistency) != Consistency.Eventual)
                 removeOptions.Consistency(Consistency.Eventual);
 
             return await BatchProcessAsync(query, async results =>
@@ -1399,7 +1399,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             recordsProcessed += results.Documents.Count;
         } while (await results.NextPageAsync().AnyContext());
 
-        if (options.GetConsistency() != Consistency.Eventual)
+        if (options.GetConsistency(DefaultConsistency) != Consistency.Eventual)
             await RefreshForConsistency(query, options).AnyContext();
 
         _logger.LogTrace("{Processed} records processed", recordsProcessed);

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -872,9 +872,6 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         {
             var patcher = new JsonPatcher();
             long modifiedRecords = 0;
-            var batchOptions = options.Clone();
-            if (batchOptions.GetConsistency(DefaultConsistency) != Consistency.Eventual)
-                batchOptions.Consistency(Consistency.Eventual);
 
             await BatchProcessAsync(query, async results =>
             {
@@ -964,16 +961,13 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 }
 
                 return true;
-            }, batchOptions).AnyContext();
+            }, options).AnyContext();
 
             affectedRecords += modifiedRecords;
         }
         else if (operation is ActionPatch<T> actionOperation)
         {
             long modifiedRecords = 0;
-            var actionBatchOptions = options.Clone();
-            if (actionBatchOptions.GetConsistency(DefaultConsistency) != Consistency.Eventual)
-                actionBatchOptions.Consistency(Consistency.Eventual);
             await BatchProcessAsync(query, async results =>
             {
                 var modifiedHits = new List<FindHit<T>>(results.Hits.Count);
@@ -1064,7 +1058,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                 }
 
                 return true;
-            }, actionBatchOptions).AnyContext();
+            }, options).AnyContext();
 
             affectedRecords += modifiedRecords;
         }
@@ -1168,9 +1162,6 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     query.Include(_idField!.Value);
 
                 long modifiedInBatch = 0;
-                var partialBatchOptions = options.Clone();
-                if (partialBatchOptions.GetConsistency(DefaultConsistency) != Consistency.Eventual)
-                    partialBatchOptions.Consistency(Consistency.Eventual);
 
                 await BatchProcessAsync(query, async results =>
                 {
@@ -1284,7 +1275,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
                     }
 
                     return true;
-                }, partialBatchOptions).AnyContext();
+                }, options).AnyContext();
 
                 affectedRecords += modifiedInBatch;
             }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/IdentityRepository.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/IdentityRepository.cs
@@ -17,3 +17,11 @@ public class IdentityWithNoCachingRepository : IdentityRepository
         DisableCache();
     }
 }
+
+public class IdentityWithImmediateConsistencyRepository : IdentityRepository
+{
+    public IdentityWithImmediateConsistencyRepository(MyAppElasticConfiguration configuration) : base(configuration)
+    {
+        DefaultConsistency = Consistency.Immediate;
+    }
+}

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -3018,6 +3018,22 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
+    public async Task PatchAllAsync_WithEventualConsistency_DoesNotRefresh()
+    {
+        // Arrange
+        var repository = new IdentityWithImmediateConsistencyRepository(_configuration);
+        var identities = IdentityGenerator.GenerateIdentities(3);
+        await repository.AddAsync(identities, o => o.ImmediateConsistency());
+
+        // Act — explicit Eventual overrides DefaultConsistency; no refresh should occur
+        long modified = await repository.PatchAllAsync(q => q, new ActionPatch<Identity>(_ => { }),
+            o => o.Consistency(Consistency.Eventual));
+
+        // Assert — all 3 processed; results may or may not be visible without explicit refresh
+        Assert.Equal(3, modified);
+    }
+
+    [Fact]
     public async Task PatchAllAsync_WithImmediateDefaultConsistency_CompletesSuccessfully()
     {
         // Arrange
@@ -3049,6 +3065,23 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert
         var count = await repository.CountAsync();
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task RemoveAllAsync_WithEventualConsistency_DoesNotRefresh()
+    {
+        // Arrange
+        var repository = new IdentityWithImmediateConsistencyRepository(_configuration);
+        await repository.AddAsync(IdentityGenerator.GenerateIdentities(3), o => o.ImmediateConsistency());
+        Assert.Equal(3, await repository.CountAsync(o => o.ImmediateConsistency()));
+
+        // Act — explicit Eventual overrides the repository's DefaultConsistency
+        await repository.RemoveAllAsync(q => q, o => o.Consistency(Consistency.Eventual));
+
+        // Assert — documents removed but no refresh forced; verify at least they were processed
+        // Use explicit ImmediateConsistency to force visibility for the assertion
+        var count = await repository.CountAsync(o => o.ImmediateConsistency());
         Assert.Equal(0, count);
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -3018,18 +3018,18 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
-    public async Task PatchAllAsync_WithEventualConsistency_DoesNotRefresh()
+    public async Task PatchAllAsync_WithExplicitEventualConsistency_OverridesDefaultConsistency()
     {
         // Arrange
         var repository = new IdentityWithImmediateConsistencyRepository(_configuration);
         var identities = IdentityGenerator.GenerateIdentities(3);
         await repository.AddAsync(identities, o => o.ImmediateConsistency());
 
-        // Act — explicit Eventual overrides DefaultConsistency; no refresh should occur
+        // Act — explicit Eventual overrides the repository's DefaultConsistency = Immediate
         long modified = await repository.PatchAllAsync(q => q, new ActionPatch<Identity>(_ => { }),
             o => o.Consistency(Consistency.Eventual));
 
-        // Assert — all 3 processed; results may or may not be visible without explicit refresh
+        // Assert
         Assert.Equal(3, modified);
     }
 
@@ -3069,18 +3069,17 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
-    public async Task RemoveAllAsync_WithEventualConsistency_DoesNotRefresh()
+    public async Task RemoveAllAsync_WithExplicitEventualConsistency_OverridesDefaultConsistency()
     {
         // Arrange
         var repository = new IdentityWithImmediateConsistencyRepository(_configuration);
         await repository.AddAsync(IdentityGenerator.GenerateIdentities(3), o => o.ImmediateConsistency());
         Assert.Equal(3, await repository.CountAsync(o => o.ImmediateConsistency()));
 
-        // Act — explicit Eventual overrides the repository's DefaultConsistency
+        // Act — explicit Eventual overrides the repository's DefaultConsistency = Immediate
         await repository.RemoveAllAsync(q => q, o => o.Consistency(Consistency.Eventual));
 
-        // Assert — documents removed but no refresh forced; verify at least they were processed
-        // Use explicit ImmediateConsistency to force visibility for the assertion
+        // Assert — verify all documents were removed (use ImmediateConsistency to force visibility)
         var count = await repository.CountAsync(o => o.ImmediateConsistency());
         Assert.Equal(0, count);
     }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -3027,10 +3027,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(5, await repository.CountAsync());
 
         // Act — ActionPatch(Action<T>) always reports modified; body is irrelevant
-        await repository.PatchAllAsync(q => q, new ActionPatch<Identity>(d =>
-        {
-            d.Id = d.Id;
-        }));
+        await repository.PatchAllAsync(q => q, new ActionPatch<Identity>(_ => { }));
 
         // Assert
         var results = await repository.FindAsync(q => q);

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -2937,64 +2937,44 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
-    public async Task RemoveAllAsync_BatchProcess_FinalRefreshRespectsDefaultConsistency()
+    public async Task FindAsync_WithEventualConsistency_MayNotReflectRecentWrites()
     {
-        var repository = new IdentityWithImmediateConsistencyRepository(_configuration);
-        await repository.AddAsync(IdentityGenerator.GenerateIdentities(5), o => o.ImmediateConsistency());
-        Assert.Equal(5, await repository.CountAsync(o => o.ImmediateConsistency()));
+        // Arrange
+        var identity = IdentityGenerator.Default;
+        await _identityRepository.AddAsync(identity, o => o.Consistency(Consistency.Eventual));
 
-        await repository.RemoveAllAsync();
+        // Act
+        var results = await _identityRepository.FindAsync(q => q, o => o.Consistency(Consistency.Eventual));
 
-        var count = await repository.CountAsync();
-        Assert.Equal(0, count);
+        // Assert
+        Assert.True(results.Total is 0 or 1);
     }
 
     [Fact]
     public async Task FindAsync_WithImmediateConsistency_ReflectsRecentWrites()
     {
+        // Arrange
         var identity = IdentityGenerator.Default;
         await _identityRepository.AddAsync(identity, o => o.Consistency(Consistency.Eventual));
 
+        // Act
         var results = await _identityRepository.FindAsync(q => q, o => o.ImmediateConsistency());
+
+        // Assert
         Assert.Equal(1, results.Total);
-    }
-
-    [Fact]
-    public async Task FindAsync_WithEventualConsistency_MayNotReflectRecentWrites()
-    {
-        var identity = IdentityGenerator.Default;
-        await _identityRepository.AddAsync(identity, o => o.Consistency(Consistency.Eventual));
-
-        var results = await _identityRepository.FindAsync(q => q, o => o.Consistency(Consistency.Eventual));
-        Assert.True(results.Total is 0 or 1);
-    }
-
-    [Fact]
-    public async Task PatchAllAsync_BatchProcess_DoesNotDoubleRefresh()
-    {
-        var repository = new IdentityWithImmediateConsistencyRepository(_configuration);
-        var identities = IdentityGenerator.GenerateIdentities(5);
-        await repository.AddAsync(identities, o => o.ImmediateConsistency());
-        Assert.Equal(5, await repository.CountAsync());
-
-        await repository.PatchAllAsync(q => q, new ActionPatch<Identity>(d =>
-        {
-            d.Id = d.Id;
-        }));
-
-        var results = await repository.FindAsync(q => q);
-        Assert.Equal(5, results.Total);
-        foreach (var hit in results.Hits)
-            Assert.NotNull(hit.Document);
     }
 
     [Fact]
     public async Task GetNextPageFunc_DoesNotMutateOriginalOptions()
     {
+        // Arrange
         var identities = IdentityGenerator.GenerateIdentities(5);
         await _identityRepository.AddAsync(identities, o => o.ImmediateConsistency());
 
+        // Act
         var results = await _identityRepository.FindAsync(q => q, o => o.PageLimit(2).ImmediateConsistency());
+
+        // Assert
         Assert.Equal(5, results.Total);
         Assert.Equal(2, results.Documents.Count);
         Assert.True(results.HasMore);
@@ -3006,5 +2986,43 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         Assert.True(await results.NextPageAsync());
         Assert.Single(results.Documents);
         Assert.False(results.HasMore);
+    }
+
+    [Fact]
+    public async Task PatchAllAsync_BatchProcess_DoesNotDoubleRefresh()
+    {
+        // Arrange
+        var repository = new IdentityWithImmediateConsistencyRepository(_configuration);
+        var identities = IdentityGenerator.GenerateIdentities(5);
+        await repository.AddAsync(identities, o => o.ImmediateConsistency());
+        Assert.Equal(5, await repository.CountAsync());
+
+        // Act
+        await repository.PatchAllAsync(q => q, new ActionPatch<Identity>(d =>
+        {
+            d.Id = d.Id;
+        }));
+
+        // Assert
+        var results = await repository.FindAsync(q => q);
+        Assert.Equal(5, results.Total);
+        foreach (var hit in results.Hits)
+            Assert.NotNull(hit.Document);
+    }
+
+    [Fact]
+    public async Task RemoveAllAsync_BatchProcess_FinalRefreshRespectsDefaultConsistency()
+    {
+        // Arrange
+        var repository = new IdentityWithImmediateConsistencyRepository(_configuration);
+        await repository.AddAsync(IdentityGenerator.GenerateIdentities(5), o => o.ImmediateConsistency());
+        Assert.Equal(5, await repository.CountAsync(o => o.ImmediateConsistency()));
+
+        // Act
+        await repository.RemoveAllAsync();
+
+        // Assert
+        var count = await repository.CountAsync();
+        Assert.Equal(0, count);
     }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -2965,7 +2965,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
-    public async Task GetNextPageFunc_DoesNotMutateOriginalOptions()
+    public async Task FindAsync_WithSearchAfterPaging_ReturnsAllPages()
     {
         // Arrange
         var identities = IdentityGenerator.GenerateIdentities(5);

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -2968,4 +2968,43 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var results = await _identityRepository.FindAsync(q => q, o => o.Consistency(Consistency.Eventual));
         Assert.True(results.Total is 0 or 1);
     }
+
+    [Fact]
+    public async Task PatchAllAsync_BatchProcess_DoesNotDoubleRefresh()
+    {
+        var repository = new IdentityWithImmediateConsistencyRepository(_configuration);
+        var identities = IdentityGenerator.GenerateIdentities(5);
+        await repository.AddAsync(identities, o => o.ImmediateConsistency());
+        Assert.Equal(5, await repository.CountAsync());
+
+        await repository.PatchAllAsync(q => q, new ActionPatch<Identity>(d =>
+        {
+            d.Id = d.Id;
+        }));
+
+        var results = await repository.FindAsync(q => q);
+        Assert.Equal(5, results.Total);
+        foreach (var hit in results.Hits)
+            Assert.NotNull(hit.Document);
+    }
+
+    [Fact]
+    public async Task GetNextPageFunc_DoesNotMutateOriginalOptions()
+    {
+        var identities = IdentityGenerator.GenerateIdentities(5);
+        await _identityRepository.AddAsync(identities, o => o.ImmediateConsistency());
+
+        var results = await _identityRepository.FindAsync(q => q, o => o.PageLimit(2).ImmediateConsistency());
+        Assert.Equal(5, results.Total);
+        Assert.Equal(2, results.Documents.Count);
+        Assert.True(results.HasMore);
+
+        Assert.True(await results.NextPageAsync());
+        Assert.Equal(2, results.Documents.Count);
+        Assert.Equal(2, results.Page);
+
+        Assert.True(await results.NextPageAsync());
+        Assert.Single(results.Documents);
+        Assert.False(results.HasMore);
+    }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -2989,7 +2989,36 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
-    public async Task PatchAllAsync_BatchProcess_DoesNotDoubleRefresh()
+    public async Task FindAsync_WithWaitConsistency_ReflectsRecentWrites()
+    {
+        // Arrange
+        var identity = IdentityGenerator.Default;
+        await _identityRepository.AddAsync(identity, o => o.Consistency(Consistency.Eventual));
+
+        // Act
+        var results = await _identityRepository.FindAsync(q => q, o => o.ImmediateConsistency(shouldWait: true));
+
+        // Assert
+        Assert.Equal(1, results.Total);
+    }
+
+    [Fact]
+    public async Task GetByIdsAsync_WithMultipleIndexes_PropagatesConsistency()
+    {
+        // Arrange — DailyLogEventRepository uses HasMultipleIndexes, triggering the FindAsync fallback
+        var log = LogEventGenerator.Generate();
+        await _dailyRepository.AddAsync(log, o => o.Consistency(Consistency.Eventual));
+
+        // Act — ImmediateConsistency should propagate to the fallback FindAsync path
+        var results = await _dailyRepository.GetByIdsAsync(new[] { log.Id }, o => o.ImmediateConsistency());
+
+        // Assert
+        Assert.Single(results);
+        Assert.Equal(log.Id, results.First().Id);
+    }
+
+    [Fact]
+    public async Task PatchAllAsync_WithImmediateDefaultConsistency_CompletesSuccessfully()
     {
         // Arrange
         var repository = new IdentityWithImmediateConsistencyRepository(_configuration);
@@ -2997,7 +3026,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         await repository.AddAsync(identities, o => o.ImmediateConsistency());
         Assert.Equal(5, await repository.CountAsync());
 
-        // Act
+        // Act — ActionPatch(Action<T>) always reports modified; body is irrelevant
         await repository.PatchAllAsync(q => q, new ActionPatch<Identity>(d =>
         {
             d.Id = d.Id;

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -2935,4 +2935,37 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         Assert.DoesNotContain(employees[0].Id, receivedIds);
         Assert.DoesNotContain(employees[1].Id, receivedIds);
     }
+
+    [Fact]
+    public async Task RemoveAllAsync_BatchProcess_FinalRefreshRespectsDefaultConsistency()
+    {
+        var repository = new IdentityWithImmediateConsistencyRepository(_configuration);
+        await repository.AddAsync(IdentityGenerator.GenerateIdentities(5), o => o.ImmediateConsistency());
+        Assert.Equal(5, await repository.CountAsync(o => o.ImmediateConsistency()));
+
+        await repository.RemoveAllAsync();
+
+        var count = await repository.CountAsync();
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task FindAsync_WithImmediateConsistency_ReflectsRecentWrites()
+    {
+        var identity = IdentityGenerator.Default;
+        await _identityRepository.AddAsync(identity, o => o.Consistency(Consistency.Eventual));
+
+        var results = await _identityRepository.FindAsync(q => q, o => o.ImmediateConsistency());
+        Assert.Equal(1, results.Total);
+    }
+
+    [Fact]
+    public async Task FindAsync_WithEventualConsistency_MayNotReflectRecentWrites()
+    {
+        var identity = IdentityGenerator.Default;
+        await _identityRepository.AddAsync(identity, o => o.Consistency(Consistency.Eventual));
+
+        var results = await _identityRepository.FindAsync(q => q, o => o.Consistency(Consistency.Eventual));
+        Assert.True(results.Total is 0 or 1);
+    }
 }


### PR DESCRIPTION
## Summary

Comprehensive consistency correctness improvements across the Elasticsearch repository layer. This PR fixes critical bugs where consistency options were improperly propagated through batch operations, pagination, and fallback paths.

## Bugs Fixed

### Bug 1 (Critical): PatchAllAsync double-refresh in batch paths

The `JsonPatch`, `ActionPatch`, and `PartialPatch`/`ScriptPatch` batch processing paths in `PatchAllAsync` used `options.GetRefreshMode(DefaultConsistency)` on each inner bulk write. When `DefaultConsistency = Immediate`, this caused `Refresh.True` on every page, forcing a synchronous refresh per bulk request. Combined with the inter-page `RefreshForConsistency` call in `BatchProcessAsAsync` (via `FindAsAsync`), this doubled the refresh cost per page.

**Fix**: Inner bulk writes now use `Refresh.False` unconditionally. The `BatchProcessAsAsync` loop handles refresh between pages (via `FindAsAsync` → `RefreshForConsistency`) and at the end (final `RefreshForConsistency`). This centralized refresh lifecycle eliminates waste while preserving correctness.

### Bug 2 (Medium): GetByIdsAsync fallback discards caller options

When `GetByIdsAsync` fell back to `FindAsync` (for multi-index or parent-child scenarios), it created a new options object via a lambda that only set `PageLimit(1000)`, discarding all caller options: consistency, cache settings, `IncludeSoftDeletes`, etc.

**Fix**: The fallback now clones the caller's options, overrides `PageLimit(1000)`, and passes the complete options to `FindAsync`.

### Bug 3 (Medium): BatchProcessAsAsync final refresh used wrong default

`BatchProcessAsAsync` called `options.GetConsistency()` (no default parameter) which always defaults to `Eventual`, ignoring the repository's `DefaultConsistency`. Repositories configured with `DefaultConsistency = Immediate` would skip the critical post-batch refresh.

**Fix**: Removed the redundant outer `if` guard entirely — `RefreshForConsistency` already has the correct guard internally (`options.GetConsistency(DefaultConsistency) is not Consistency.Eventual`).

### Bug 4 (Medium): RemoveAllAsync consistency downgrade check

`RemoveAllAsync` compared against `Consistency.Eventual` but didn't account for `DefaultConsistency` when deciding whether to downgrade inner removes.

**Fix**: Uses `GetConsistency(DefaultConsistency)` for the comparison.

## Architectural Improvements

- **Centralized refresh lifecycle**: Inner bulk writes are explicitly `Refresh.False`. `BatchProcessAsAsync` owns all refresh responsibility (inter-page via `FindAsAsync` and final `RefreshForConsistency`).
- **Defensive cloning**: `PatchAllAsync` batch paths clone options before passing to `BatchProcessAsync`, preventing mutation of the caller's options by paging internals.
- **`RefreshForConsistency` made `protected virtual`**: Enables subclass customization (e.g., metrics, throttling) with a documented override contract.

## Behavioral Changes & Risk Assessment

### 1. Intermediate visibility window (PatchAllAsync)

| | Before | After |
|---|--------|-------|
| **When writes become visible** | After each bulk write (`Refresh.True`) | At page boundaries (inter-page `RefreshForConsistency`) |
| **Affected repos** | Only those with `DefaultConsistency = Immediate` | Same |
| **Risk** | Low — external readers observing the index during a batch operation will see writes in page-sized "lumps" (~500 docs) rather than continuously. Batch operations are transient; callers should not depend on observing intermediate state. |

### 2. GetByIdsAsync fallback now triggers index refresh

| | Before | After |
|---|--------|-------|
| **Fallback consistency** | Always Eventual (fresh options) — could miss recent writes | Propagates caller's consistency — refresh if non-Eventual |
| **Affected repos** | Multi-index (`DailyIndex`, `MonthlyIndex`) or parent-child repos |
| **Risk** | Medium for performance — multi-index repos with `DefaultConsistency = Immediate` under high read load will now issue an `Indices.RefreshAsync` call per `GetByIdsAsync` fallback that didn't exist before. This is more *correct* but more expensive. Single-index repos are unaffected (fallback never triggers). |

### 3. RemoveAllAsync correctly downgrades inner removes

| | Before | After |
|---|--------|-------|
| **Downgrade check** | `GetConsistency()` without default → always returns `Eventual` → never entered the downgrade branch | `GetConsistency(DefaultConsistency)` → correctly enters branch for `DefaultConsistency = Immediate` repos |
| **Risk** | None — this is a pure correctness fix. Repos with `DefaultConsistency = Immediate` were previously passing Immediate options to per-document `RemoveAsync` inside a batch loop (defeating the point of batch processing). |

### What Won't Break

- Single-index repositories (GetByIdsAsync fallback never triggers)
- Callers using `Consistency.Eventual` (no behavioral change — `Refresh.False` was already the mode)
- Batch pagination correctness (inter-page refresh guarantees correct page boundaries)
- Repositories without `DefaultConsistency = Immediate` (vast majority)

## Test Coverage

- `FindAsync_WithEventualConsistency_MayNotReflectRecentWrites` — documents eventual behavior
- `FindAsync_WithImmediateConsistency_ReflectsRecentWrites` — verifies read-side refresh
- `FindAsync_WithSearchAfterPaging_ReturnsAllPages` — verifies pagination works correctly
- `FindAsync_WithWaitConsistency_ReflectsRecentWrites` — verifies Consistency.Wait mode
- `GetByIdsAsync_WithMultipleIndexes_PropagatesConsistency` — verifies fallback path propagates options
- `PatchAllAsync_WithImmediateDefaultConsistency_CompletesSuccessfully` — verifies batch processing with DefaultConsistency
- `RemoveAllAsync_BatchProcess_FinalRefreshRespectsDefaultConsistency` — verifies DefaultConsistency propagation in remove

## Design Decisions

1. **Why `Refresh.False` in inner batches?** — `BatchProcessAsAsync` already refreshes between pages (via `FindAsAsync` → `RefreshForConsistency`) and at the end. Per-write refresh is redundant and wasteful.
2. **Why clone options for PatchAllAsync batch calls?** — `BatchProcessAsAsync` mutates options (adds `SearchAfterPaging`, `PageLimit`). Cloning prevents corrupting the caller's options which are reused after the call for notifications and event firing.
3. **Why NOT clone for RemoveAllAsync?** — `RemoveAllAsync` immediately returns the `BatchProcessAsync` result; options are never read again after the call.
