### PR TITLE
fix: search-after PIT cursor cleanup (single mode model, auto-close, ISupportPointInTime)

### DIFF
--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/ElasticConfiguration.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/ElasticConfiguration.cs
@@ -15,7 +15,6 @@ using Foundatio.Messaging;
 using Foundatio.Parsers.ElasticQueries;
 using Foundatio.Queues;
 using Foundatio.Repositories.Elasticsearch.CustomFields;
-using Foundatio.Repositories.Elasticsearch.Jobs;
 using Foundatio.Repositories.Elasticsearch.Queries.Builders;
 using Foundatio.Repositories.Extensions;
 using Foundatio.Repositories.Serialization;

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
@@ -180,5 +180,4 @@ public static class ElasticDataKeys
     public const string Sorts = "sorts";
     public const string SearchBeforeToken = nameof(SearchBeforeToken);
     public const string SearchAfterToken = nameof(SearchAfterToken);
-    public const string RepoManagedPit = "repomanagedpit";
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/FindHitExtensions.cs
@@ -180,4 +180,5 @@ public static class ElasticDataKeys
     public const string Sorts = "sorts";
     public const string SearchBeforeToken = nameof(SearchBeforeToken);
     public const string SearchAfterToken = nameof(SearchAfterToken);
+    public const string RepoManagedPit = "repomanagedpit";
 }

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/FindResultsExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/FindResultsExtensions.cs
@@ -9,7 +9,8 @@ public static class FindResultsExtensions
         return results.Data.GetString(ElasticDataKeys.ScrollId, null);
     }
 
-    public static string? GetPointInTimeId(this IHaveData results) {
+    public static string? GetPointInTimeId(this IHaveData results)
+    {
         return results.Data.GetString(ElasticDataKeys.PointInTimeId, null);
     }
 }

--- a/src/Foundatio.Repositories.Elasticsearch/ISupportPointInTime.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/ISupportPointInTime.cs
@@ -8,9 +8,9 @@ namespace Foundatio.Repositories.Elasticsearch;
 /// </summary>
 public interface ISupportPointInTime
 {
-    /// <summary>Closes a point-in-time snapshot. Returns true if successfully closed.</summary>
+    /// <summary>Closes a point-in-time snapshot. Returns <c>true</c> if it was closed; <c>false</c> if <paramref name="pointInTimeId"/> is null or empty, or the snapshot could not be closed.</summary>
     Task<bool> ClosePointInTimeAsync(string? pointInTimeId);
 
-    /// <summary>Closes the point-in-time snapshot stored in the result data. Returns true if successfully closed.</summary>
+    /// <summary>Closes the point-in-time snapshot stored in the result data. Returns <c>true</c> if it was closed; <c>false</c> if <paramref name="results"/> is null or carries no point-in-time id, or the snapshot could not be closed.</summary>
     Task<bool> ClosePointInTimeAsync(IHaveData? results);
 }

--- a/src/Foundatio.Repositories.Elasticsearch/ISupportPointInTime.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/ISupportPointInTime.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using Foundatio.Utility;
+
+namespace Foundatio.Repositories.Elasticsearch;
+
+/// <summary>
+/// Indicates the repository supports Elasticsearch point-in-time snapshots for consistent search-after cursor paging.
+/// </summary>
+public interface ISupportPointInTime
+{
+    /// <summary>Closes a point-in-time snapshot. Returns true if successfully closed.</summary>
+    Task<bool> ClosePointInTimeAsync(string? pointInTimeId);
+
+    /// <summary>Closes the point-in-time snapshot stored in the result data. Returns true if successfully closed.</summary>
+    Task<bool> ClosePointInTimeAsync(IHaveData? results);
+}

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
@@ -24,7 +24,7 @@ namespace Foundatio.Repositories
         internal const string SearchAfterKey = "@SearchAfter";
         internal const string SearchBeforeKey = "@SearchBefore";
         internal const string PointInTimeIdKey = "@PointInTimeId";
