### PR TITLE
fix: retry ElasticRepository RemoveAllAsync on delete-by-query versio…

### DIFF
--- a/.agents/skills/foundatio-repositories/references/patterns.md
+++ b/.agents/skills/foundatio-repositories/references/patterns.md
@@ -238,6 +238,8 @@ var employees = await repository.GetByIdsAsync(ids, o => o.Cache());
 bool exists = await repository.ExistsAsync(id);
 ```
 
+**Gotcha:** When caching is disabled and no event listeners are registered, `RemoveAllAsync` uses Elasticsearch `delete_by_query`, which counts (and skips) version conflicts when concurrent writes modify matching documents. Since `delete_by_query` has no `retry_on_conflict`, the repository re-runs the query up to `o.Retry(n)` times (default 10) until conflicts clear. The returned count is the cumulative number deleted across attempts; if conflicts persist after the retry budget, a warning is logged and the partial count is returned (no exception).
+
 ## Command Options
 
 | Option                          | Purpose                                      |

--- a/docs/guide/crud-operations.md
+++ b/docs/guide/crud-operations.md
@@ -204,6 +204,12 @@ long deleted = await repository.RemoveAllAsync(
     q => q.FieldEquals(e => e.Department, "Sales"));
 ```
 
+::: tip Version Conflicts and Retries
+When no event listeners are registered and caching is disabled, `RemoveAllAsync` uses Elasticsearch's `delete_by_query`. This API snapshots document versions when it begins and skips any document modified before the delete executes, counting it as a version conflict. Because `delete_by_query` does not support `retry_on_conflict`, the repository automatically re-runs the query up to the configured retry count (default `10`, override with `o.Retry(n)`) until no conflicts remain.
+
+The returned count is the cumulative number of documents deleted across all attempts. If conflicts persist after the retry budget is exhausted, a warning is logged and the partial count is returned; no exception is thrown.
+:::
+
 ### Soft Delete vs Hard Delete
 
 If your entity implements `ISupportSoftDeletes`:

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -1327,20 +1327,39 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             }, options).AnyContext();
         }
 
-        var response = await _client.DeleteByQueryAsync(new DeleteByQueryRequest(ElasticIndex.Name)
-        {
-            Refresh = options.GetRefreshMode(DefaultConsistency) != Refresh.False,
-            Conflicts = Conflicts.Proceed,
-            Query = await ElasticIndex.QueryBuilder.BuildQueryAsync(query, options, new SearchRequestDescriptor<T>()).AnyContext()
-        }).AnyContext();
-        _logger.LogRequest(response, options.GetQueryLogLevel());
+        // Elasticsearch's delete-by-query snapshots document versions when it begins and skips any document
+        // whose version changed before the delete executes (counted as a version conflict via Conflicts.Proceed).
+        // Unlike single-document updates, delete-by-query does not support retry_on_conflict, so we re-run the
+        // query at the application level until no conflicts remain or the retry budget is exhausted.
+        var esQuery = await ElasticIndex.QueryBuilder.BuildQueryAsync(query, options, new SearchRequestDescriptor<T>()).AnyContext();
+        var indices = Indices.Index(String.Join(",", ElasticIndex.GetIndexesByQuery(query)));
+        int maxAttempts = options.GetRetryCount();
+        int attempt = 0;
+        long totalDeleted = 0;
+        long lastConflicts;
 
-        if (!response.IsValidResponse)
+        do
         {
-            throw new DocumentException(response.GetErrorMessage("Error removing documents"), response.OriginalException());
+            attempt++;
+            var response = await _client.DeleteByQueryAsync(new DeleteByQueryRequest(indices)
+            {
+                // Force a refresh on retry passes so the next snapshot observes the resolved versions and converges.
+                Refresh = attempt > 1 || options.GetRefreshMode(DefaultConsistency) != Refresh.False,
+                Conflicts = Conflicts.Proceed,
+                IgnoreUnavailable = true,
+                Query = esQuery
+            }, DisposedCancellationToken).AnyContext();
+            _logger.LogRequest(response, options.GetQueryLogLevel());
+
+            if (!response.IsValidResponse)
+                throw new DocumentException(response.GetErrorMessage("Error removing documents"), response.OriginalException());
+
+            totalDeleted += response.Deleted ?? 0;
+            lastConflicts = response.VersionConflicts ?? 0;
         }
