### PR TITLE
fix: correct existing-analysis read on in-place index upgrades (+ upgrade test coverage)

### DIFF
--- a/.agents/skills/foundatio-repositories/references/index-lifecycle.md
+++ b/.agents/skills/foundatio-repositories/references/index-lifecycle.md
@@ -365,6 +365,31 @@ public override void ConfigureIndex(CreateIndexRequestDescriptor idx)
 }
 ```
 
+### In-Place Analysis Upgrades (analyzers/tokenizers/filters)
+
+When a `VersionedIndex` already exists and `ConfigureAsync` runs again, dynamic settings (including the
+`Analysis` block: analyzers, tokenizers, token filters, normalizers, char filters) are applied in place via
+`PutSettings(.Reopen())` rather than requiring a new index version. The reopen briefly closes and reopens the
+index so newly added analysis components take effect; existing documents are not reindexed, so the new
+component only applies to writes/queries after the upgrade.
+
+Before applying, `UpdateIndexAsync` diffs the desired analysis components against the live index and logs a
+`requires close/reopen` warning for each genuinely new component.
+
+**Analysis settings location — `Settings.Index.Analysis` vs root `Settings.Analysis`:** these are two
+different shapes of the same data:
+
+- **Read path (`GetSettingsAsync`)** returns analysis nested under the `index` key, i.e.
+  `response.Settings[name].Settings.Index.Analysis`. This is the canonical location for the *current* live
+  state and is what the diff reads. The root `Settings.Analysis` is **not** populated on reads.
+- **Write path (create/update request)** uses the root `Settings.Analysis` shape (what your
+  `ConfigureIndex(...).Analysis(...)` builds). This is the *desired* state sent to Elasticsearch.
+
+So the in-place diff compares desired root `Settings.Analysis` (from `ConfigureIndex`) against current
+`Settings.Index.Analysis` (from `GetSettingsAsync`). Reading the current set from the root `Settings.Analysis`
+returns nothing, which makes every existing component look new and falsely warns on every upgrade — always
+read current analysis from `Settings.Index.Analysis`.
+
 ### Query Field Restrictions
 
 ```csharp

--- a/docs/guide/index-management.md
+++ b/docs/guide/index-management.md
@@ -622,6 +622,23 @@ Elasticsearch itself has no mapping cache you need to invalidate — once a PUT 
 - **For queries**: The `ElasticMappingResolver` auto-refreshes. If you need it sooner, call `RefreshMapping()`.
 - **For writes**: The `_isEnsured` / `_ensuredDates` flags only control whether `ConfigureAsync` runs again. They don't prevent writes to the index — they just skip redundant index creation/mapping calls. Manual PUT Mapping changes are orthogonal to these flags.
 
+### In-Place Analysis Updates (analyzers, tokenizers, filters)
+
+For `Index<T>` and `VersionedIndex<T>`, adding new analysis components (analyzers, tokenizers, token filters, normalizers, char filters) to an existing index does **not** require a new index version. When `ConfigureIndexesAsync` re-runs against an existing index, the dynamic settings — including the `Analysis` block — are applied in place via a `PutSettings` call with `Reopen()`. The reopen briefly closes and reopens the index so the new components become active.
+
+This is unlike changing an existing **field mapping** type (which does require a new version on a `VersionedIndex`). Existing documents are not reindexed by an in-place analysis update, so a newly added analyzer only affects documents indexed (and queries run) after the upgrade.
+
+Before applying, the library diffs the desired analysis components against the live index and logs a `requires close/reopen` warning for each genuinely **new** component (see the table below). Components that already exist are not re-warned.
+
+::: info Where Elasticsearch stores analysis settings: `Settings.Index.Analysis` vs root `Settings.Analysis`
+Elasticsearch exposes index analysis settings in two different shapes depending on direction:
+
+- **Reading** via the Get Settings API returns analysis nested under the `index` key — `Settings.Index.Analysis`. This is the canonical location for the **current** live state of an index. The root `Settings.Analysis` is **not** populated on reads.
+- **Writing** via a create/update request uses the root `Settings.Analysis` shape — the same shape your `ConfigureIndex(...).Analysis(...)` builder produces for the **desired** state.
+
+The in-place upgrade therefore compares the desired root `Settings.Analysis` (from `ConfigureIndex`) against the current `Settings.Index.Analysis` (from the Get Settings response). Reading the current set from the root `Settings.Analysis` would always return nothing, making every existing component look new and falsely warning on every upgrade.
+:::
+
 ### Failure Log Messages
 
 When mapping or settings updates fail, the following log messages are emitted:

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
@@ -6,7 +6,6 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
-using Elastic.Clients.Elasticsearch.Analysis;
 using Elastic.Clients.Elasticsearch.Fluent;
 using Elastic.Clients.Elasticsearch.IndexManagement;
 using Elastic.Clients.Elasticsearch.Mapping;
