### PR TITLE
Fail explicitly on multi-get item errors

### DIFF
--- a/.agents/skills/foundatio-repositories/SKILL.md
+++ b/.agents/skills/foundatio-repositories/SKILL.md
@@ -131,6 +131,7 @@ IReadOnlyRepository<T>
 - **`ImmediateConsistency()` is for tests only**: It triggers an Elasticsearch index refresh after writes. Never use in production.
 - **`ExistsAsync(query)` is a dirty read**: Uses the Search API (`size: 0`), NOT the realtime Document Exists API. After a write without `ImmediateConsistency`, it can return stale results.
 - **`ExistsAsync(id)` is real-time even with soft deletes**: Uses the GET API with a source filter for `IsDeleted`.
+- **Use `ThrowOnMultiGetErrors()` for safety-critical batch reads**: By default, `GetByIdsAsync` logs and omits per-item Elasticsearch MGET errors for backward compatibility. When a missing result can trigger deletion, authorization, or another irreversible action, enable this option so closed/unavailable index errors throw instead of looking like missing documents.
 - **Register repositories as singletons**: Repository instances maintain internal state (index configuration, cache references).
 - **`FieldEquals` with multiple values is OR**: `.FieldEquals(e => e.Field, "A", "B")` produces an OR filter, not AND.
 - **`FieldContains` is token matching, NOT wildcard**: `FieldContains(f => f.Name, "Er")` will NOT match "Eric". Use `FilterExpression("field:pattern*")` for prefix/wildcard matching.

--- a/.agents/skills/foundatio-repositories/SKILL.md
+++ b/.agents/skills/foundatio-repositories/SKILL.md
@@ -131,7 +131,7 @@ IReadOnlyRepository<T>
 - **`ImmediateConsistency()` is for tests only**: It triggers an Elasticsearch index refresh after writes. Never use in production.
 - **`ExistsAsync(query)` is a dirty read**: Uses the Search API (`size: 0`), NOT the realtime Document Exists API. After a write without `ImmediateConsistency`, it can return stale results.
 - **`ExistsAsync(id)` is real-time even with soft deletes**: Uses the GET API with a source filter for `IsDeleted`.
-- **Use `ThrowOnMultiGetErrors()` for safety-critical batch reads**: By default, `GetByIdsAsync` logs and omits per-item Elasticsearch MGET errors for backward compatibility. When a missing result can trigger deletion, authorization, or another irreversible action, enable this option so closed/unavailable index errors throw instead of looking like missing documents.
+- **Use `ThrowOnMultiGetErrors()` for safety-critical batch reads**: By default, `GetByIdsAsync` logs and omits per-item Elasticsearch MGET errors for backward compatibility. Enable this option when a missing result could trigger deletion, authorization, or another irreversible action. For time-series/parent-child repositories the throw is deferred until after the multi-index fallback query, so it only fires for ids still unresolved afterward.
 - **Register repositories as singletons**: Repository instances maintain internal state (index configuration, cache references).
 - **`FieldEquals` with multiple values is OR**: `.FieldEquals(e => e.Field, "A", "B")` produces an OR filter, not AND.
 - **`FieldContains` is token matching, NOT wildcard**: `FieldContains(f => f.Name, "Er")` will NOT match "Eric". Use `FilterExpression("field:pattern*")` for prefix/wildcard matching.