+        while (lastConflicts > 0 && attempt < maxAttempts && !DisposedCancellationToken.IsCancellationRequested);
 
-        if (response.Deleted.HasValue && response.Deleted > 0)
+        if (totalDeleted > 0)
         {
             if (IsCacheEnabled)
                 await InvalidateCacheByQueryAsync(query.As<T>()).AnyContext();
@@ -1349,10 +1368,10 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
             await SendQueryNotificationsAsync(ChangeType.Removed, query, options).AnyContext();
         }
 
-        if (response.Total != response.Deleted)
-            _logger.LogWarning("RemoveAll: {Deleted} of {Total} records were removed ({Conflicts} version conflicts)", response.Deleted, response.Total, response.VersionConflicts);
+        if (lastConflicts > 0)
+            _logger.LogWarning("RemoveAll: {Deleted} records removed after {Attempts} attempts ({Conflicts} unresolved version conflicts)", totalDeleted, attempt, lastConflicts);
 
-        return response.Deleted ?? 0;
+        return totalDeleted;
     }
 
     public Task<long> BatchProcessAsync(RepositoryQueryDescriptor<T> query, Func<FindResults<T>, Task<bool>> processFunc, CommandOptionsDescriptor<T>? options = null)

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticRepositoryBase.cs
@@ -1333,7 +1333,7 @@ public abstract class ElasticRepositoryBase<T> : ElasticReadOnlyRepositoryBase<T
         // query at the application level until no conflicts remain or the retry budget is exhausted.
         var esQuery = await ElasticIndex.QueryBuilder.BuildQueryAsync(query, options, new SearchRequestDescriptor<T>()).AnyContext();
         var indices = Indices.Index(String.Join(",", ElasticIndex.GetIndexesByQuery(query)));
-        int maxAttempts = options.GetRetryCount();
+        int maxAttempts = options.GetRetryCount() + 1;
         int attempt = 0;
         long totalDeleted = 0;
         long lastConflicts;

--- a/src/Foundatio.Repositories/ISearchableRepository.cs
+++ b/src/Foundatio.Repositories/ISearchableRepository.cs
@@ -44,8 +44,9 @@ public interface ISearchableRepository<T> : IRepository<T>, ISearchableReadOnlyR
     /// <para>When no event listeners are registered and caching is disabled, removal uses Elasticsearch's
     /// delete-by-query, which snapshots document versions and skips any document modified before the delete
     /// executes (a version conflict). Because delete-by-query does not support <c>retry_on_conflict</c>, the
-    /// query is re-run up to the configured retry count (see <c>RetryCount</c>, default 10) until no conflicts
-    /// remain. The returned count is the cumulative number of documents deleted across all attempts.</para>
+    /// query is re-run up to <c>o.Retry(n)</c> additional times (default 10 retries, i.e. up to 11 total
+    /// passes) until no conflicts remain. The returned count is the cumulative number of documents deleted
+    /// across all passes.</para>
     /// <para>If conflicts persist after the retry budget is exhausted, a warning is logged and the partial
     /// count is returned; no exception is thrown.</para>
     /// </remarks>

--- a/src/Foundatio.Repositories/ISearchableRepository.cs
+++ b/src/Foundatio.Repositories/ISearchableRepository.cs
@@ -40,6 +40,15 @@ public interface ISearchableRepository<T> : IRepository<T>, ISearchableReadOnlyR
     /// <param name="query">An object containing filter criteria used to enforce tenancy or other system-level filters.</param>
     /// <param name="options">Options to control caching, notifications, and other behaviors.</param>
     /// <returns>The number of documents removed.</returns>
