### PR TITLE
[codex] Add search-after cursor options

### DIFF
--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
@@ -50,6 +50,7 @@ public static class ElasticIndexExtensions
             TrackScores = searchRequest.TrackScores,
             TrackTotalHits = searchRequest.TrackTotalHits,
             Version = searchRequest.Version,
+            Pit = searchRequest.Pit,
             RuntimeMappings = searchRequest.RuntimeMappings,
             SeqNoPrimaryTerm = searchRequest.SeqNoPrimaryTerm
         };
@@ -77,6 +78,8 @@ public static class ElasticIndexExtensions
         var data = new DataDictionary();
         if (response.ScrollId is not null)
             data.Add(ElasticDataKeys.ScrollId, response.ScrollId.ToString());
+        if (response.PitId is not null)
+            data.Add(ElasticDataKeys.PointInTimeId, response.PitId);
 
         var results = new FindResults<T>(docs, response.Total, response.ToAggregations(serializer, logger), null, data);
         var protectedResults = (IFindResults<T>)results;
@@ -135,6 +138,8 @@ public static class ElasticIndexExtensions
 
         if (options.ShouldAutoDeleteAsyncQuery() && !response.IsRunning)
             data.Remove(AsyncQueryDataKeys.AsyncQueryId);
+        if (response.Response.PitId is not null)
+            data.Add(ElasticDataKeys.PointInTimeId, response.Response.PitId);
 
         var results = new FindResults<T>(docs, response.Response.Total, response.ToAggregations(serializer, logger), null, data);
         var protectedResults = (IFindResults<T>)results;

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
@@ -176,6 +176,7 @@ public static class ElasticDataKeys
 {
     public const string Index = "index";
     public const string ScrollId = "scrollid";
+    public const string PointInTimeId = "pointintimeid";
     public const string Sorts = "sorts";
     public const string SearchBeforeToken = nameof(SearchBeforeToken);
     public const string SearchAfterToken = nameof(SearchAfterToken);

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/FindResultsExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/FindResultsExtensions.cs
@@ -8,4 +8,8 @@ public static class FindResultsExtensions
     {
         return results.Data.GetString(ElasticDataKeys.ScrollId, null);
     }
+
+    public static string? GetPointInTimeId(this IHaveData results) {
+        return results.Data.GetString(ElasticDataKeys.PointInTimeId, null);
+    }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Options/ElasticCommandOptions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Options/ElasticCommandOptions.cs
@@ -14,6 +14,12 @@ namespace Foundatio.Repositories
     {
         internal const string SnapshotPagingKey = "@SnapshotPaging";
         internal const string SnapshotPagingScrollIdKey = "@SnapshotPagingScrollId";
+        internal const string TrackTotalHitsKey = "@TrackTotalHits";
+
+        public static T TrackTotalHits<T>(this T options, bool enabled = true) where T : ICommandOptions
+        {
+            return options.BuildOption(TrackTotalHitsKey, enabled);
+        }
 
         public static T SnapshotPaging<T>(this T options) where T : ICommandOptions
         {
@@ -172,6 +178,11 @@ namespace Foundatio.Repositories.Options
             return ToRefresh(options.GetConsistency(defaultMode));
         }
 
+        public static bool ShouldTrackTotalHits(this ICommandOptions options)
+        {
+            return options.SafeGetOption<bool>(SetElasticOptionsExtensions.TrackTotalHitsKey, true);
+        }
+
         private static Refresh ToRefresh(Consistency mode)
         {
             if (mode == Consistency.Immediate)
@@ -183,4 +194,3 @@ namespace Foundatio.Repositories.Options
         }
     }
 }