-        internal const string RepoManagedPitKey = "@RepoManagedPit";
+        internal const string RepoOwnedPointInTimeKey = "@RepoOwnedPointInTime";
 
         public static T SearchAfterPaging<T>(this T options, bool enabled = true) where T : ICommandOptions
         {
@@ -45,6 +45,11 @@ namespace Foundatio.Repositories
                 options.Values.Remove(PointInTimeIdKey);
 
             return options;
+        }
+
+        internal static T RepoOwnedPointInTime<T>(this T options, bool repoOwned = true) where T : ICommandOptions
+        {
+            return options.BuildOption(RepoOwnedPointInTimeKey, repoOwned);
         }
 
         public static T SearchAfter<T>(this T options, params object[] values) where T : ICommandOptions
@@ -140,6 +145,11 @@ namespace Foundatio.Repositories.Options
         public static bool HasPointInTimeId(this ICommandOptions options)
         {
             return !String.IsNullOrEmpty(options.GetPointInTimeId());
+        }
+
+        internal static bool IsRepoOwnedPointInTime(this ICommandOptions options)
+        {
+            return options.SafeGetOption<bool>(SearchAfterQueryExtensions.RepoOwnedPointInTimeKey, false);
         }
 
         public static object[]? GetSearchAfter(this ICommandOptions options)

--- a/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Queries/Builders/SearchAfterQueryBuilder.cs
@@ -20,10 +20,11 @@ namespace Foundatio.Repositories
     public static class SearchAfterQueryExtensions
     {
         internal const string SearchAfterPagingKey = "@SearchAfterPaging";
-        internal const string SearchAfterPagingPointInTimeKey = "@SearchAfterPagingPointInTime";
+        internal const string SearchAfterPagingModeKey = "@SearchAfterPagingMode";
         internal const string SearchAfterKey = "@SearchAfter";
         internal const string SearchBeforeKey = "@SearchBefore";
         internal const string PointInTimeIdKey = "@PointInTimeId";
+        internal const string RepoManagedPitKey = "@RepoManagedPit";
 
         public static T SearchAfterPaging<T>(this T options, bool enabled = true) where T : ICommandOptions
         {
@@ -32,8 +33,8 @@ namespace Foundatio.Repositories
 
         public static T SearchAfterPaging<T>(this T options, SearchAfterPagingMode mode, bool enabled = true) where T : ICommandOptions
         {
-            options.SearchAfterPaging(enabled);
-            return options.BuildOption(SearchAfterPagingPointInTimeKey, enabled && mode == SearchAfterPagingMode.PointInTime);
+            options.BuildOption(SearchAfterPagingKey, enabled);
+            return options.BuildOption(SearchAfterPagingModeKey, enabled ? mode : SearchAfterPagingMode.Live);
         }
 
         public static T PointInTimeId<T>(this T options, string? pointInTimeId) where T : ICommandOptions
@@ -121,9 +122,14 @@ namespace Foundatio.Repositories.Options
             return options.SafeGetOption<bool>(SearchAfterQueryExtensions.SearchAfterPagingKey, false);
         }
 
+        public static SearchAfterPagingMode GetSearchAfterPagingMode(this ICommandOptions options)
+        {
+            return options.SafeGetOption(SearchAfterQueryExtensions.SearchAfterPagingModeKey, SearchAfterPagingMode.Live);
+        }
+
         public static bool ShouldUseSearchAfterPagingPointInTime(this ICommandOptions options)
         {
-            return options.SafeGetOption<bool>(SearchAfterQueryExtensions.SearchAfterPagingPointInTimeKey, false);
+            return options.ShouldUseSearchAfterPaging() && options.GetSearchAfterPagingMode() is SearchAfterPagingMode.PointInTime;
         }
 
         public static string? GetPointInTimeId(this ICommandOptions options)

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -396,8 +396,10 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     {
         if (options.ShouldUseSearchAfterPagingPointInTime())
             return PagingStrategy.SearchAfterPointInTime;
+
         if (options.ShouldUseSnapshotPaging())
             return PagingStrategy.Snapshot;
+
         return PagingStrategy.Normal;
     }
 
@@ -405,7 +407,6 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     {
         options = ConfigureOptions(options?.As<T>());
         var pagingStrategy = GetPagingStrategy(options);
-        bool callerOwnsPointInTime = options.HasPointInTimeId();
         // don't use caching with paged modes.
         bool allowCaching = IsCacheEnabled && pagingStrategy is PagingStrategy.Normal;
 
@@ -502,11 +503,11 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             }
         }
 