+    /// <remarks>
+    /// <para>When no event listeners are registered and caching is disabled, removal uses Elasticsearch's
+    /// delete-by-query, which snapshots document versions and skips any document modified before the delete
+    /// executes (a version conflict). Because delete-by-query does not support <c>retry_on_conflict</c>, the
+    /// query is re-run up to the configured retry count (see <c>RetryCount</c>, default 10) until no conflicts
+    /// remain. The returned count is the cumulative number of documents deleted across all attempts.</para>
+    /// <para>If conflicts persist after the retry budget is exhausted, a warning is logged and the partial
+    /// count is returned; no exception is thrown.</para>
+    /// </remarks>
     Task<long> RemoveAllAsync(RepositoryQueryDescriptor<T> query, CommandOptionsDescriptor<T>? options = null);
 
     /// <inheritdoc cref="RemoveAllAsync(RepositoryQueryDescriptor{T}, CommandOptionsDescriptor{T})"/>

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -3151,12 +3151,16 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var subset = identities.Take(100).Select(i => i.Id).ToArray();
         var writer = StartConflictWriterAsync(subset, writerCancellation.Token);
 
-        // Act — a single retry attempt cannot resolve persistent conflicts; the method must not throw.
-        long deleted = await _identityRepositoryWithNoCaching.RemoveAllAsync(o => o.ImmediateConsistency().Retry(1));
+        // Give the writer a head start so it is actively patching documents before the delete begins,
+        // guaranteeing at least one version conflict on the single pass.
+        await Task.Delay(100, TestCancellationToken);
+
+        // Act — Retry(0) means exactly one delete-by-query pass.  Any conflict that occurs triggers the warning.
+        long deleted = await _identityRepositoryWithNoCaching.RemoveAllAsync(o => o.ImmediateConsistency().Retry(0));
 
         await StopWriterAsync(writerCancellation, writer);
 
-        // Assert — a partial (or full) count is returned without throwing.
+        // Assert — a partial (or full) count is returned without throwing, and the unresolved-conflicts warning was emitted.
         Assert.True(deleted >= 0 && deleted <= COUNT);
         Assert.Contains(Log.LogEntries, l => l.LogLevel == LogLevel.Warning && l.Message.Contains("unresolved version conflicts"));
     }
@@ -3227,6 +3231,10 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
                         Trace.WriteLine($"Ignoring {nameof(VersionConflictDocumentException)} while generating delete-by-query conflicts: {ex.Message}");
                     }
                 }
+
+                // Yield between passes to avoid monopolising the thread pool and to give the scheduler
+                // a chance to run the delete-under-test concurrently.
+                await Task.Yield();
             }
         }, cancellationToken);
     }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -3083,4 +3083,157 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         var count = await repository.CountAsync(o => o.ImmediateConsistency());
         Assert.Equal(0, count);
     }