@@ -238,11 +237,7 @@ public class Index : IIndex
         }
 
         var indexState = currentSettings.Settings.TryGetValue(name, out var indexSettings) ? indexSettings : null;
-        var currentAnalyzers = indexState?.Settings?.Analysis?.Analyzers ?? new Analyzers();
-        var currentTokenizers = indexState?.Settings?.Analysis?.Tokenizers ?? new Tokenizers();
-        var currentTokenFilters = indexState?.Settings?.Analysis?.TokenFilters ?? new TokenFilters();
-        var currentNormalizers = indexState?.Settings?.Analysis?.Normalizers ?? new Normalizers();
-        var currentCharFilters = indexState?.Settings?.Analysis?.CharFilters ?? new CharFilters();
+        var currentAnalysis = indexState?.Settings?.Index?.Analysis;
 
         // default to update dynamic index settings from the ConfigureIndex method
         var createIndexRequestDescriptor = new CreateIndexRequestDescriptor((IndexName)name);
@@ -260,55 +255,11 @@ public class Index : IIndex
         settings.Sort = null;
         settings.SoftDeletes = null;
 
-        if (settings.Analysis?.Analyzers is not null && currentAnalyzers is not null)
-        {
-            var currentKeys = currentAnalyzers.Select(kvp => kvp.Key).ToHashSet();
-            foreach (var analyzer in settings.Analysis.Analyzers.ToList())
-            {
-                if (!currentKeys.Contains(analyzer.Key))
-                    _logger.LogWarning("Adding new analyzer {AnalyzerKey} to existing index (requires close/reopen)", analyzer.Key);
-            }
-        }
-
-        if (settings.Analysis?.Tokenizers is not null && currentTokenizers is not null)
-        {
-            var currentKeys = currentTokenizers.Select(kvp => kvp.Key).ToHashSet();
-            foreach (var tokenizer in settings.Analysis.Tokenizers.ToList())
-            {
-                if (!currentKeys.Contains(tokenizer.Key))
-                    _logger.LogWarning("Adding new tokenizer {TokenizerKey} to existing index (requires close/reopen)", tokenizer.Key);
-            }
-        }
-
-        if (settings.Analysis?.TokenFilters is not null && currentTokenFilters is not null)
-        {
-            var currentKeys = currentTokenFilters.Select(kvp => kvp.Key).ToHashSet();
-            foreach (var tokenFilter in settings.Analysis.TokenFilters.ToList())
-            {
-                if (!currentKeys.Contains(tokenFilter.Key))
-                    _logger.LogWarning("Adding new token filter {TokenFilterKey} to existing index (requires close/reopen)", tokenFilter.Key);
-            }
-        }
-
-        if (settings.Analysis?.Normalizers is not null && currentNormalizers is not null)
-        {
-            var currentKeys = currentNormalizers.Select(kvp => kvp.Key).ToHashSet();
-            foreach (var normalizer in settings.Analysis.Normalizers.ToList())
-            {
-                if (!currentKeys.Contains(normalizer.Key))
-                    _logger.LogWarning("Adding new normalizer {NormalizerKey} to existing index (requires close/reopen)", normalizer.Key);
-            }
-        }
-
-        if (settings.Analysis?.CharFilters is not null && currentCharFilters is not null)
-        {
-            var currentKeys = currentCharFilters.Select(kvp => kvp.Key).ToHashSet();
-            foreach (var charFilter in settings.Analysis.CharFilters.ToList())
-            {
-                if (!currentKeys.Contains(charFilter.Key))
-                    _logger.LogWarning("Adding new char filter {CharFilterKey} to existing index (requires close/reopen)", charFilter.Key);
-            }
-        }
+        WarnOnNewAnalysisComponents(settings.Analysis?.Analyzers?.Select(kvp => kvp.Key), currentAnalysis?.Analyzers?.Select(kvp => kvp.Key), "analyzer");
+        WarnOnNewAnalysisComponents(settings.Analysis?.Tokenizers?.Select(kvp => kvp.Key), currentAnalysis?.Tokenizers?.Select(kvp => kvp.Key), "tokenizer");
+        WarnOnNewAnalysisComponents(settings.Analysis?.TokenFilters?.Select(kvp => kvp.Key), currentAnalysis?.TokenFilters?.Select(kvp => kvp.Key), "token filter");
+        WarnOnNewAnalysisComponents(settings.Analysis?.Normalizers?.Select(kvp => kvp.Key), currentAnalysis?.Normalizers?.Select(kvp => kvp.Key), "normalizer");
+        WarnOnNewAnalysisComponents(settings.Analysis?.CharFilters?.Select(kvp => kvp.Key), currentAnalysis?.CharFilters?.Select(kvp => kvp.Key), "char filter");
 
         var updateResponse = await Configuration.Client.Indices.PutSettingsAsync(name, d => d.Reopen().Settings(settings)).AnyContext();
 