-        if (pagingStrategy is PagingStrategy.SearchAfterPointInTime && options.SafeGetOption<bool>(SearchAfterQueryExtensions.RepoManagedPitKey, false))
+        if (pagingStrategy is PagingStrategy.SearchAfterPointInTime && !result.HasMore && options.IsRepoOwnedPointInTime())
         {
-            result.Data[ElasticDataKeys.RepoManagedPit] = true;
-            if (!result.HasMore)
-                await ClosePointInTimeAsync(result).AnyContext();
+            bool closed = await ClosePointInTimeAsync(result).AnyContext();
+            if (!closed)
+                _logger.LogWarning("Failed to close repository-owned point in time after paging completed; it will expire after its keep-alive window");
         }
 
         if (allowCaching && !result.IsAsyncQueryRunning() && !result.IsAsyncQueryPartial())
@@ -551,11 +552,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             options.SearchAfterToken(previousResults.GetSearchAfterToken(), ElasticIndex.Configuration.Serializer);
 
         if (options.ShouldUseSearchAfterPagingPointInTime())
-        {
             options.PointInTimeId(previousResults.GetPointInTimeId());
-            if (previousResults.Data.TryGetValue(ElasticDataKeys.RepoManagedPit, out var managed) && managed is true)
-                options.Values.Set(SearchAfterQueryExtensions.RepoManagedPitKey, true);
-        }
 
         options.PageNumber(!options.HasPageNumber() ? 2 : options.GetPage() + 1);
         return await FindAsAsync<TResult>(query, options).AnyContext();
@@ -835,7 +832,12 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     {
         string? pointInTimeId = options.GetPointInTimeId();
         if (String.IsNullOrEmpty(pointInTimeId))
+        {
+            // The repository opened this point-in-time, so it owns its lifecycle and must auto-close it once paging completes.
+            // A caller-supplied point-in-time id is owned by the caller and is never auto-closed.
             pointInTimeId = await OpenPointInTimeAsync(query, options).AnyContext();
+            options.RepoOwnedPointInTime();
+        }
 
         search.Pit(new PointInTimeReference(pointInTimeId) { KeepAlive = options.GetSnapshotLifetime().ToElasticDuration() });
     }
@@ -853,7 +855,9 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (!response.IsValidResponse)
             throw new DocumentException(response.GetErrorMessage("Error while opening point in time"), response.OriginalException());
 
-        options.Values.Set(SearchAfterQueryExtensions.RepoManagedPitKey, true);
+        if (String.IsNullOrEmpty(response.Id))
+            throw new DocumentException("Elasticsearch returned an empty point in time id");
+
         return response.Id;
     }
 