+
+    [Fact]
+    public async Task RemoveAllAsync_DeleteByQuery_AccumulatesDeletedCountAcrossConflictRetries()
+    {
+        // Arrange
+        const int COUNT = 1000;
+        var identities = IdentityGenerator.GenerateIdentities(COUNT);
+        await _identityRepositoryWithNoCaching.AddAsync(identities, o => o.ImmediateConsistency());
+        Assert.Equal(COUNT, await _identityRepositoryWithNoCaching.CountAsync());
+
+        // Concurrently patch a subset to bump their versions while the delete is running, forcing
+        // delete-by-query version conflicts on early passes. Patching (unlike SaveAsync) never resurrects
+        // a deleted document — it throws DocumentNotFoundException — so the writer stops naturally and the
+        // total deleted converges on COUNT.
+        using var writerCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var subset = identities.Take(50).Select(i => i.Id).ToArray();
+        var writer = StartConflictWriterAsync(subset, writerCancellation.Token);
+
+        // Act — the retry loop accumulates the deleted count across all passes.
+        long deleted = await _identityRepositoryWithNoCaching.RemoveAllAsync(o => o.ImmediateConsistency());
+
+        await StopWriterAsync(writerCancellation, writer);
+
+        // Assert — every seeded document is deleted exactly once and the returned count is the cumulative total.
+        Assert.Equal(COUNT, deleted);
+        Assert.Equal(0, await _identityRepositoryWithNoCaching.CountAsync());
+    }
+
+    [Fact]
+    public async Task RemoveAllAsync_DeleteByQuery_FiresNotificationsOnceAfterAllRetries()
+    {
+        // Arrange
+        const int COUNT = 500;
+        var identities = IdentityGenerator.GenerateIdentities(COUNT);
+        await _identityRepositoryWithNoCaching.AddAsync(identities, o => o.ImmediateConsistency());
+        _messageBus.ResetMessagesSent();
+
+        using var writerCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var subset = identities.Take(50).Select(i => i.Id).ToArray();
+        var writer = StartConflictWriterAsync(subset, writerCancellation.Token);
+
+        // Act
+        await _identityRepositoryWithNoCaching.RemoveAllAsync(o => o.ImmediateConsistency());
+
+        await StopWriterAsync(writerCancellation, writer);
+
+        // Assert — side effects fire once per call (not once per retry pass). The delete-by-query path emits
+        // both a per-document removal notification (empty id set) and a query-scoped notification: two messages
+        // total, regardless of how many retry passes were needed to clear conflicts.
+        Assert.Equal(2, _messageBus.MessagesSent);
+    }
+
+    [Fact]
+    public async Task RemoveAllAsync_DeleteByQuery_ReturnsPartialCountAndLogsWarnWhenConflictsNeverResolve()
+    {
+        // Arrange
+        const int COUNT = 1000;
+        var identities = IdentityGenerator.GenerateIdentities(COUNT);
+        await _identityRepositoryWithNoCaching.AddAsync(identities, o => o.ImmediateConsistency());
+
+        // A writer that never stops keeps bumping versions so conflicts persist across passes.
+        using var writerCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var subset = identities.Take(100).Select(i => i.Id).ToArray();
+        var writer = StartConflictWriterAsync(subset, writerCancellation.Token);
+
+        // Act — a single retry attempt cannot resolve persistent conflicts; the method must not throw.
+        long deleted = await _identityRepositoryWithNoCaching.RemoveAllAsync(o => o.ImmediateConsistency().Retry(1));
+
+        await StopWriterAsync(writerCancellation, writer);
+
+        // Assert — a partial (or full) count is returned without throwing.
+        Assert.True(deleted >= 0 && deleted <= COUNT);
+    }
+
+    [Fact]
+    public async Task RemoveAllAsync_DeleteByQuery_RetriesUntilNoConflictsAndDeletesAllDocuments()
+    {
+        // Arrange
+        const int COUNT = 1000;
+        var identities = IdentityGenerator.GenerateIdentities(COUNT);
+        await _identityRepositoryWithNoCaching.AddAsync(identities, o => o.ImmediateConsistency());
+        Assert.Equal(COUNT, await _identityRepositoryWithNoCaching.CountAsync());
+
+        using var writerCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var subset = identities.Take(50).Select(i => i.Id).ToArray();
+        var writer = StartConflictWriterAsync(subset, writerCancellation.Token);
+
+        // Act — the bounded retry loop converges once the writer can no longer bump surviving documents.
+        long deleted = await _identityRepositoryWithNoCaching.RemoveAllAsync(o => o.ImmediateConsistency());
+
+        await StopWriterAsync(writerCancellation, writer);
+
+        // Assert
+        Assert.Equal(COUNT, deleted);
+        Assert.Equal(0, await _identityRepositoryWithNoCaching.CountAsync());
+    }
+
+    [Fact]
+    public async Task RemoveAllAsync_DeleteByQuery_SkipsRetryWhenNoVersionConflicts()
+    {
+        // Arrange
+        const int COUNT = 100;
+        await _identityRepositoryWithNoCaching.AddAsync(IdentityGenerator.GenerateIdentities(COUNT), o => o.ImmediateConsistency());
+        Assert.Equal(COUNT, await _identityRepositoryWithNoCaching.CountAsync());
+
+        // Act — no concurrent writer, so the delete completes in a single pass with no conflicts.
+        long deleted = await _identityRepositoryWithNoCaching.RemoveAllAsync(o => o.ImmediateConsistency());
+
+        // Assert
+        Assert.Equal(COUNT, deleted);
+        Assert.Equal(0, await _identityRepositoryWithNoCaching.CountAsync());
+    }
+
+    private Task StartConflictWriterAsync(string[] ids, CancellationToken cancellationToken)
+    {
+        // Patches (rather than saves) the given documents in a tight loop to bump their versions and induce
+        // delete-by-query version conflicts. Patching a document that has already been deleted throws
+        // DocumentNotFoundException instead of resurrecting it, so the writer never recreates removed documents.
+        return Task.Run(async () =>
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                foreach (string id in ids)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                        return;
+
+                    try
+                    {
+                        await _identityRepositoryWithNoCaching.PatchAsync(id, new ScriptPatch("ctx._source.name = ctx._id;"), o => o.Consistency(Consistency.Eventual).Notifications(false));
+                    }
+                    catch (DocumentNotFoundException)
+                    {
+                    }
+                    catch (VersionConflictDocumentException)
+                    {
+                    }
+                }
+            }
+        }, cancellationToken);
+    }
+
+    private static async Task StopWriterAsync(CancellationTokenSource cancellation, Task writer)
+    {
+        await cancellation.CancelAsync();
+        try
+        {
+            await writer;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
 }

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/RepositoryTests.cs
@@ -3138,6 +3138,9 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
     [Fact]
     public async Task RemoveAllAsync_DeleteByQuery_ReturnsPartialCountAndLogsWarnWhenConflictsNeverResolve()
     {
+        Log.Reset();
+        Log.SetLogLevel<IdentityWithNoCachingRepository>(LogLevel.Trace);
+
         // Arrange
         const int COUNT = 1000;
         var identities = IdentityGenerator.GenerateIdentities(COUNT);
@@ -3155,6 +3158,7 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
 
         // Assert — a partial (or full) count is returned without throwing.
         Assert.True(deleted >= 0 && deleted <= COUNT);
+        Assert.Contains(Log.LogEntries, l => l.LogLevel == LogLevel.Warning && l.Message.Contains("unresolved version conflicts"));
     }
 
     [Fact]
@@ -3214,11 +3218,13 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
                     {
                         await _identityRepositoryWithNoCaching.PatchAsync(id, new ScriptPatch("ctx._source.name = ctx._id;"), o => o.Consistency(Consistency.Eventual).Notifications(false));
                     }
-                    catch (DocumentNotFoundException)
+                    catch (DocumentNotFoundException ex)
                     {
+                        Trace.WriteLine($"Ignoring {nameof(DocumentNotFoundException)} while generating delete-by-query conflicts: {ex.Message}");
                     }
-                    catch (VersionConflictDocumentException)
+                    catch (VersionConflictDocumentException ex)
                     {
+                        Trace.WriteLine($"Ignoring {nameof(VersionConflictDocumentException)} while generating delete-by-query conflicts: {ex.Message}");
                     }
                 }
             }
@@ -3232,8 +3238,9 @@ public sealed class RepositoryTests : ElasticRepositoryTestBase
         {
             await writer;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException ex)
         {
+            Trace.WriteLine($"Writer cancellation expected during teardown: {ex.Message}");
         }
     }
 }


### PR DESCRIPTION
…n conflicts

Elasticsearch's delete-by-query API snapshots document versions and skips any document modified before the delete executes, counting it as a version conflict without supporting retry_on_conflict.

This change implements an application-level retry mechanism for RemoveAllAsync to ensure all matching documents are eventually deleted under concurrent write conditions. The query is re-executed up to the configured retry count until no conflicts remain, accumulating the deleted count across attempts. Warnings are logged for unresolved conflicts, and documentation is updated to explain this behavior.
```