@@ -316,6 +267,19 @@ public class Index : IIndex
             _logger.LogRequest(updateResponse);
         else
             _logger.LogErrorRequest(updateResponse, $"Error updating index ({name}) settings");
+    }
+
+    private void WarnOnNewAnalysisComponents(IEnumerable<string>? desiredKeys, IEnumerable<string>? currentKeys, string componentType)
+    {
+        if (desiredKeys is null)
+            return;
+
+        var existing = currentKeys?.ToHashSet() ?? new HashSet<string>();
+        foreach (string key in desiredKeys)
+        {
+            if (!existing.Contains(key))
+                _logger.LogWarning("Adding new {ComponentType} {ComponentKey} to existing index (requires close/reopen)", componentType, key);
+        }
     }
 
     protected virtual Task DeleteIndexAsync(string name)

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
@@ -279,11 +279,8 @@ public class Index : IIndex
             return;
 
         var existing = currentKeys?.ToHashSet() ?? new HashSet<string>();
-        foreach (string key in desiredKeys)
-        {
-            if (!existing.Contains(key))
-                _logger.LogWarning("Adding new {ComponentType} {ComponentKey} to existing index (requires close/reopen)", componentType, key);
-        }
+        foreach (string key in desiredKeys.Where(key => !existing.Contains(key)))
+            _logger.LogWarning("Adding new {ComponentType} {ComponentKey} to existing index (requires close/reopen)", componentType, key);
     }
 
     protected virtual Task DeleteIndexAsync(string name)

--- a/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Configuration/Index.cs
@@ -237,6 +237,10 @@ public class Index : IIndex
         }
 
         var indexState = currentSettings.Settings.TryGetValue(name, out var indexSettings) ? indexSettings : null;
+
+        // GetSettingsAsync nests analysis settings under the "index" key (Settings.Index.Analysis); the root
+        // Settings.Analysis is the write-time shape used in create requests and is not populated on reads. Read
+        // from Settings.Index.Analysis so the diff below sees the components that already exist on the live index.
         var currentAnalysis = indexState?.Settings?.Index?.Analysis;
 
         // default to update dynamic index settings from the ConfigureIndex method

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/IndexTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/IndexTests.cs
@@ -662,8 +662,8 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         Assert.NotNull(settings.Settings);
         var analyzers = settings.Settings[index.VersionedName].Settings?.Index?.Analysis?.Analyzers;
         Assert.NotNull(analyzers);