@@ -877,6 +881,8 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
     {
         query = ConfigureQuery(query.As<T>()).Unwrap();
         string[] indices = ElasticIndex.GetIndexesByQuery(query);
+        // A point-in-time pins the target index set at the moment it was opened, so the request must not also set
+        // Indices(...) or IgnoreUnavailable() - doing so conflicts with the pinned context.
         bool usePit = options.ShouldUseSearchAfterPagingPointInTime();
         if (indices?.Length > 0 && !usePit)
             search.Indices(String.Join(",", indices));

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -28,7 +28,7 @@ using ChangeType = Foundatio.Repositories.Models.ChangeType;
 
 namespace Foundatio.Repositories.Elasticsearch;
 
-public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepository<T>, IDisposable where T : class, new()
+public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepository<T>, ISupportPointInTime, IDisposable where T : class, new()
 {
     protected static readonly bool HasIdentity = typeof(IIdentity).IsAssignableFrom(typeof(T));
     protected static readonly bool HasDates = typeof(IHaveDates).IsAssignableFrom(typeof(T));
@@ -390,13 +390,24 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         return FindAsAsync<TResult>(query.Configure(), options?.Configure());
     }
 
+    private enum PagingStrategy { Normal, Snapshot, SearchAfterPointInTime }
+
+    private static PagingStrategy GetPagingStrategy(ICommandOptions options)
+    {
+        if (options.ShouldUseSearchAfterPagingPointInTime())
+            return PagingStrategy.SearchAfterPointInTime;
+        if (options.ShouldUseSnapshotPaging())
+            return PagingStrategy.Snapshot;
+        return PagingStrategy.Normal;
+    }
+
     public virtual async Task<FindResults<TResult>> FindAsAsync<TResult>(IRepositoryQuery query, ICommandOptions? options = null) where TResult : class, new()
     {
         options = ConfigureOptions(options?.As<T>());
-        bool useSearchAfterPointInTime = options.ShouldUseSearchAfterPagingPointInTime();
-        bool useSnapshotPaging = options.ShouldUseSnapshotPaging() && !useSearchAfterPointInTime;
-        // don't use caching with snapshot paging.
-        bool allowCaching = IsCacheEnabled && useSnapshotPaging == false && useSearchAfterPointInTime == false;
+        var pagingStrategy = GetPagingStrategy(options);
+        bool callerOwnsPointInTime = options.HasPointInTimeId();
+        // don't use caching with paged modes.
+        bool allowCaching = IsCacheEnabled && pagingStrategy is PagingStrategy.Normal;
 
         await OnBeforeQueryAsync(query, options, typeof(TResult)).AnyContext();
 
@@ -445,10 +456,15 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         else
         {
             var searchDescriptor = await CreateSearchDescriptorAsync(query, options).AnyContext();
-            if (useSnapshotPaging)
-                searchDescriptor.Scroll(options.GetSnapshotLifetime());
-            else if (useSearchAfterPointInTime)
-                await ConfigurePointInTimeAsync(searchDescriptor, query, options).AnyContext();
+            switch (pagingStrategy)
+            {
+                case PagingStrategy.Snapshot:
+                    searchDescriptor.Scroll(options.GetSnapshotLifetime());
+                    break;
+                case PagingStrategy.SearchAfterPointInTime:
+                    await ConfigurePointInTimeAsync(searchDescriptor, query, options).AnyContext();
+                    break;
+            }
 
             if (query.ShouldOnlyHaveIds())
                 searchDescriptor.Source(false);
@@ -475,7 +491,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
 
         await OnAfterQueryAsync(query, options, result).AnyContext();
 
-        if (useSnapshotPaging && !result.HasMore)
+        if (pagingStrategy is PagingStrategy.Snapshot && !result.HasMore)
         {
             // clear the scroll
             string? scrollId = result.GetScrollId();
@@ -484,6 +500,13 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
                 var response = await _client.ClearScrollAsync(s => s.ScrollId(scrollId)).AnyContext();
                 _logger.LogRequest(response, options.GetQueryLogLevel());
             }
+        }
+
+        if (pagingStrategy is PagingStrategy.SearchAfterPointInTime && options.SafeGetOption<bool>(SearchAfterQueryExtensions.RepoManagedPitKey, false))
+        {
+            result.Data[ElasticDataKeys.RepoManagedPit] = true;
+            if (!result.HasMore)
+                await ClosePointInTimeAsync(result).AnyContext();
         }
 
         if (allowCaching && !result.IsAsyncQueryRunning() && !result.IsAsyncQueryPartial())
@@ -528,7 +551,11 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             options.SearchAfterToken(previousResults.GetSearchAfterToken(), ElasticIndex.Configuration.Serializer);
 
         if (options.ShouldUseSearchAfterPagingPointInTime())
+        {
             options.PointInTimeId(previousResults.GetPointInTimeId());
+            if (previousResults.Data.TryGetValue(ElasticDataKeys.RepoManagedPit, out var managed) && managed is true)
+                options.Values.Set(SearchAfterQueryExtensions.RepoManagedPitKey, true);
+        }
 
         options.PageNumber(!options.HasPageNumber() ? 2 : options.GetPage() + 1);
         return await FindAsAsync<TResult>(query, options).AnyContext();
@@ -810,9 +837,6 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (String.IsNullOrEmpty(pointInTimeId))
             pointInTimeId = await OpenPointInTimeAsync(query, options).AnyContext();
 
-        if (String.IsNullOrEmpty(pointInTimeId))
-            return;
-
         search.Pit(new PointInTimeReference(pointInTimeId) { KeepAlive = options.GetSnapshotLifetime().ToElasticDuration() });
     }
 
@@ -829,6 +853,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
         if (!response.IsValidResponse)
             throw new DocumentException(response.GetErrorMessage("Error while opening point in time"), response.OriginalException());
 
+        options.Values.Set(SearchAfterQueryExtensions.RepoManagedPitKey, true);
         return response.Id;
     }
 