-

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
@@ -11,15 +11,39 @@ using Foundatio.Serializer;
 
 namespace Foundatio.Repositories
 {
+    public enum SearchAfterPagingMode
+    {
+        Live,
+        PointInTime
+    }
+
     public static class SearchAfterQueryExtensions
     {
         internal const string SearchAfterPagingKey = "@SearchAfterPaging";
+        internal const string SearchAfterPagingPointInTimeKey = "@SearchAfterPagingPointInTime";
         internal const string SearchAfterKey = "@SearchAfter";
         internal const string SearchBeforeKey = "@SearchBefore";
+        internal const string PointInTimeIdKey = "@PointInTimeId";
 
         public static T SearchAfterPaging<T>(this T options, bool enabled = true) where T : ICommandOptions
         {
             return options.BuildOption(SearchAfterPagingKey, enabled);
+        }
+
+        public static T SearchAfterPaging<T>(this T options, SearchAfterPagingMode mode, bool enabled = true) where T : ICommandOptions
+        {
+            options.SearchAfterPaging(enabled);
+            return options.BuildOption(SearchAfterPagingPointInTimeKey, enabled && mode == SearchAfterPagingMode.PointInTime);
+        }
+
+        public static T PointInTimeId<T>(this T options, string? pointInTimeId) where T : ICommandOptions
+        {
+            if (!String.IsNullOrEmpty(pointInTimeId))
+                options.Values.Set(PointInTimeIdKey, pointInTimeId);
+            else
+                options.Values.Remove(PointInTimeIdKey);
+
+            return options;
         }
 
         public static T SearchAfter<T>(this T options, params object[] values) where T : ICommandOptions
@@ -95,6 +119,21 @@ namespace Foundatio.Repositories.Options
         public static bool ShouldUseSearchAfterPaging(this ICommandOptions options)
         {
             return options.SafeGetOption<bool>(SearchAfterQueryExtensions.SearchAfterPagingKey, false);
+        }
+
+        public static bool ShouldUseSearchAfterPagingPointInTime(this ICommandOptions options)
+        {
+            return options.SafeGetOption<bool>(SearchAfterQueryExtensions.SearchAfterPagingPointInTimeKey, false);
+        }
+
+        public static string? GetPointInTimeId(this ICommandOptions options)
+        {
+            return options.SafeGetOption<string?>(SearchAfterQueryExtensions.PointInTimeIdKey);
+        }
+
+        public static bool HasPointInTimeId(this ICommandOptions options)
+        {
+            return !String.IsNullOrEmpty(options.GetPointInTimeId());
         }
 
         public static object[]? GetSearchAfter(this ICommandOptions options)

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -393,9 +393,10 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     public virtual async Task<FindResults<TResult>> FindAsAsync<TResult>(IRepositoryQuery query, ICommandOptions? options = null) where TResult : class, new()
     {
         options = ConfigureOptions(options?.As<T>());
-        bool useSnapshotPaging = options.ShouldUseSnapshotPaging();
+        bool useSearchAfterPointInTime = options.ShouldUseSearchAfterPagingPointInTime();
+        bool useSnapshotPaging = options.ShouldUseSnapshotPaging() && !useSearchAfterPointInTime;
         // don't use caching with snapshot paging.
-        bool allowCaching = IsCacheEnabled && useSnapshotPaging == false;
+        bool allowCaching = IsCacheEnabled && useSnapshotPaging == false && useSearchAfterPointInTime == false;
 
         await OnBeforeQueryAsync(query, options, typeof(TResult)).AnyContext();
 
@@ -446,6 +447,8 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             var searchDescriptor = await CreateSearchDescriptorAsync(query, options).AnyContext();
             if (useSnapshotPaging)
                 searchDescriptor.Scroll(options.GetSnapshotLifetime());
+            else if (useSearchAfterPointInTime)
+                await ConfigurePointInTimeAsync(searchDescriptor, query, options).AnyContext();
 
             if (query.ShouldOnlyHaveIds())
                 searchDescriptor.Source(false);
@@ -523,6 +526,9 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
 
         if (options.ShouldUseSearchAfterPaging())
             options.SearchAfterToken(previousResults.GetSearchAfterToken(), ElasticIndex.Configuration.Serializer);
+
+        if (options.ShouldUseSearchAfterPagingPointInTime())
+            options.PointInTimeId(previousResults.GetPointInTimeId());
 
         options.PageNumber(!options.HasPageNumber() ? 2 : options.GetPage() + 1);
         return await FindAsAsync<TResult>(query, options).AnyContext();
@@ -798,12 +804,56 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return ConfigureSearchDescriptorAsync(new SearchRequestDescriptor<T>(), query, options);
     }
 
+    private async Task ConfigurePointInTimeAsync(SearchRequestDescriptor<T> search, IRepositoryQuery query, ICommandOptions options)
+    {
+        string? pointInTimeId = options.GetPointInTimeId();
+        if (String.IsNullOrEmpty(pointInTimeId))
+            pointInTimeId = await OpenPointInTimeAsync(query, options).AnyContext();
+
+        if (String.IsNullOrEmpty(pointInTimeId))
+            return;
+
+        search.Pit(new PointInTimeReference(pointInTimeId) { KeepAlive = options.GetSnapshotLifetime().ToElasticDuration() });
+    }
+
+    private async Task<string> OpenPointInTimeAsync(IRepositoryQuery query, ICommandOptions options)
+    {
+        string[] indices = ElasticIndex.GetIndexesByQuery(query);
+        Indices index = indices?.Length > 0 ? Indices.Parse(String.Join(",", indices)) : Indices.All;
+
+        var response = await _client.OpenPointInTimeAsync(index, p => p
+            .IgnoreUnavailable(true)
+            .KeepAlive(options.GetSnapshotLifetime().ToElasticDuration())).AnyContext();
+        _logger.LogRequest(response, options.GetQueryLogLevel());
+
+        if (!response.IsValidResponse)
+            throw new DocumentException(response.GetErrorMessage("Error while opening point in time"), response.OriginalException());
+
+        return response.Id;
+    }
+
+    public Task<bool> ClosePointInTimeAsync(IHaveData? results)
+    {
+        return ClosePointInTimeAsync(results?.GetPointInTimeId());
+    }
+
+    public async Task<bool> ClosePointInTimeAsync(string? pointInTimeId)
+    {
+        if (String.IsNullOrEmpty(pointInTimeId))
+            return false;
+
+        var response = await _client.ClosePointInTimeAsync(p => p.Id(pointInTimeId)).AnyContext();
+        _logger.LogRequest(response);
+
+        return response.IsValidResponse && response.Succeeded;
+    }
+
     protected virtual async Task<SearchRequestDescriptor<T>> ConfigureSearchDescriptorAsync(SearchRequestDescriptor<T> search, IRepositoryQuery query, ICommandOptions options)
     {
 
         query = ConfigureQuery(query.As<T>()).Unwrap();
         string[] indices = ElasticIndex.GetIndexesByQuery(query);
-        if (indices?.Length > 0)
+        if (indices?.Length > 0 && !options.ShouldUseSearchAfterPagingPointInTime())
             search.Indices(String.Join(",", indices));
         if (HasVersion)
             search.SeqNoPrimaryTerm(HasVersion);
@@ -814,8 +864,9 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             search.Timeout(timeout.ToElasticDuration());
         }
 
-        search.IgnoreUnavailable();
-        search.TrackTotalHits(new TrackHits(true));
+        if (!options.ShouldUseSearchAfterPagingPointInTime())
+            search.IgnoreUnavailable();
+        search.TrackTotalHits(new TrackHits(options.ShouldTrackTotalHits()));
 
         await ElasticIndex.QueryBuilder.ConfigureSearchAsync(query, options, search).AnyContext();
 

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
@@ -988,6 +988,152 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
+    public async Task FindWithSearchAfterPagingWithoutTrackTotalHitsAsync()
+    {
+        var employee1 = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Charlie"), o => o.ImmediateConsistency());
+        Assert.NotNull(employee1?.Id);
+
+        var employee2 = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Blake"), o => o.ImmediateConsistency());
+        Assert.NotNull(employee2?.Id);
+
+        var results = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(1).SearchAfterPaging().TrackTotalHits(false));
+        Assert.NotNull(results);
+        Assert.Single(results.Documents);
+        Assert.Equal(employee1.Id, results.Documents.First().Id);
+        Assert.True(results.HasMore);
+        Assert.Null(results.GetSearchBeforeToken());
+        Assert.False(String.IsNullOrEmpty(results.GetSearchAfterToken()));
+        Assert.NotEqual(2, results.Total);
+
+        Assert.True(await results.NextPageAsync());
+        Assert.Single(results.Documents);
+        Assert.Equal(employee2.Id, results.Documents.First().Id);
+        Assert.False(results.HasMore);
+        Assert.False(String.IsNullOrEmpty(results.GetSearchBeforeToken()));
+        Assert.Null(results.GetSearchAfterToken());
+        Assert.NotEqual(2, results.Total);
+    }
+
+    [Fact]
+    public async Task FindWithPointInTimeSearchAfterPagingAsync()
+    {
+        var employee1 = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Charlie"), o => o.ImmediateConsistency());
+        Assert.NotNull(employee1?.Id);
+
+        var employee2 = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Blake"), o => o.ImmediateConsistency());
+        Assert.NotNull(employee2?.Id);
+
+        await _client.ClearScrollAsync(cancellationToken: TestCancellationToken);
+        long baselineScrollCount = await GetCurrentScrollCountAsync();
+
+        var results = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(1).SearchAfterPaging(SearchAfterPagingMode.PointInTime));
+        Assert.NotNull(results);
+        Assert.Single(results.Documents);
+        Assert.Equal(employee1.Id, results.Documents.First().Id);
+        Assert.True(results.HasMore);
+        Assert.False(String.IsNullOrEmpty(results.GetPointInTimeId()));
+        Assert.False(String.IsNullOrEmpty(results.GetSearchAfterToken()));
+        Assert.Equal(baselineScrollCount, await GetCurrentScrollCountAsync());
+
+        var employee3 = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Aaron"), o => o.ImmediateConsistency());
+        Assert.NotNull(employee3?.Id);
+
+        Assert.True(await results.NextPageAsync());
+        Assert.Single(results.Documents);
+        Assert.Equal(employee2.Id, results.Documents.First().Id);
+        Assert.False(results.HasMore);
+        Assert.DoesNotContain(results.Documents, e => e.Id == employee3.Id);
+        Assert.False(String.IsNullOrEmpty(results.GetSearchBeforeToken()));
+        Assert.Null(results.GetSearchAfterToken());
+        Assert.False(String.IsNullOrEmpty(results.GetPointInTimeId()));
+        Assert.Equal(baselineScrollCount, await GetCurrentScrollCountAsync());
+    }
+
+    [Fact]
+    public async Task CanUsePointInTimeSearchAfterPagingLikeWebCursorAsync()
+    {
+        var employees = new[] {
+            await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Echo"), o => o.ImmediateConsistency()),
+            await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Delta"), o => o.ImmediateConsistency()),
+            await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Charlie"), o => o.ImmediateConsistency()),
+            await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Blake"), o => o.ImmediateConsistency()),
+            await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Aaron"), o => o.ImmediateConsistency())
+        };
+        Assert.All(employees, employee => Assert.NotNull(employee?.Id));
+
+        await _client.ClearScrollAsync(cancellationToken: TestCancellationToken);
+        long baselineScrollCount = await GetCurrentScrollCountAsync();
+        string? pointInTimeId = null;
+
+        try
+        {
+            var firstPage = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(2).SearchAfterPaging(SearchAfterPagingMode.PointInTime));
+            pointInTimeId = firstPage.GetPointInTimeId();
+
+            Assert.False(String.IsNullOrEmpty(pointInTimeId));
+            Assert.Equal(5, firstPage.Total);
+            Assert.Equal(new[] { "Echo", "Delta" }, firstPage.Documents.Select(e => e.Name));
+            Assert.True(firstPage.HasMore);
+            Assert.Null(firstPage.GetSearchBeforeToken());
+            Assert.False(String.IsNullOrEmpty(firstPage.GetSearchAfterToken()));
+            Assert.Equal(baselineScrollCount, await GetCurrentScrollCountAsync());
+
+            var newEmployee = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Foxtrot"), o => o.ImmediateConsistency());
+            Assert.NotNull(newEmployee?.Id);
+
+            var secondPage = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(2).SearchAfterPaging(SearchAfterPagingMode.PointInTime).PointInTimeId(pointInTimeId).SearchAfterToken(firstPage.GetSearchAfterToken(), _serializer).TrackTotalHits(false));
+            pointInTimeId = secondPage.GetPointInTimeId();
+
+            Assert.False(String.IsNullOrEmpty(pointInTimeId));
+            Assert.Equal(new[] { "Charlie", "Blake" }, secondPage.Documents.Select(e => e.Name));
+            Assert.True(secondPage.HasMore);
+            Assert.False(String.IsNullOrEmpty(secondPage.GetSearchBeforeToken()));
+            Assert.False(String.IsNullOrEmpty(secondPage.GetSearchAfterToken()));
+            Assert.NotEqual(6, secondPage.Total);
+            Assert.Equal(baselineScrollCount, await GetCurrentScrollCountAsync());
+
+            var thirdPage = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(2).SearchAfterPaging(SearchAfterPagingMode.PointInTime).PointInTimeId(pointInTimeId).SearchAfterToken(secondPage.GetSearchAfterToken(), _serializer).TrackTotalHits(false));
+            pointInTimeId = thirdPage.GetPointInTimeId();
+
+            Assert.False(String.IsNullOrEmpty(pointInTimeId));
+            Assert.Equal(new[] { "Aaron" }, thirdPage.Documents.Select(e => e.Name));
+            Assert.False(thirdPage.HasMore);
+            Assert.False(String.IsNullOrEmpty(thirdPage.GetSearchBeforeToken()));
+            Assert.Null(thirdPage.GetSearchAfterToken());
+            Assert.DoesNotContain(thirdPage.Documents, e => e.Id == newEmployee.Id);
+            Assert.Equal(baselineScrollCount, await GetCurrentScrollCountAsync());
+
+            var backToSecondPage = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(2).SearchAfterPaging(SearchAfterPagingMode.PointInTime).PointInTimeId(pointInTimeId).SearchBeforeToken(thirdPage.GetSearchBeforeToken(), _serializer).TrackTotalHits(false));
+            pointInTimeId = backToSecondPage.GetPointInTimeId();
+
+            Assert.False(String.IsNullOrEmpty(pointInTimeId));
+            Assert.Equal(new[] { "Charlie", "Blake" }, backToSecondPage.Documents.Select(e => e.Name));
+            Assert.True(backToSecondPage.HasMore);
+            Assert.False(String.IsNullOrEmpty(backToSecondPage.GetSearchBeforeToken()));
+            Assert.False(String.IsNullOrEmpty(backToSecondPage.GetSearchAfterToken()));
+            Assert.Equal(baselineScrollCount, await GetCurrentScrollCountAsync());
+
+            var backToFirstPage = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(2).SearchAfterPaging(SearchAfterPagingMode.PointInTime).PointInTimeId(pointInTimeId).SearchBeforeToken(backToSecondPage.GetSearchBeforeToken(), _serializer).TrackTotalHits(false));
+            pointInTimeId = backToFirstPage.GetPointInTimeId();
+
+            Assert.False(String.IsNullOrEmpty(pointInTimeId));
+            Assert.Equal(new[] { "Echo", "Delta" }, backToFirstPage.Documents.Select(e => e.Name));
+            Assert.False(backToFirstPage.HasMore);
+            Assert.Null(backToFirstPage.GetSearchBeforeToken());
+            Assert.False(String.IsNullOrEmpty(backToFirstPage.GetSearchAfterToken()));
+            Assert.Equal(baselineScrollCount, await GetCurrentScrollCountAsync());
+
+            Assert.True(await ((EmployeeRepository)_employeeRepository).ClosePointInTimeAsync(pointInTimeId));
+            pointInTimeId = null;
+        }
+        finally
+        {
+            if (!String.IsNullOrEmpty(pointInTimeId))
+                await ((EmployeeRepository)_employeeRepository).ClosePointInTimeAsync(pointInTimeId);
+        }
+    }
+
+    [Fact]
     public async Task GetAllWithSearchAfterPagingWithCustomSortAsync()
     {
         var identity1 = await _identityRepository.AddAsync(IdentityGenerator.Default, o => o.ImmediateConsistency());


### PR DESCRIPTION
## Summary

- Add `.TrackTotalHits(bool enabled = true)` so search-after cursor calls can opt out of exact total hit tracking after the first page.
- Add `SearchAfterPagingMode` with `Live` and `PointInTime` modes, preserving the existing `.SearchAfterPaging(bool enabled = true)` toggle.
- Add PIT-backed search-after cursor support with explicit PIT cleanup via `ClosePointInTimeAsync`.
- Add tests for totals-off cursor paging and web-style PIT cursor navigation using separate before/after requests.

## Validation

- `dotnet build /Users/ejsmith/.codex/worktrees/73c2/Foundatio.Repositories/tests/Foundatio.Repositories.Elasticsearch.Tests/Foundatio.Repositories.Elasticsearch.Tests.csproj -p:UseSharedCompilation=false -p:BuildInParallel=false -p:ReferenceFoundatioSource=false -p:ReferenceFoundatioRepositoriesSource=false`
- `git diff --check`

Targeted runtime tests were attempted with the xUnit v3 direct runner, but the local Elasticsearch fixture timed out waiting for Elasticsearch readiness before reaching the test bodies.