-        Assert.NotNull(analyzers["custom1"]);
-        Assert.NotNull(analyzers["custom2"]);
+        Assert.Contains("custom1", analyzers.Select(a => a.Key));
+        Assert.Contains("custom2", analyzers.Select(a => a.Key));
 
         var fieldMapping = await _client.Indices.GetFieldMappingAsync<Employee>(new Field("upgradedField"), d => d.Indices(index.VersionedName), cancellationToken: TestCancellationToken);
         Assert.True(fieldMapping.IsValidResponse);
@@ -703,10 +703,11 @@ public sealed class IndexTests : ElasticRepositoryTestBase
         }
 
         Assert.NotNull(analyzeResponse);
-        _logger.LogRequest(analyzeResponse);
-        Assert.True(analyzeResponse.IsValidResponse, analyzeResponse.DebugInformation);
-        Assert.NotNull(analyzeResponse.Tokens);
-        var tokens = analyzeResponse.Tokens.Select(t => t.Token).ToList();
+        var response = analyzeResponse;
+        _logger.LogRequest(response);
+        Assert.True(response.IsValidResponse, response.DebugInformation);
+        Assert.NotNull(response.Tokens);
+        var tokens = response.Tokens.Select(t => t.Token).ToList();
         Assert.Equal(new[] { "foo", "bar", "baz" }, tokens);
     }
 

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/IndexTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/IndexTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.IndexManagement;
 using Elastic.Clients.Elasticsearch.Mapping;
 using Exceptionless.DateTimeExtensions;
 using Foundatio.Repositories.Elasticsearch.Configuration;