--- a/.agents/skills/foundatio-repositories/references/patterns.md
+++ b/.agents/skills/foundatio-repositories/references/patterns.md
@@ -234,6 +234,10 @@ await repository.RemoveAllAsync(q => q
 // Batch fetch (returns IReadOnlyCollection<T>)
 var employees = await repository.GetByIdsAsync(ids, o => o.Cache());
 
+// Fail the entire read if any Elasticsearch MGET item reports an error
+var requiredEmployees = await repository.GetByIdsAsync(ids,
+    o => o.ThrowOnMultiGetErrors());
+
 // Existence check
 bool exists = await repository.ExistsAsync(id);
 ```
@@ -253,6 +257,7 @@ bool exists = await repository.ExistsAsync(id);
 | `o => o.Notifications(false)`   | Suppress change notifications                |
 | `o => o.Originals()`            | Track original values for change detection   |
 | `o => o.IncludeSoftDeletes()`   | Include soft-deleted docs in queries         |
+| `o => o.ThrowOnMultiGetErrors()` | Fail `GetByIdsAsync` on any MGET item error  |
 
 ## Index Mapping
 

--- a/.agents/skills/foundatio-repositories/references/patterns.md
+++ b/.agents/skills/foundatio-repositories/references/patterns.md
@@ -246,18 +246,18 @@ bool exists = await repository.ExistsAsync(id);
 
 ## Command Options
 
-| Option                          | Purpose                                      |
-| ------------------------------- | -------------------------------------------- |
-| `o => o.Cache()`                | Enable cache read/write                      |
-| `o => o.Cache("key")`           | Cache with specific key                      |
-| `o => o.ImmediateConsistency()` | ES refresh after write (use in tests only)   |
-| `o => o.SearchAfterPaging()`    | Deep pagination with search_after            |
-| `o => o.PageLimit(N)`           | Page size                                    |
-| `o => o.SoftDeleteMode(mode)`   | `ActiveOnly` (default), `All`, `DeletedOnly` |
-| `o => o.Notifications(false)`   | Suppress change notifications                |
-| `o => o.Originals()`            | Track original values for change detection   |
-| `o => o.IncludeSoftDeletes()`   | Include soft-deleted docs in queries         |
-| `o => o.ThrowOnMultiGetErrors()` | Fail `GetByIdsAsync` on any MGET item error  |
+| Option                           | Purpose                                                                                  |
+| -------------------------------- | ---------------------------------------------------------------------------------------- |
+| `o => o.Cache()`                 | Enable cache read/write                                                                  |
+| `o => o.Cache("key")`            | Cache with specific key                                                                  |
+| `o => o.ImmediateConsistency()`  | ES refresh after write (use in tests only)                                               |
+| `o => o.SearchAfterPaging()`     | Deep pagination with search_after                                                        |
+| `o => o.PageLimit(N)`            | Page size                                                                                |
+| `o => o.SoftDeleteMode(mode)`    | `ActiveOnly` (default), `All`, `DeletedOnly`                                             |
+| `o => o.Notifications(false)`    | Suppress change notifications                                                            |
+| `o => o.Originals()`             | Track original values for change detection                                               |
+| `o => o.IncludeSoftDeletes()`    | Include soft-deleted docs in queries                                                     |
+| `o => o.ThrowOnMultiGetErrors()` | Fail `GetByIdsAsync` on unresolved MGET item errors (deferred past multi-index fallback) |
 
 ## Index Mapping
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -326,6 +326,15 @@ await repository.FindAsync(query, o => o.AsyncQueryId(
     autoDelete: true));
 ```
 
+### Multi-Get Error Options
+
+```csharp
+// Throw DocumentException for GetByIdsAsync items that error instead of missing data silently
+await repository.GetByIdsAsync(ids, o => o.ThrowOnMultiGetErrors());
+```
+
+For time-series and parent/child repositories, the throw is deferred until after the multi-index fallback query, so it only fires for ids that remain unresolved.
+
 ### Combining Options
 
 ```csharp
@@ -384,6 +393,7 @@ public class EmployeeRepository : ElasticRepositoryBase<Employee>
 | Validation | true | N/A | `.SkipValidation()`, `.Validation()` |
 | Soft Deletes | ActiveOnly | N/A | `.IncludeSoftDeletes()`, `.SoftDeleteMode()` |
 | Version Check | true | N/A | `.SkipVersionCheck()`, `.VersionCheck()` |
+| Multi-Get Errors | false | N/A | `.ThrowOnMultiGetErrors()` |
 
 ## Next Steps
 

--- a/docs/guide/crud-operations.md
+++ b/docs/guide/crud-operations.md
@@ -75,6 +75,16 @@ var employees = await repository.GetByIdsAsync(ids);
 Console.WriteLine($"Found {employees.Count} employees");
 ```
 
+By default, the Elasticsearch provider logs and omits individual MGET items that report an error. This preserves compatibility for time-series repositories where an unavailable physical index may be treated like missing data. If a missing result drives deletion, authorization, or another irreversible decision, require an all-or-error read:
+
+```csharp
+var employees = await repository.GetByIdsAsync(
+    ids,
+    o => o.ThrowOnMultiGetErrors());
+```
+
+`ThrowOnMultiGetErrors()` throws `DocumentException` before returning results or caching not-found markers when any MGET item reports an error. Documents explicitly returned with `found: false` remain ordinary missing documents.
+
 ### Get All Documents
 
 ```csharp

--- a/docs/guide/crud-operations.md
+++ b/docs/guide/crud-operations.md
@@ -83,7 +83,7 @@ var employees = await repository.GetByIdsAsync(
     o => o.ThrowOnMultiGetErrors());
 ```
 
-`ThrowOnMultiGetErrors()` throws `DocumentException` before returning results or caching not-found markers when any MGET item reports an error. Documents explicitly returned with `found: false` remain ordinary missing documents.
+For repositories backed by multiple indexes (time-series or parent/child), `ThrowOnMultiGetErrors()` defers the throw until after the multi-index fallback query runs, so a document that errors on its primary index but is still found elsewhere returns normally. `DocumentException` is only thrown for ids that remain unresolved after the fallback, and it is thrown before returning results or caching not-found markers. Documents explicitly returned with `found: false` remain ordinary missing documents.
 
 ### Get All Documents
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -67,6 +67,20 @@ protected override void ConfigureSettings(ElasticsearchClientSettings settings)
 
 ## Index Issues
 
+### GetByIdsAsync Returns Fewer Documents During an Index Error
+
+Elasticsearch can return HTTP 200 for a multi-get request while individual items contain errors such as `index_closed_exception` or `index_not_found_exception`. `GetByIdsAsync` logs and omits those items by default for backward compatibility, so the returned collection can look the same as a normal not-found result.
+
+Use strict item-error handling when missing documents would trigger an irreversible action:
+
+```csharp
+var documents = await repository.GetByIdsAsync(
+    ids,
+    o => o.ThrowOnMultiGetErrors());
+```
+
+With this option, any per-item MGET error throws `DocumentException` before partial results or not-found cache markers are returned. An explicit `found: false` response still represents a normal missing document.
+
 ### Index Not Found
 
 **Symptoms:**

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -79,7 +79,7 @@ var documents = await repository.GetByIdsAsync(
     o => o.ThrowOnMultiGetErrors());
 ```
 
-With this option, any per-item MGET error throws `DocumentException` before partial results or not-found cache markers are returned. An explicit `found: false` response still represents a normal missing document.
+For time-series and parent/child repositories, the fallback query across the index's other aliases runs first, so an item error on one dated index does not fail a document that is actually retrievable elsewhere. `DocumentException` is thrown only for ids still unresolved after that fallback, before any partial results or not-found cache markers are returned. An explicit `found: false` response still represents a normal missing document.
 
 ### Index Not Found
 

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
@@ -415,6 +415,11 @@ public static class ElasticIndexExtensions
 
     public static IEnumerable<FindHit<T>> ToFindHits<T>(this MultiGetResponse<T> response, ILogger? logger = null) where T : class
     {
+        return response.ToFindHits(logger, false);
+    }
+
+    internal static IEnumerable<FindHit<T>> ToFindHits<T>(this MultiGetResponse<T> response, ILogger? logger, bool throwOnError) where T : class
+    {
         foreach (var doc in response.Docs)
         {
             FindHit<T>? findHit = null;
@@ -448,8 +453,14 @@ public static class ElasticIndexExtensions
                 {
                     if (error is null)
                     {
+                        if (throwOnError)
+                            throw new DocumentException("Elasticsearch returned an invalid multi-get error item.");
+
                         return;
                     }
+
+                    if (throwOnError)
+                        throw new DocumentException($"Error getting document {error.Id} from index {error.Index}: {error.Error?.Reason}");
 
                     logger?.LogWarning("MultiGet document error: index={Index}, id={Id}, reason={Reason}", error.Index, error.Id, error.Error?.Reason);
                 }

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
@@ -460,9 +460,9 @@ public static class ElasticIndexExtensions
                     }
 
                     if (throwOnError)
-                        throw new DocumentException($"Error getting document {error.Id} from index {error.Index}: {error.Error?.Reason}");
+                        throw new DocumentException($"Error getting document {error.Id} from index {error.Index}: {error.Error?.Type}: {error.Error?.Reason}");
 
-                    logger?.LogWarning("MultiGet document error: index={Index}, id={Id}, reason={Reason}", error.Index, error.Id, error.Error?.Reason);
+                    logger?.LogWarning("MultiGet document error: index={Index}, id={Id}, type={ErrorType}, reason={Reason}", error.Index, error.Id, error.Error?.Type, error.Error?.Reason);
                 }
             );
             if (findHit is not null)

--- a/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Extensions/ElasticIndexExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.AsyncSearch;
 using Elastic.Clients.Elasticsearch.Core.Bulk;
+using Elastic.Clients.Elasticsearch.Core.MGet;
 using Elastic.Clients.Elasticsearch.Core.Search;
 using Elastic.Clients.Elasticsearch.IndexManagement;
 using Elastic.Clients.Elasticsearch.Mapping;
@@ -415,11 +416,6 @@ public static class ElasticIndexExtensions
 
     public static IEnumerable<FindHit<T>> ToFindHits<T>(this MultiGetResponse<T> response, ILogger? logger = null) where T : class
     {
-        return response.ToFindHits(logger, false);
-    }
-
-    internal static IEnumerable<FindHit<T>> ToFindHits<T>(this MultiGetResponse<T> response, ILogger? logger, bool throwOnError) where T : class
-    {
         foreach (var doc in response.Docs)
         {
             FindHit<T>? findHit = null;
@@ -453,14 +449,8 @@ public static class ElasticIndexExtensions
                 {
                     if (error is null)
                     {
-                        if (throwOnError)
-                            throw new DocumentException("Elasticsearch returned an invalid multi-get error item.");
-
                         return;
                     }
-
-                    if (throwOnError)
-                        throw new DocumentException($"Error getting document {error.Id} from index {error.Index}: {error.Error?.Type}: {error.Error?.Reason}");
 
                     logger?.LogWarning("MultiGet document error: index={Index}, id={Id}, type={ErrorType}, reason={Reason}", error.Index, error.Id, error.Error?.Type, error.Error?.Reason);
                 }
@@ -468,6 +458,30 @@ public static class ElasticIndexExtensions
             if (findHit is not null)
                 yield return findHit;
         }
+    }
+
+    public static IReadOnlyCollection<MultiGetError> GetItemErrors<T>(this MultiGetResponse<T> response, ILogger? logger = null) where T : class
+    {
+        List<MultiGetError>? errors = null;
+        foreach (var doc in response.Docs)
+        {
+            doc.Match(
+                result => { },
+                error =>
+                {
+                    if (error is null)
+                    {
+                        logger?.LogWarning("Elasticsearch returned an invalid multi-get error item.");
+                        return;
+                    }
+
+                    errors ??= [];
+                    errors.Add(error);
+                }
+            );
+        }
+
+        return errors ?? (IReadOnlyCollection<MultiGetError>)[];
     }
 
     private static readonly long _epochTicks = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero).Ticks;

--- a/src/Foundatio.Repositories.Elasticsearch/Options/ElasticCommandOptions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Options/ElasticCommandOptions.cs
@@ -15,6 +15,15 @@ namespace Foundatio.Repositories
         internal const string SnapshotPagingKey = "@SnapshotPaging";
         internal const string SnapshotPagingScrollIdKey = "@SnapshotPagingScrollId";
         internal const string TrackTotalHitsKey = "@TrackTotalHits";
+        internal const string ThrowOnMultiGetErrorsKey = "@ThrowOnMultiGetErrors";
+
+        /// <summary>
+        /// Throws when Elasticsearch returns an error for any item in a multi-get response.
+        /// </summary>
+        public static T ThrowOnMultiGetErrors<T>(this T options, bool enabled = true) where T : ICommandOptions
+        {
+            return options.BuildOption(ThrowOnMultiGetErrorsKey, enabled);
+        }
 
         public static T TrackTotalHits<T>(this T options, bool enabled = true) where T : ICommandOptions
         {
@@ -151,6 +160,11 @@ namespace Foundatio.Repositories.Options
         public static bool ShouldUseSnapshotPaging(this ICommandOptions options)
         {
             return options.SafeGetOption<bool>(SetElasticOptionsExtensions.SnapshotPagingKey, false);
+        }
+
+        public static bool ShouldThrowOnMultiGetErrors(this ICommandOptions options)
+        {
+            return options.SafeGetOption<bool>(SetElasticOptionsExtensions.ThrowOnMultiGetErrorsKey, false);
         }
 
         public static bool HasSnapshotScrollId(this ICommandOptions options)

--- a/src/Foundatio.Repositories.Elasticsearch/Options/ElasticCommandOptions.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Options/ElasticCommandOptions.cs
@@ -18,8 +18,14 @@ namespace Foundatio.Repositories
         internal const string ThrowOnMultiGetErrorsKey = "@ThrowOnMultiGetErrors";
 
         /// <summary>
-        /// Throws when Elasticsearch returns an error for any item in a multi-get response.
+        /// Throws a <see cref="DocumentException"/> from <c>GetByIdsAsync</c> when Elasticsearch returns
+        /// an error for any multi-get item, instead of silently treating it like a missing document.
         /// </summary>
+        /// <remarks>
+        /// For repositories backed by multiple indexes (time-series or parent/child), the throw is deferred
+        /// until after the fallback query, so an item error is only fatal when the document truly cannot be
+        /// resolved. No results are returned and no not-found cache markers are written when this throws.
+        /// </remarks>
         public static T ThrowOnMultiGetErrors<T>(this T options, bool enabled = true) where T : ICommandOptions
         {
             return options.BuildOption(ThrowOnMultiGetErrorsKey, enabled);
@@ -162,6 +168,10 @@ namespace Foundatio.Repositories.Options
             return options.SafeGetOption<bool>(SetElasticOptionsExtensions.SnapshotPagingKey, false);
         }
 
+        /// <summary>
+        /// Gets whether <c>GetByIdsAsync</c> should throw when a multi-get item reports an error that
+        /// cannot be resolved by the multi-index fallback query. See <see cref="SetElasticOptionsExtensions.ThrowOnMultiGetErrors{T}"/>.
+        /// </summary>
         public static bool ShouldThrowOnMultiGetErrors(this ICommandOptions options)
         {
             return options.SafeGetOption<bool>(SetElasticOptionsExtensions.ThrowOnMultiGetErrorsKey, false);

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -192,7 +192,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             if (!multiGetResults.IsValidResponse)
                 throw new DocumentException(multiGetResults.GetErrorMessage("Error getting documents"), multiGetResults.OriginalException());
 
-            foreach (var findHit in multiGetResults.ToFindHits(_logger))
+            foreach (var findHit in multiGetResults.ToFindHits(_logger, options.ShouldThrowOnMultiGetErrors()))
             {
                 hits.Add(findHit);
                 itemsToFind.Remove(new Id(findHit.Id!, findHit.Routing));

--- a/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
+++ b/src/Foundatio.Repositories.Elasticsearch/Repositories/ElasticReadOnlyRepositoryBase.cs
@@ -171,6 +171,7 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
 
         // Build MultiGetOperation objects for each ID
         var itemsForMultiGet = itemsToFind.Where(i => i.Routing != null || !HasParent).ToList();
+        IReadOnlyCollection<MultiGetError> itemErrors = [];
         if (itemsForMultiGet.Count > 0)
         {
             var docOperations = itemsForMultiGet
@@ -192,7 +193,9 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
             if (!multiGetResults.IsValidResponse)
                 throw new DocumentException(multiGetResults.GetErrorMessage("Error getting documents"), multiGetResults.OriginalException());
 
-            foreach (var findHit in multiGetResults.ToFindHits(_logger, options.ShouldThrowOnMultiGetErrors()))
+            itemErrors = options.ShouldThrowOnMultiGetErrors() ? multiGetResults.GetItemErrors(_logger) : [];
+
+            foreach (var findHit in multiGetResults.ToFindHits(_logger))
             {
                 hits.Add(findHit);
                 itemsToFind.Remove(new Id(findHit.Id!, findHit.Routing));
@@ -216,6 +219,17 @@ public abstract class ElasticReadOnlyRepositoryBase<T> : ISearchableReadOnlyRepo
                     }
                 }
             } while (await response.NextPageAsync().AnyContext());
+        }
+
+        if (itemErrors.Count > 0)
+        {
+            var stillMissingIds = new HashSet<string>(itemsToFind.Select(id => id.Value));
+            var unresolvedErrors = itemErrors.Where(e => stillMissingIds.Contains(e.Id!.ToString())).ToList();
+            if (unresolvedErrors.Count > 0)
+            {
+                string message = String.Join("; ", unresolvedErrors.Select(e => $"id={e.Id}, index={e.Index}, type={e.Error?.Type}, reason={e.Error?.Reason}"));
+                throw new DocumentException($"Error getting documents: {message}");
+            }
         }
 
         if (IsCacheEnabled && options.ShouldUseCache())

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
@@ -425,6 +425,16 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
+    public async Task GetByIdsAsync_WithMissingDocumentAndThrowOnMultiGetErrors_ReturnsEmpty()
+    {
+        var identity = await _identityRepository.AddAsync(IdentityGenerator.Generate(), o => o.ImmediateConsistency());
+        Assert.NotNull(identity.Id);
+
+        Assert.Single(await _identityRepository.GetByIdsAsync([identity.Id], o => o.ThrowOnMultiGetErrors()));
+        Assert.Empty(await _identityRepository.GetByIdsAsync(["missing-id"], o => o.ThrowOnMultiGetErrors()));
+    }
+
+    [Fact]
     public async Task GetByIdsWithInvalidIdAsync()
     {
         var identity = await _identityRepository.AddAsync(IdentityGenerator.Generate());

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
@@ -402,6 +402,29 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
     }
 
     [Fact]
+    public async Task GetByIdsAsync_WithClosedIndexAndThrowOnMultiGetErrors_ThrowsDocumentException()
+    {
+        var identity = await _identityRepository.AddAsync(IdentityGenerator.Generate(), o => o.ImmediateConsistency());
+        var closeResponse = await _client.Indices.CloseAsync(_configuration.Identities.Name, TestCancellationToken);
+        Assert.True(closeResponse.IsValidResponse, closeResponse.DebugInformation);
+
+        try
+        {
+            Assert.Empty(await _identityRepository.GetByIdsAsync([identity.Id]));
+            await Assert.ThrowsAsync<DocumentException>(() =>
+                _identityRepository.GetByIdsAsync([identity.Id], o => o.Cache().ThrowOnMultiGetErrors()));
+            Assert.Equal(0, _cache.Count);
+        }
+        finally
+        {
+            var openResponse = await _client.Indices.OpenAsync(_configuration.Identities.Name, TestCancellationToken);
+            Assert.True(openResponse.IsValidResponse, openResponse.DebugInformation);
+        }
+
+        Assert.Single(await _identityRepository.GetByIdsAsync([identity.Id], o => o.Cache().ThrowOnMultiGetErrors()));
+    }
+
+    [Fact]
     public async Task GetByIdsWithInvalidIdAsync()
     {
         var identity = await _identityRepository.AddAsync(IdentityGenerator.Generate());
@@ -517,6 +540,17 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         var results = await _dailyRepository.GetByIdsAsync(new[] { yesterdayLog.Id, nowLog.Id });
         Assert.NotNull(results);
         Assert.Equal(2, results.Count);
+    }
+
+    [Fact]
+    public async Task GetByIdsAsync_WithMixedTimeSeriesItemErrorAndThrowOnMultiGetErrors_ThrowsDocumentException()
+    {
+        var existingLog = await _dailyRepository.AddAsync(LogEventGenerator.Default, o => o.ImmediateConsistency());
+        string missingIndexId = ObjectId.GenerateNewId(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc)).ToString();
+
+        Assert.Single(await _dailyRepository.GetByIdsAsync([existingLog.Id, missingIndexId]));
+        await Assert.ThrowsAsync<DocumentException>(() =>
+            _dailyRepository.GetByIdsAsync([existingLog.Id, missingIndexId], o => o.ThrowOnMultiGetErrors()));
     }
 
     [Fact]

--- a/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
+++ b/tests/Foundatio.Repositories.Elasticsearch.Tests/ReadOnlyRepositoryTests.cs
@@ -12,6 +12,7 @@ using Foundatio.Repositories.Extensions;
 using Foundatio.Repositories.Models;
 using Foundatio.Repositories.Options;
 using Foundatio.Repositories.Utility;
+using Foundatio.Utility;
 using Microsoft.Extensions.Logging;
 using TimeZoneConverter;
 using Xunit;
@@ -408,20 +409,18 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         var closeResponse = await _client.Indices.CloseAsync(_configuration.Identities.Name, TestCancellationToken);
         Assert.True(closeResponse.IsValidResponse, closeResponse.DebugInformation);
 
-        try
-        {
-            Assert.Empty(await _identityRepository.GetByIdsAsync([identity.Id]));
-            await Assert.ThrowsAsync<DocumentException>(() =>
-                _identityRepository.GetByIdsAsync([identity.Id], o => o.Cache().ThrowOnMultiGetErrors()));
-            Assert.Equal(0, _cache.Count);
-        }
-        finally
+        await using AsyncDisposableAction _ = new(async () =>
         {
             var openResponse = await _client.Indices.OpenAsync(_configuration.Identities.Name, TestCancellationToken);
             Assert.True(openResponse.IsValidResponse, openResponse.DebugInformation);
-        }
 
-        Assert.Single(await _identityRepository.GetByIdsAsync([identity.Id], o => o.Cache().ThrowOnMultiGetErrors()));
+            Assert.Single(await _identityRepository.GetByIdsAsync([identity.Id], o => o.Cache().ThrowOnMultiGetErrors()));
+        });
+
+        Assert.Empty(await _identityRepository.GetByIdsAsync([identity.Id]));
+        await Assert.ThrowsAsync<DocumentException>(() =>
+            _identityRepository.GetByIdsAsync([identity.Id], o => o.Cache().ThrowOnMultiGetErrors()));
+        Assert.Equal(0, _cache.Count);
     }
 
     [Fact]
@@ -561,6 +560,20 @@ public sealed class ReadOnlyRepositoryTests : ElasticRepositoryTestBase
         Assert.Single(await _dailyRepository.GetByIdsAsync([existingLog.Id, missingIndexId]));
         await Assert.ThrowsAsync<DocumentException>(() =>
             _dailyRepository.GetByIdsAsync([existingLog.Id, missingIndexId], o => o.ThrowOnMultiGetErrors()));
+    }
+
+    [Fact]
+    public async Task GetByIdsAsync_WithOutOfSyncTimeSeriesIndexAndThrowOnMultiGetErrors_ReturnsDocument()
+    {
+        string mismatchedDateId = ObjectId.GenerateNewId(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc)).ToString();
+        var log = await _dailyRepository.AddAsync(
+            LogEventGenerator.Generate(mismatchedDateId, createdUtc: DateTime.UtcNow),
+            o => o.ImmediateConsistency());
+        Assert.NotNull(log);
+
+        var results = await _dailyRepository.GetByIdsAsync([mismatchedDateId], o => o.ThrowOnMultiGetErrors());
+        Assert.Single(results);
+        Assert.Equal(log, results.First());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #313.

- adds the opt-in `ThrowOnMultiGetErrors()` command option for `GetByIdsAsync`
- throws a single aggregated `DocumentException` when Elasticsearch MGET items report errors that remain unresolved
- for repositories backed by multiple indexes (time-series or parent/child), the throw is **deferred until after the multi-index fallback query** runs, so an item error against one dated/aliased index is not fatal when the document is actually retrievable elsewhere
- preserves the current default behavior for backward compatibility
- prevents strict reads from returning partial results or writing not-found cache markers once a genuinely unresolved item error is detected
- documents when safety-critical callers should enable strict handling

### Design

- `GetItemErrors<T>(MultiGetResponse<T>, ILogger?)` is a new eager extension in `ElasticIndexExtensions` that collects `MultiGetError` items without throwing. `ToFindHits` is unchanged (single overload, no threaded `bool`).
- `GetByIdsAsync` collects errors up front only when `ShouldThrowOnMultiGetErrors()` is set, lets the existing `HasMultipleIndexes`/`HasParent` fallback `FindAsync` run to completion, and only then throws for ids whose errors are still unresolved after the fallback — immediately before the cache block, so the "no not-found cache markers" guarantee holds.
- The degenerate "error variant with a null payload" case now logs a warning instead of throwing, matching how the `result is null` branch is already handled.

The option is implemented in the Elasticsearch provider and does not add requests or change the public repository interfaces.

## Tests

- closed single index (no fallback): default read remains empty; strict cached read throws and does not poison the cache
- mixed time-series response (id that has no index anywhere): default read returns the valid hit; strict read throws on the truly missing item
- **new** out-of-sync time-series test: a document whose id's `ObjectId` creation time points at a nonexistent dated index, but whose `CreatedUtc` places it in today's index — strict mode returns the document instead of throwing, proving the fallback runs before the throw
- full `ReadOnlyRepositoryTests`: 67 passed, 0 failed
- `dotnet build Foundatio.Repositories.slnx --no-restore`: 0 warnings, 0 errors
- `dotnet format Foundatio.Repositories.slnx --verify-no-changes --no-restore`: passed
- full solution suite passes; two unrelated `QueryTests` cleanup failures were observed, caused by transport timeouts against a resource-contended local Elasticsearch shared with other concurrent test runs on this host, not by this change

## Compatibility

No breaking API or default behavior changes. Callers opt into the stricter contract explicitly, and multi-index repositories only see a throw when a document cannot be resolved by any means.