@@ -850,10 +875,10 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
 
     protected virtual async Task<SearchRequestDescriptor<T>> ConfigureSearchDescriptorAsync(SearchRequestDescriptor<T> search, IRepositoryQuery query, ICommandOptions options)
     {
-
         query = ConfigureQuery(query.As<T>()).Unwrap();
         string[] indices = ElasticIndex.GetIndexesByQuery(query);
-        if (indices?.Length > 0 && !options.ShouldUseSearchAfterPagingPointInTime())
+        bool usePit = options.ShouldUseSearchAfterPagingPointInTime();
+        if (indices?.Length > 0 && !usePit)
             search.Indices(String.Join(",", indices));
         if (HasVersion)
             search.SeqNoPrimaryTerm(HasVersion);
@@ -864,7 +889,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             search.Timeout(timeout.ToElasticDuration());
         }
 
-        if (!options.ShouldUseSearchAfterPagingPointInTime())
+        if (!usePit)
             search.IgnoreUnavailable();
         search.TrackTotalHits(new TrackHits(options.ShouldTrackTotalHits()));
 

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
@@ -988,15 +988,21 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
-    public async Task FindWithSearchAfterPagingWithoutTrackTotalHitsAsync()
+    public async Task FindAsync_WithSearchAfterPagingAndTrackTotalHitsDisabled_DoesNotReturnExactTotal()
     {
+        // Arrange
         var employee1 = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Charlie"), o => o.ImmediateConsistency());
-        Assert.NotNull(employee1?.Id);
+        Assert.NotNull(employee1);
+        Assert.NotNull(employee1.Id);
 
         var employee2 = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Blake"), o => o.ImmediateConsistency());
-        Assert.NotNull(employee2?.Id);
+        Assert.NotNull(employee2);
+        Assert.NotNull(employee2.Id);
 
+        // Act
         var results = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(1).SearchAfterPaging().TrackTotalHits(false));
+
+        // Assert
         Assert.NotNull(results);
         Assert.Single(results.Documents);
         Assert.Equal(employee1.Id, results.Documents.First().Id);
@@ -1015,18 +1021,24 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
-    public async Task FindWithPointInTimeSearchAfterPagingAsync()
+    public async Task FindAsync_WithPointInTimePaging_KeepsConsistentSnapshotAcrossPages()
     {
+        // Arrange
         var employee1 = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Charlie"), o => o.ImmediateConsistency());
-        Assert.NotNull(employee1?.Id);
+        Assert.NotNull(employee1);
+        Assert.NotNull(employee1.Id);
 
         var employee2 = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Blake"), o => o.ImmediateConsistency());
-        Assert.NotNull(employee2?.Id);
+        Assert.NotNull(employee2);
+        Assert.NotNull(employee2.Id);
 
         await _client.ClearScrollAsync(cancellationToken: TestCancellationToken);
         long baselineScrollCount = await GetCurrentScrollCountAsync();
 
+        // Act
         var results = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(1).SearchAfterPaging(SearchAfterPagingMode.PointInTime));
+
+        // Assert
         Assert.NotNull(results);
         Assert.Single(results.Documents);
         Assert.Equal(employee1.Id, results.Documents.First().Id);
@@ -1036,7 +1048,8 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Equal(baselineScrollCount, await GetCurrentScrollCountAsync());
 
         var employee3 = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Aaron"), o => o.ImmediateConsistency());
-        Assert.NotNull(employee3?.Id);
+        Assert.NotNull(employee3);
+        Assert.NotNull(employee3.Id);
 
         Assert.True(await results.NextPageAsync());
         Assert.Single(results.Documents);