@@ -22,6 +23,12 @@ namespace Foundatio.Repositories.Elasticsearch.Tests;
 
 public sealed class IndexTests : ElasticRepositoryTestBase
 {
+    // Each in-place upgrade test uses a distinct version so its "employees-vN" index name is unique and
+    // cannot collide with the other upgrade tests or with the v1/v2 indexes used elsewhere in this class.
+    private const int AddAnalyzerWarningVersion = 5;
+    private const int UpgradeInPlaceVersion = 6;
+    private const int NewAnalyzerUsableVersion = 7;
+
     public IndexTests(ITestOutputHelper output) : base(output)
     {
         Log.SetLogLevel<EmployeeRepository>(LogLevel.Trace);
@@ -614,6 +621,93 @@ public sealed class IndexTests : ElasticRepositoryTestBase
 
         await index2.ConfigureAsync();
         Assert.Contains(Log.LogEntries, l => l.LogLevel == LogLevel.Error && l.Message.Contains("requires a new index version"));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_WhenAddingNewAnalyzerToExistingIndex_LogsCloseReopenWarning()
+    {
+        // Arrange
+        var index = new UpgradeableEmployeeIndex(_configuration, AddAnalyzerWarningVersion);
+        await index.DeleteAsync();
+        await using AsyncDisposableAction _ = new(() => index.DeleteAsync());
+        await index.ConfigureAsync();
+        Log.Reset();
+
+        // Act
+        var upgradedIndex = new UpgradedEmployeeIndex(_configuration, AddAnalyzerWarningVersion);
+        await upgradedIndex.ConfigureAsync();
+
+        // Assert
+        Assert.Contains(Log.LogEntries, l => l.LogLevel == LogLevel.Warning && l.Message.Contains("Adding new analyzer") && l.Message.Contains("custom2"));
+        Assert.Contains(Log.LogEntries, l => l.LogLevel == LogLevel.Warning && l.Message.Contains("Adding new tokenizer") && l.Message.Contains("comma_whitespace"));
+        Assert.DoesNotContain(Log.LogEntries, l => l.LogLevel == LogLevel.Warning && l.Message.Contains("Adding new analyzer") && l.Message.Contains("custom1"));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_WhenUpgradingInPlaceMultipleTimes_RetainsAllAnalyzersAndMappings()
+    {
+        // Arrange
+        var index = new UpgradeableEmployeeIndex(_configuration, UpgradeInPlaceVersion);
+        await index.DeleteAsync();
+        await using AsyncDisposableAction _ = new(() => index.DeleteAsync());
+        await index.ConfigureAsync();
+
+        // Act
+        var upgradedIndex = new UpgradedEmployeeIndex(_configuration, UpgradeInPlaceVersion);
+        await upgradedIndex.ConfigureAsync();
+        await index.ConfigureAsync();
+
+        // Assert
+        var settings = await _client.Indices.GetSettingsAsync((Indices)index.VersionedName, cancellationToken: TestCancellationToken);
+        Assert.NotNull(settings.Settings);
+        var analyzers = settings.Settings[index.VersionedName].Settings?.Index?.Analysis?.Analyzers;
+        Assert.NotNull(analyzers);
+        Assert.NotNull(analyzers["custom1"]);
+        Assert.NotNull(analyzers["custom2"]);
+
+        var fieldMapping = await _client.Indices.GetFieldMappingAsync<Employee>(new Field("upgradedField"), d => d.Indices(index.VersionedName), cancellationToken: TestCancellationToken);
+        Assert.True(fieldMapping.IsValidResponse);
+        Assert.True(fieldMapping.FieldMappings.TryGetValue(index.VersionedName, out var indexMapping));
+        Assert.True(indexMapping.Mappings.ContainsKey("upgradedField"));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_AfterAddingAnalyzerToExistingIndex_NewAnalyzerIsUsable()
+    {
+        // Arrange
+        var index = new UpgradeableEmployeeIndex(_configuration, NewAnalyzerUsableVersion);
+        await index.DeleteAsync();
+        await using AsyncDisposableAction _ = new(() => index.DeleteAsync());
+        await index.ConfigureAsync();
+
+        // Act
+        var upgradedIndex = new UpgradedEmployeeIndex(_configuration, NewAnalyzerUsableVersion);
+        await upgradedIndex.ConfigureAsync();
+
+        // Assert
+        var settings = await _client.Indices.GetSettingsAsync((Indices)index.VersionedName, cancellationToken: TestCancellationToken);
+        Assert.NotNull(settings.Settings[index.VersionedName].Settings?.Index?.Analysis?.Analyzers?["custom2"]);
+
+        // The new analyzer is applied via PutSettings(.Reopen()); refresh first, then allow a brief window for it to propagate to all shards.
+        await _client.Indices.RefreshAsync((Indices)index.VersionedName, cancellationToken: TestCancellationToken);
+        AnalyzeIndexResponse? analyzeResponse = null;
+        for (int attempt = 0; attempt < 5; attempt++)
+        {
+            analyzeResponse = await _client.Indices.AnalyzeAsync((IndexName)index.VersionedName, a => a
+                .Analyzer("custom2")
+                .Text("Foo,Bar Baz"), TestCancellationToken);
+            if (analyzeResponse.IsValidResponse)
+                break;
+
+            await Task.Delay(250, TestCancellationToken);
+        }
+
+        Assert.NotNull(analyzeResponse);
+        _logger.LogRequest(analyzeResponse);
+        Assert.True(analyzeResponse.IsValidResponse, analyzeResponse.DebugInformation);
+        Assert.NotNull(analyzeResponse.Tokens);
+        var tokens = analyzeResponse.Tokens.Select(t => t.Token).ToList();
+        Assert.Equal(new[] { "foo", "bar", "baz" }, tokens);
     }
 
     [Fact]

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/EmployeeIndex.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/Repositories/Configuration/Indexes/EmployeeIndex.cs
@@ -132,6 +132,46 @@ public sealed class EmployeeIndexWithYearsEmployed : Index<Employee>
     }
 }
 
+public class UpgradeableEmployeeIndex : VersionedIndex<Employee>
+{
+    public UpgradeableEmployeeIndex(IElasticConfiguration configuration, int version = 1)
+        : base(configuration, "employees", version) { }
+
+    public override void ConfigureIndex(CreateIndexRequestDescriptor idx)
+    {
+        base.ConfigureIndex(idx.Settings(s => s
+            .NumberOfReplicas(0)
+            .NumberOfShards(1)
+            .Analysis(a => a
+                .Analyzers(an => an.Custom("custom1", c => c.Filter("uppercase").Tokenizer("whitespace"))))));
+    }
+}
+
+public sealed class UpgradedEmployeeIndex : UpgradeableEmployeeIndex
+{
+    public UpgradedEmployeeIndex(IElasticConfiguration configuration, int version = 1)
+        : base(configuration, version) { }
+
+    public override void ConfigureIndex(CreateIndexRequestDescriptor idx)
+    {
+        base.ConfigureIndex(idx);
+        // The second .Settings(...).Analyzers(...) call replaces the analyzers block from the base
+        // configuration rather than merging, so custom1 must be re-declared here for both analyzers to survive.
+        idx.Settings(s => s
+            .Analysis(a => a
+                .Tokenizers(t => t.CharGroup("comma_whitespace", cg => cg.TokenizeOnChars(",", "whitespace")))
+                .Analyzers(an => an
+                    .Custom("custom1", c => c.Filter("uppercase").Tokenizer("whitespace"))
+                    .Custom("custom2", c => c.Filter("lowercase").Tokenizer("comma_whitespace")))));
+    }
+
+    public override void ConfigureIndexMapping(TypeMappingDescriptor<Employee> map)
+    {
+        base.ConfigureIndexMapping(map);
+        map.Properties(p => p.Text("upgradedField", t => t.Analyzer("custom2")));
+    }
+}
+
 public sealed class VersionedEmployeeIndex : VersionedIndex<Employee>
 {
     private readonly Action<CreateIndexRequestDescriptor>? _createIndex;


### PR DESCRIPTION
## Summary

Fixes a bug in `Index.UpdateIndexAsync` (in-place index upgrade path) and adds integration coverage proving repeated in-place upgrades work correctly.

### Bug: existing analysis components always looked "new"

When upgrading an existing index in place, `UpdateIndexAsync` diffs the desired analysis components against the live index and logs a `requires close/reopen` warning for each genuinely new analyzer/tokenizer/filter/normalizer/char-filter. It read the current set from `Settings.Analysis`, but `GetSettingsAsync` returns analysis nested under `Settings.Index.Analysis` — so the current set was always empty and **every** existing component falsely warned on **every** update.

Fix: read the canonical `Settings.Index.Analysis` location (the same location the existing `CanChangeIndexSettings` test and the new tests assert against).

### Cleanup: one diff helper instead of five copy-pasted blocks

The five structurally identical diff blocks (one per analysis component type) are exactly where this bug hid — a single wrong source fed all five copies. Collapsed them into one `WarnOnNewAnalysisComponents(desiredKeys, currentKeys, componentType)` helper so there's a single source of truth for the comparison, and dropped the now-unused empty-collection allocations.

### Test coverage

Added typed test index configs (`UpgradeableEmployeeIndex` / `UpgradedEmployeeIndex`) so the in-place upgrade is expressed in C# (compile-time checked) rather than hand-posted mappings, plus three integration tests following the `Method_State_Behavior` + AAA conventions:

- `ConfigureAsync_WhenAddingNewAnalyzerToExistingIndex_LogsCloseReopenWarning` — warning fires for the newly added `custom2` analyzer and `comma_whitespace` tokenizer, and **not** for the pre-existing `custom1` (this would have failed before the fix).
- `ConfigureAsync_WhenUpgradingInPlaceMultipleTimes_RetainsAllAnalyzersAndMappings` — repeated upgrades keep all analyzers and the added `upgradedField` mapping.
- `ConfigureAsync_AfterAddingAnalyzerToExistingIndex_NewAnalyzerIsUsable` — the newly added analyzer is functionally usable via the `_analyze` API (refresh + bounded retry to absorb post-reopen propagation).

## Test plan

- [x] `dotnet build` (src + ES tests) — 0 warnings, 0 errors
- [x] All three new tests pass against a local Elasticsearch
- [x] `dotnet format --verify-no-changes` clean on changed files