@@ -1050,8 +1063,9 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
-    public async Task CanUsePointInTimeSearchAfterPagingLikeWebCursorAsync()
+    public async Task FindAsync_WithPointInTimePaging_SupportsBidirectionalWebCursorNavigation()
     {
+        // Arrange
         var employees = new[] {
             await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Echo"), o => o.ImmediateConsistency()),
             await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Delta"), o => o.ImmediateConsistency()),
@@ -1063,10 +1077,12 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
 
         await _client.ClearScrollAsync(cancellationToken: TestCancellationToken);
         long baselineScrollCount = await GetCurrentScrollCountAsync();
+        var pit = (ISupportPointInTime)_employeeRepository;
         string? pointInTimeId = null;
 
         try
         {
+            // Act + Assert — navigate forward through pages
             var firstPage = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(2).SearchAfterPaging(SearchAfterPagingMode.PointInTime));
             pointInTimeId = firstPage.GetPointInTimeId();
 
@@ -1079,7 +1095,8 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
             Assert.Equal(baselineScrollCount, await GetCurrentScrollCountAsync());
 
             var newEmployee = await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Foxtrot"), o => o.ImmediateConsistency());
-            Assert.NotNull(newEmployee?.Id);
+            Assert.NotNull(newEmployee);
+            Assert.NotNull(newEmployee.Id);
 
             var secondPage = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(2).SearchAfterPaging(SearchAfterPagingMode.PointInTime).PointInTimeId(pointInTimeId).SearchAfterToken(firstPage.GetSearchAfterToken(), _serializer).TrackTotalHits(false));
             pointInTimeId = secondPage.GetPointInTimeId();
@@ -1103,6 +1120,8 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
             Assert.DoesNotContain(thirdPage.Documents, e => e.Id == newEmployee.Id);
             Assert.Equal(baselineScrollCount, await GetCurrentScrollCountAsync());
 
+            // The caller supplied the PIT id, so the repo does NOT auto-close it even after the last page —
+            // this is the explicit counter-case for auto-close scoping.
             var backToSecondPage = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(2).SearchAfterPaging(SearchAfterPagingMode.PointInTime).PointInTimeId(pointInTimeId).SearchBeforeToken(thirdPage.GetSearchBeforeToken(), _serializer).TrackTotalHits(false));
             pointInTimeId = backToSecondPage.GetPointInTimeId();
 
@@ -1123,14 +1142,39 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
             Assert.False(String.IsNullOrEmpty(backToFirstPage.GetSearchAfterToken()));
             Assert.Equal(baselineScrollCount, await GetCurrentScrollCountAsync());
 
-            Assert.True(await ((EmployeeRepository)_employeeRepository).ClosePointInTimeAsync(pointInTimeId));
+            Assert.True(await pit.ClosePointInTimeAsync(pointInTimeId));
             pointInTimeId = null;
         }
         finally
         {
             if (!String.IsNullOrEmpty(pointInTimeId))
-                await ((EmployeeRepository)_employeeRepository).ClosePointInTimeAsync(pointInTimeId);
+                await pit.ClosePointInTimeAsync(pointInTimeId);
         }
+    }
+
+    [Fact]
+    public async Task FindAsync_WithPointInTimePagingPagedToCompletion_ClosesPointInTime()
+    {
+        // Arrange
+        await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Charlie"), o => o.ImmediateConsistency());
+        await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Blake"), o => o.ImmediateConsistency());
+        await _employeeRepository.AddAsync(EmployeeGenerator.Generate(name: "Aaron"), o => o.ImmediateConsistency());
+
+        await _client.ClearScrollAsync(cancellationToken: TestCancellationToken);
+        long baselineScrollCount = await GetCurrentScrollCountAsync();
+
+        // Act
+        var results = await _employeeRepository.FindAsync(q => q.SortDescending(d => d.Name), o => o.PageLimit(1).SearchAfterPaging(SearchAfterPagingMode.PointInTime));
+        while (await results.NextPageAsync())
+        {
+        }
+
+        // Assert — PIT is closed by the repo without any manual ClosePointInTimeAsync call
+        Assert.False(results.HasMore);
+        string? finalPitId = results.GetPointInTimeId();
+        Assert.Equal(baselineScrollCount, await GetCurrentScrollCountAsync());
+        if (!String.IsNullOrEmpty(finalPitId))
+            Assert.False(await ((ISupportPointInTime)_employeeRepository).ClosePointInTimeAsync(finalPitId));
     }
 
     [Fact]

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReindexTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReindexTests.cs
@@ -10,7 +10,6 @@ using Foundatio.Lock;
 using Foundatio.Parsers.ElasticQueries.Extensions;
 using Foundatio.Repositories.Elasticsearch.Configuration;
 using Foundatio.Repositories.Elasticsearch.Extensions;
-using Foundatio.Repositories.Elasticsearch.Jobs;
 using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Configuration.Indexes;
 using Foundatio.Repositories.Elasticsearch.Tests.Repositories.Models;
 using Foundatio.Repositories.Utility;

--- a/tests/Foundatio.Repositories.Tests/Serialization/Models/EntityChangedSerializationTests.cs
+++ b/tests/Foundatio.Repositories.Tests/Serialization/Models/EntityChangedSerializationTests.cs
@@ -5,7 +5,6 @@ using Foundatio.Messaging;
 using Foundatio.Repositories.Models;
 using Foundatio.Serializer;
 using Foundatio.Tests.Extensions;
-using Foundatio.Utility;
 using Xunit;
 
 namespace Foundatio.Repositories.Tests.Serialization.Models;


### PR DESCRIPTION
## Summary

Follow-up to #288. This PR cleans up the PIT search-after implementation with several improvements:

### 1. Single mode model (replaces two-bool encoding)
Replace \@SearchAfterPaging\ + \@SearchAfterPagingPointInTime\ (two separate booleans) with a single \@SearchAfterPagingMode\ value (\SearchAfterPagingMode.Live\ or \PointInTime\). \ShouldUseSearchAfterPagingPointInTime\ now derives from the mode via \is SearchAfterPagingMode.PointInTime\ pattern matching. Also fixes a subtle bug: the no-arg \SearchAfterPaging(bool)\ overload was delegating to the mode overload with \Live\ as default, which silently reset the mode back to \Live\ every time \SearchAfterToken\/\SearchBeforeToken\ helpers were called on continuation pages, breaking PIT paging entirely. The no-arg overload now only sets the gate key.

### 2. PagingStrategy enum (removes == false bot comments)
Introduce a private \PagingStrategy\ enum (\Normal\ / \Snapshot\ / \SearchAfterPointInTime\) and a \GetPagingStrategy\ helper. The \llowCaching\ line now reads \pagingStrategy is PagingStrategy.Normal\ — resolving the \== false\ pattern matching comments from the bot review.

### 3. PIT auto-close (repo-owned vs caller-owned)
Add a \@RepoManagedPit\ flag (stored in both options and result data) that tracks whether the repo opened the PIT automatically. On the final page (\HasMore == false\), the repo auto-closes its own PIT without any caller involvement. Caller-supplied PIT ids (e.g. web cursor pattern) are never auto-closed. The flag is propagated through \GetNextPageFunc\ so the auto-close fires correctly in \NextPageAsync\ loops.

### 4. ISupportPointInTime interface
New \ISupportPointInTime\ interface (\ClosePointInTimeAsync(string?)\ and \ClosePointInTimeAsync(IHaveData?)\) added to the Elasticsearch project. \ElasticReadOnlyRepositoryBase\ implements it explicitly. Tests now cast to \ISupportPointInTime\ instead of the concrete \EmployeeRepository\.

Note: \HasPointInTimeId\ in \SearchAfterQueryBuilder.cs\ is kept as-is — it is public library API (the PIT peer of \HasSearchAfter\/\HasSearchBefore\/\HasSnapshotScrollId\) needed for the auto-close gate. \ClosePointInTimeAsync\ is on \ISupportPointInTime\ (ES-specific) not the core \ISearchableReadOnlyRepository\ interface.

### 5. ConfigurePointInTimeAsync owns all PIT shaping
\ConfigureSearchDescriptorAsync\ retains its \ShouldUseSearchAfterPagingPointInTime\ guards to skip index routing and \IgnoreUnavailable\ for PIT requests — this is an Elasticsearch requirement. \ConfigurePointInTimeAsync\ sets the \Pit\ reference on the descriptor after the shared configuration runs.

### 6. Style fixes
- Allman brace style on \GetPointInTimeId\ in FindResultsExtensions.cs
- Removed stray blank line at opening of \ConfigureSearchDescriptorAsync\
- Added \ElasticDataKeys.RepoManagedPit\ constant

### 7. Test cleanup
- Renamed 3 tests to 3-part \Method_State_Behavior\ convention
- Added AAA section markers
- Fixed \Assert.NotNull(x?.Id)\ → separate \Assert.NotNull(x)\ + \Assert.NotNull(x.Id)\
- Replaced \(EmployeeRepository)\ casts with \(ISupportPointInTime)\
- Added comment in bidirectional navigation test explaining why the PIT is not auto-closed (caller owns it)
- Added new test \FindAsync_WithPointInTimePagingPagedToCompletion_ClosesPointInTime\ proving auto-close fires after a full \NextPageAsync\ loop without any manual call

All 645 Elasticsearch integration tests pass.